### PR TITLE
fix: correctly pass TLVs in NIP-47 pay_keysend

### DIFF
--- a/lnclient/breez/breez.go
+++ b/lnclient/breez/breez.go
@@ -119,9 +119,13 @@ func (bs *BreezService) SendPaymentSync(ctx context.Context, payReq string) (*ln
 func (bs *BreezService) SendKeysend(ctx context.Context, amount uint64, destination, preimage string, custom_records []lnclient.TLVRecord) (preImage string, err error) {
 	extraTlvs := []breez_sdk.TlvEntry{}
 	for _, record := range custom_records {
+		decodedValue, err := hex.DecodeString(record.Value)
+		if err != nil {
+			return "", err
+		}
 		extraTlvs = append(extraTlvs, breez_sdk.TlvEntry{
 			FieldNumber: record.Type,
-			Value:       []uint8(record.Value),
+			Value:       decodedValue,
 		})
 	}
 

--- a/lnclient/greenlight/greenlight.go
+++ b/lnclient/greenlight/greenlight.go
@@ -132,7 +132,7 @@ func (gs *GreenlightService) SendKeysend(ctx context.Context, amount uint64, des
 	for _, customRecord := range custom_records {
 		extraTlvs = append(extraTlvs, glalby.TlvEntry{
 			Ty:    customRecord.Type,
-			Value: customRecord.Value,
+			Value: customRecord.Value, // glalby expects hex-encoded TLV values
 		})
 	}
 

--- a/lnclient/greenlight/greenlight.go
+++ b/lnclient/greenlight/greenlight.go
@@ -2,7 +2,6 @@ package greenlight
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"log"
 	"math/rand"
@@ -133,7 +132,7 @@ func (gs *GreenlightService) SendKeysend(ctx context.Context, amount uint64, des
 	for _, customRecord := range custom_records {
 		extraTlvs = append(extraTlvs, glalby.TlvEntry{
 			Ty:    customRecord.Type,
-			Value: hex.EncodeToString([]byte(customRecord.Value)),
+			Value: customRecord.Value,
 		})
 	}
 

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -498,9 +498,13 @@ func (ls *LDKService) SendKeysend(ctx context.Context, amount uint64, destinatio
 	customTlvs := []ldk_node.TlvEntry{}
 
 	for _, customRecord := range custom_records {
+		decodedValue, err := hex.DecodeString(customRecord.Value)
+		if err != nil {
+			return "", err
+		}
 		customTlvs = append(customTlvs, ldk_node.TlvEntry{
 			Type:  customRecord.Type,
-			Value: []uint8(customRecord.Value),
+			Value: decodedValue,
 		})
 	}
 

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -359,7 +359,11 @@ func (svc *LNDService) SendKeysend(ctx context.Context, amount uint64, destinati
 
 	destCustomRecords := map[uint64][]byte{}
 	for _, record := range custom_records {
-		destCustomRecords[record.Type] = []byte(record.Value)
+		decodedValue, err := hex.DecodeString(record.Value)
+		if err != nil {
+			return "", err
+		}
+		destCustomRecords[record.Type] = decodedValue
 	}
 	const KEYSEND_CUSTOM_RECORD = 5482373484
 	destCustomRecords[KEYSEND_CUSTOM_RECORD] = preImageBytes


### PR DESCRIPTION
as per the nip-47 spec, pay_keysend TLV values are hex-encoded

Fixes https://github.com/getAlby/hub/issues/230