### PR TITLE
fix: validate theme from storage

### DIFF
--- a/frontend/src/components/ui/theme-provider.tsx
+++ b/frontend/src/components/ui/theme-provider.tsx
@@ -35,7 +35,8 @@ export function ThemeProvider({
   ...props
 }: ThemeProviderProps) {
   const [theme, setTheme] = useState<Theme>(() => {
-    return (localStorage.getItem(storageKey) as Theme) || defaultTheme;
+    const themeFromStorage = localStorage.getItem(storageKey) as Theme;
+    return Themes.includes(themeFromStorage) ? themeFromStorage : defaultTheme;
   });
 
   const [darkMode, setDarkMode] = useState<DarkMode>(() => {


### PR DESCRIPTION
Partly fixes #221

Older hubs had "dark" saved as the ui theme which now was rename to a explicit darkmode setting, however there is no theme named "dark". Thus the theme appears broken if you upgrade an older version of the hub, for new installs it should be fine.  