### PR TITLE
fix: LDK mark channel as inactive and show error if counterparty forwarding info missing

### DIFF
--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -670,13 +670,17 @@ export default function Channels() {
                         channel.localBalance + channel.remoteBalance;
 
                       let channelWarning = "";
-                      if (channel.localSpendableBalance < capacity * 0.1) {
-                        channelWarning =
-                          "Spending balance low. You may have trouble sending payments through this channel.";
-                      }
-                      if (channel.localSpendableBalance > capacity * 0.9) {
-                        channelWarning =
-                          "Receiving capacity low. You may have trouble receiving payments through this channel.";
+                      if (channel.error) {
+                        channelWarning = channel.error;
+                      } else {
+                        if (channel.localSpendableBalance < capacity * 0.1) {
+                          channelWarning =
+                            "Spending balance low. You may have trouble sending payments through this channel.";
+                        }
+                        if (channel.localSpendableBalance > capacity * 0.9) {
+                          channelWarning =
+                            "Receiving capacity low. You may have trouble receiving payments through this channel.";
+                        }
                       }
 
                       return (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -203,6 +203,7 @@ export type Channel = {
   forwardingFeeBaseMsat: number;
   unspendablePunishmentReserve: number;
   counterpartyUnspendablePunishmentReserve: number;
+  error?: string;
 };
 
 export type UpdateChannelRequest = {

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -90,6 +90,7 @@ type Channel struct {
 	ForwardingFeeBaseMsat                    uint32      `json:"forwardingFeeBaseMsat"`
 	UnspendablePunishmentReserve             uint64      `json:"unspendablePunishmentReserve"`
 	CounterpartyUnspendablePunishmentReserve uint64      `json:"counterpartyUnspendablePunishmentReserve"`
+	Error                                    *string     `json:"error"`
 }
 
 type NodeStatus struct {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d0fbb935-7dc2-4457-8c43-8236a0d58c55)
