### PR TITLE
fix: stop nostr when app is shutdown and use context to stop lnclient

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -314,15 +314,11 @@ func (api *api) Stop() error {
 		return errors.New("LNClient not started")
 	}
 
-	// TODO: this should stop everything related to the lnclient
-	// stop the lnclient
+	// stop the lnclient, nostr relay etc.
 	// The user will be forced to re-enter their unlock password to restart the node
-	err := api.svc.StopLNClient()
-	if err != nil {
-		logger.Logger.WithError(err).Error("Failed to stop LNClient")
-	}
+	api.svc.StopApp()
 
-	return err
+	return nil
 }
 
 func (api *api) GetNodeConnectionInfo(ctx context.Context) (*lnclient.NodeConnectionInfo, error) {

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -57,6 +57,6 @@ func main() {
 	defer cancel()
 	e.Shutdown(ctx)
 	logger.Logger.Info("Echo server exited")
-	svc.WaitShutdown()
+	svc.Shutdown()
 	logger.Logger.Info("Service exited")
 }

--- a/main_wails.go
+++ b/main_wails.go
@@ -31,6 +31,6 @@ func main() {
 	logger.Logger.Info("Cancelling service context...")
 	// cancel the service context
 	cancel()
-	svc.WaitShutdown()
+	svc.Shutdown()
 	logger.Logger.Info("Service exited")
 }

--- a/service/models.go
+++ b/service/models.go
@@ -12,8 +12,7 @@ import (
 type Service interface {
 	StartApp(encryptionKey string) error
 	StopApp()
-	StopLNClient() error
-	WaitShutdown()
+	Shutdown()
 
 	// TODO: remove getters (currently used by http / wails services)
 	GetAlbyOAuthSvc() alby.AlbyOAuthService

--- a/service/service.go
+++ b/service/service.go
@@ -203,19 +203,12 @@ func finishRestoreNode(workDir string) {
 }
 
 func (svc *service) Shutdown() {
-	svc.StopLNClient()
+	svc.StopApp()
 	svc.eventPublisher.Publish(&events.Event{
 		Event: "nwc_stopped",
 	})
 	// wait for any remaining events
 	time.Sleep(1 * time.Second)
-}
-
-func (svc *service) StopApp() {
-	if svc.appCancelFn != nil {
-		svc.appCancelFn()
-		svc.wg.Wait()
-	}
 }
 
 func (svc *service) GetDB() *gorm.DB {
@@ -244,9 +237,4 @@ func (svc *service) GetLNClient() lnclient.LNClient {
 
 func (svc *service) GetKeys() keys.Keys {
 	return svc.keys
-}
-
-func (svc *service) WaitShutdown() {
-	logger.Logger.Info("Waiting for service to exit...")
-	svc.wg.Wait()
 }


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/57

- Relay is now correctly shut down
- LNClient is stopped by waiting for the app context to be cancelled instead of manually

TESTS:
- [x] sigterm without node running
- [x] sigterm while node running
- [x] sigterm while node syncing
- [x] sigterm after successfully stopping node from settings page
- [x] stop node from settings page and start it again, then do a NWC request (no longer causes duplicates)

This does not cover the case if sigterm happens when the app is starting up (when the LNClient is being created), which could break the node as it will not be shutdown safely. I will create a separate issue for this one.