### PR TITLE
fix: migrate existing tables to have autoincrementing primary keys

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -15,21 +15,19 @@ func NewDB(uri string) (*gorm.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = gormDB.Exec("PRAGMA foreign_keys=ON;").Error
+	err = gormDB.Exec("PRAGMA foreign_keys = ON", nil).Error
 	if err != nil {
 		return nil, err
 	}
-	err = gormDB.Exec("PRAGMA auto_vacuum=FULL;").Error
+	err = gormDB.Exec("PRAGMA auto_vacuum = FULL", nil).Error
 	if err != nil {
 		return nil, err
 	}
 
-	// sqlDb, err = DB.DB()
-	// if err != nil {
-	// 	return err
-	// }
-	// this causes errors when concurrently saving DB entries and otherwise requires mutexes
-	// sqlDb.SetMaxOpenConns(1)
+	err = gormDB.Exec("PRAGMA busy_timeout = 5000", nil).Error
+	if err != nil {
+		return nil, err
+	}
 
 	err = migrations.Migrate(gormDB)
 	if err != nil {

--- a/db/migrations/202407151352_autoincrement.go
+++ b/db/migrations/202407151352_autoincrement.go
@@ -58,7 +58,7 @@ CREATE INDEX idx_app_permissions_app_id ON app_permissions(app_id);
 
 			// create fresh request and response event tables
 			if err := tx.Exec(`
-CREATE TABLE "request_events" (id integer PRIMARY KEY AUTOINCREMENT,app_id integer null,nostr_id text UNIQUE,state text,created_at datetime,updated_at datetime, method TEXT, content_data TEXT,CONSTRAINT fk_request_events_app FOREIGN KEY (app_id) REFERENCES apps(id) ON DELETE CASCADE);
+CREATE TABLE "request_events" (id integer PRIMARY KEY AUTOINCREMENT,app_id integer,nostr_id text UNIQUE,state text,created_at datetime,updated_at datetime, method TEXT, content_data TEXT,CONSTRAINT fk_request_events_app FOREIGN KEY (app_id) REFERENCES apps(id) ON DELETE CASCADE);
 CREATE INDEX idx_request_events_app_id ON request_events(app_id);
 CREATE INDEX idx_request_events_app_id_and_id ON request_events(app_id, id);
 CREATE INDEX idx_request_events_method ON request_events(method);

--- a/db/migrations/202407151352_autoincrement.go
+++ b/db/migrations/202407151352_autoincrement.go
@@ -1,0 +1,88 @@
+package migrations
+
+import (
+	_ "embed"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// This migration (inside a DB transaction),
+// - Adds AUTOINCREMENT to the primary key of:
+// - apps, app_permissions, request_events, response_events, user_configs
+//
+// request_events and response_events are not critical (and also payments are dropped in the same release)
+// so we just drop those tables and re-create them.
+var _202407151352_autoincrement = &gormigrate.Migration{
+	ID: "202407151352_autoincrement",
+	Migrate: func(db *gorm.DB) error {
+
+		if err := db.Transaction(func(tx *gorm.DB) error {
+
+			// Request events
+			if err := tx.Exec(`
+DROP TABLE request_events;
+CREATE TABLE "request_events" (id integer PRIMARY KEY AUTOINCREMENT,app_id integer null,nostr_id text UNIQUE,state text,created_at datetime,updated_at datetime, method TEXT, content_data TEXT,CONSTRAINT fk_request_events_app FOREIGN KEY (app_id) REFERENCES apps(id) ON DELETE CASCADE);
+CREATE INDEX idx_request_events_app_id ON request_events(app_id);
+CREATE INDEX idx_request_events_app_id_and_id ON request_events(app_id, id);
+CREATE INDEX idx_request_events_method ON request_events(method);
+
+`).Error; err != nil {
+				return err
+			}
+
+			// Response events
+			if err := tx.Exec(`
+DROP TABLE response_events;
+CREATE TABLE "response_events" (id integer PRIMARY KEY AUTOINCREMENT,nostr_id text UNIQUE,request_id integer,state text,replied_at datetime,created_at datetime,updated_at datetime,CONSTRAINT fk_response_events_request_event FOREIGN KEY (request_id) REFERENCES request_events(id) ON DELETE CASCADE);
+`).Error; err != nil {
+				return err
+			}
+
+			// User configs - create new table, copy old values, delete old table, rename new table
+			if err := tx.Exec(`
+CREATE TABLE "user_configs_2" ("id" integer PRIMARY KEY AUTOINCREMENT, "key" text NOT NULL UNIQUE, "value" text, "encrypted" numeric, created_at datetime,updated_at datetime);
+INSERT INTO user_configs_2 (id, key, value, encrypted, created_at, updated_at) SELECT id, key, value, encrypted, created_at, updated_at FROM user_configs;
+DROP TABLE user_configs;
+ALTER TABLE user_configs_2 RENAME TO user_configs;
+`).Error; err != nil {
+				return err
+			}
+
+			// Apps & app permissions (interdependent)
+			// create new table, copy old values, delete old tables, rename new tables, create new indexes
+			if err := tx.Exec(`
+CREATE TABLE apps_2 (id integer PRIMARY KEY AUTOINCREMENT,name text,description text,nostr_pubkey text UNIQUE,created_at datetime,updated_at datetime, isolated boolean);
+INSERT INTO apps_2 (id, name, description, nostr_pubkey, created_at, updated_at, isolated) SELECT id, name text, description, nostr_pubkey, created_at, updated_at, isolated FROM apps;
+CREATE TABLE app_permissions_2 (id integer PRIMARY KEY AUTOINCREMENT,app_id integer,"scope" text,"max_amount_sat" integer,budget_renewal text,expires_at datetime,created_at datetime,updated_at datetime,CONSTRAINT fk_app_permissions_app FOREIGN KEY (app_id) REFERENCES apps_2(id) ON DELETE CASCADE);
+INSERT INTO app_permissions_2 (id, app_id, scope, max_amount_sat, budget_renewal, expires_at, created_at, updated_at) SELECT id, app_id, scope, max_amount_sat, budget_renewal, expires_at, created_at, updated_at FROM app_permissions;
+
+DROP TABLE apps;
+ALTER TABLE apps_2 RENAME TO apps;
+DROP TABLE app_permissions;
+ALTER TABLE app_permissions_2 RENAME TO app_permissions;
+
+CREATE INDEX idx_app_permissions_scope ON app_permissions("scope");
+CREATE INDEX idx_app_permissions_app_id ON app_permissions(app_id);
+`).Error; err != nil {
+				return err
+			}
+
+			// delete old tables and rename new tables for apps and app permissions (they are dependent on eachother)
+			if err := tx.Exec(`
+
+`).Error; err != nil {
+				return err
+			}
+
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		return nil
+	},
+	Rollback: func(tx *gorm.DB) error {
+		return nil
+	},
+}

--- a/db/migrations/202407151352_autoincrement.go
+++ b/db/migrations/202407151352_autoincrement.go
@@ -9,7 +9,9 @@ import (
 
 // This migration (inside a DB transaction),
 // - Adds AUTOINCREMENT to the primary key of:
-// - apps, app_permissions, request_events, response_events, user_configs
+// - apps, app_permissions, request_events, response_events
+//
+// user_configs is not migrated as it has no relations with other tables, therefore hopefully no issue with reusing IDs
 //
 // request_events and response_events are not critical (and also payments are dropped in the same release)
 // so we just drop those tables and re-create them.

--- a/db/migrations/202407151352_autoincrement.go
+++ b/db/migrations/202407151352_autoincrement.go
@@ -27,16 +27,6 @@ DROP TABLE response_events;
 				return err
 			}
 
-			// User configs - create new table, copy old values, delete old table, rename new table
-			if err := tx.Exec(`
-CREATE TABLE "user_configs_2" ("id" integer PRIMARY KEY AUTOINCREMENT, "key" text NOT NULL UNIQUE, "value" text, "encrypted" numeric, created_at datetime,updated_at datetime);
-INSERT INTO user_configs_2 (id, key, value, encrypted, created_at, updated_at) SELECT id, key, value, encrypted, created_at, updated_at FROM user_configs;
-DROP TABLE user_configs;
-ALTER TABLE user_configs_2 RENAME TO user_configs;
-`).Error; err != nil {
-				return err
-			}
-
 			// Apps & app permissions (interdependent)
 			// create new tables, copy old values, delete old tables, rename new tables, create new indexes
 			if err := tx.Exec(`

--- a/db/migrations/migrate.go
+++ b/db/migrations/migrate.go
@@ -16,6 +16,7 @@ func Migrate(gormDB *gorm.DB) error {
 		_202406071726_vacuum,
 		_202406301207_rename_request_methods,
 		_202407012100_transactions,
+		_202407151352_autoincrement,
 	})
 
 	return m.Migrate()

--- a/frontend/src/screens/apps/AppCreated.tsx
+++ b/frontend/src/screens/apps/AppCreated.tsx
@@ -20,6 +20,17 @@ import { copyToClipboard } from "src/lib/clipboard";
 import { CreateAppResponse } from "src/types";
 
 export default function AppCreated() {
+  const { state } = useLocation();
+  const navigate = useNavigate();
+  const createAppResponse = state as CreateAppResponse | undefined;
+  if (!createAppResponse?.pairingUri) {
+    navigate("/");
+    return null;
+  }
+
+  return <AppCreatedInternal />;
+}
+function AppCreatedInternal() {
   const { search, state } = useLocation();
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -30,6 +41,7 @@ export default function AppCreated() {
 
   const [timeout, setTimeout] = useState(false);
   const [isQRCodeVisible, setIsQRCodeVisible] = useState(false);
+
   const createAppResponse = state as CreateAppResponse;
   const pairingUri = createAppResponse.pairingUri;
   const { data: app } = useApp(createAppResponse.pairingPublicKey, true);


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/252

This PR adds autoincrement to the primary keys of all our tables which fixes weird bugs caused by ID reuse which is the default in SQLITE (if you delete app ID 7, then the next app you create will have ID 7 again). Only apps, app_permissions and user_configs are preserved. The other tables are dropped (payments are dropped as part of dynamic budgets, request_events and response_events are not critical)

TESTS:
- [x] diff select * from `table-name` before and after migration (no change)
- [x] diff schema changes (only expected changes - autoincrement, one missed index rename for scopes)
- [x] autoincrement
  - [x] apps
  - [x] app_permissions
  - [x] user_configs
  - [x] request_events
  - [x] response_events
  - [x] transactions
- [x] cascading delete
  - [x] apps -> app_permissions
  - [x] apps -> request_events
  - [x] request_events -> response_events
- [x] create app with one NWC request, delete app, create new app -> new ID and bug fixed?
- [x] check: should index creation of request and response events be done after new app table is created?