### PR TITLE
chore: return if info is not loaded in app layout

### DIFF
--- a/frontend/src/components/layouts/AppLayout.tsx
+++ b/frontend/src/components/layouts/AppLayout.tsx
@@ -85,6 +85,10 @@ export default function AppLayout() {
 
   const isHttpMode = window.location.protocol.startsWith("http");
 
+  if (!info) {
+    return;
+  }
+
   function UserMenuContent() {
     return (
       <DropdownMenuContent align="end">
@@ -184,7 +188,7 @@ export default function AppLayout() {
   }
 
   const upToDate =
-    info?.version &&
+    info.version &&
     albyMe?.hub.latest_version &&
     info.version.startsWith("v") &&
     info.version.substring(1) >= albyMe?.hub.latest_version;
@@ -210,7 +214,7 @@ export default function AppLayout() {
                             className="font-semibold text-xl"
                           >
                             <span className="text-xs flex items-center text-muted-foreground">
-                              {info?.version && <>{info?.version}&nbsp;</>}
+                              {info.version && <>{info.version}&nbsp;</>}
                               {upToDate ? (
                                 <ShieldCheckIcon className="w-4 h-4" />
                               ) : (

--- a/frontend/src/components/layouts/AppLayout.tsx
+++ b/frontend/src/components/layouts/AppLayout.tsx
@@ -86,7 +86,7 @@ export default function AppLayout() {
   const isHttpMode = window.location.protocol.startsWith("http");
 
   if (!info) {
-    return;
+    return null;
   }
 
   function UserMenuContent() {


### PR DESCRIPTION
Fixes #253

Should I return `Outlet` instead of nothing? Didn't right now as it would be weird if the Sidebar pops up after a second everywhere, and info should be present for the Hub in any case.

## Video (previously vs now)
https://github.com/user-attachments/assets/ae65cb3d-e1f4-4196-921d-7323dc3bbe64
