### PR TITLE
fix: spendable balance in lnd

### DIFF
--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -607,7 +607,7 @@ func (svc *LNDService) GetOnchainBalance(ctx context.Context) (*lnclient.Onchain
 		"balances": balances,
 	}).Debug("Listed Balances")
 	return &lnclient.OnchainBalanceResponse{
-		Spendable: int64(balances.ConfirmedBalance),
+		Spendable: int64(balances.ConfirmedBalance - balances.ReservedBalanceAnchorChan),
 		Total:     int64(balances.TotalBalance - balances.ReservedBalanceAnchorChan),
 		Reserved:  int64(balances.ReservedBalanceAnchorChan),
 	}, nil


### PR DESCRIPTION
## Issue
It is wrongly mentioned that -60000 sats are incoming although there are no channels waiting to be closed, and also this happens because total balance is less than the spendable balance (hence the -ve sign) which can never be the case
<img width="181" alt="Screenshot 2024-07-18 at 7 41 45 PM" src="https://github.com/user-attachments/assets/cbc15de2-010c-41e8-8a40-4df7caa3bac7">

## Description
This happens because we remove the ReservedBalance from the TotalBalance in LND which makes TotalBalance less than ConfirmedBalance

From LDK docs
> **total_onchain_balance_sats:** [u64](https://doc.rust-lang.org/nightly/std/primitive.u64.html)
The total balance of our on-chain wallet.
**spendable_onchain_balance_sats:** [u64](https://doc.rust-lang.org/nightly/std/primitive.u64.html)
The currently spendable balance of our on-chain wallet.
This includes any sufficiently confirmed funds, minus [total_anchor_channels_reserve_sats](https://docs.rs/ldk-node/latest/ldk_node/struct.BalanceDetails.html#structfield.total_anchor_channels_reserve_sats).

That's why we remove `total_anchor_channels_reserve_sats` from `total_onchain_balance_sats` in LDK

But in LND, `spendable_onchain_balance_sats` doesn't remove any reserves, it gives the actual confirmed balance. So this change subtracts `total_anchor_channels_reserve_sats` from both

