### PR TITLE
chore: add tooltips for node balances

### DIFF
--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -511,7 +511,19 @@ export default function Channels() {
         <Card className="flex flex-col">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">
-              Savings Balance
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <div className="flex flex-row gap-2 items-center">
+                      Savings Balance
+                      <InfoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    You can use on-chain balance to open new lightning channels
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </CardTitle>
             <Bitcoin className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
@@ -554,7 +566,17 @@ export default function Channels() {
         <Card className="flex flex-col">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">
-              Spending Balance
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <div className="flex flex-row gap-2 items-center">
+                      Spending Balance
+                      <InfoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>Your lightning wallet balance</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </CardTitle>
             <ArrowUp className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
@@ -584,7 +606,19 @@ export default function Channels() {
         <Card className="flex flex-col">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">
-              Receiving Capacity
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <div className="flex flex-row gap-2 items-center">
+                      Receiving Capacity
+                      <InfoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Shows how much bitcoin you can currently receive
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </CardTitle>
             <ArrowDown className="h-4 w-4 text-muted-foreground" />
           </CardHeader>

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -519,8 +519,10 @@ export default function Channels() {
                       <InfoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
                     </div>
                   </TooltipTrigger>
-                  <TooltipContent>
-                    You can use on-chain balance to open new lightning channels
+                  <TooltipContent className="w-[300px]">
+                    Your savings balance (on-chain balance) can be used to open
+                    new lightning channels. When channels are closed, funds from
+                    your channel will be returned to your savings balance.
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
@@ -574,7 +576,10 @@ export default function Channels() {
                       <InfoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
                     </div>
                   </TooltipTrigger>
-                  <TooltipContent>Your lightning wallet balance</TooltipContent>
+                  <TooltipContent className="w-[300px]">
+                    Your spending balance is the funds on your side of your
+                    channels, which you can use to make lightning payments.
+                  </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
             </CardTitle>
@@ -614,8 +619,10 @@ export default function Channels() {
                       <InfoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
                     </div>
                   </TooltipTrigger>
-                  <TooltipContent>
-                    Shows how much bitcoin you can currently receive
+                  <TooltipContent className="w-[300px]">
+                    Your receiving capacity is the funds owned by your channel
+                    partner, which will be moved to your side when you receive
+                    lightning payments.
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>


### PR DESCRIPTION
Fixes #283

Should I rename the Savings Balance to Onchain Balance?

<img width="100%" alt="Screenshot 2024-07-22 at 6 11 44 PM" src="https://github.com/user-attachments/assets/541d83a9-5c81-4d23-9b67-9c720c90e687">

