### PR TITLE
feat: show onchain balance in increase spending capacity screen

### DIFF
--- a/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
@@ -126,7 +126,9 @@ function NewChannelInternal({ network }: { network: Network }) {
     }
   }, [order.paymentMethod, selectedPeer]);
 
-  const [showAdvanced, setShowAdvanced] = React.useState(false);
+  const [showAdvanced, setShowAdvanced] = React.useState(
+    !channelPeerSuggestions?.length
+  );
 
   function onSubmit(e: FormEvent) {
     e.preventDefault();
@@ -184,12 +186,11 @@ function NewChannelInternal({ network }: { network: Network }) {
     }
   }
 
-  if (!channelPeerSuggestions) {
+  if (!channelPeerSuggestions || !balances) {
     return <Loading />;
   }
 
   const openImmediately =
-    balances &&
     order.amount &&
     order.paymentMethod === "onchain" &&
     +order.amount < balances.onchain.spendable;
@@ -241,6 +242,10 @@ function NewChannelInternal({ network }: { network: Network }) {
               setAmount(e.target.value.trim());
             }}
           />
+          <div className="text-muted-foreground text-sm">
+            Balance:{" "}
+            {new Intl.NumberFormat().format(balances.onchain.spendable)} sats
+          </div>
           <div className="grid grid-cols-3 gap-1.5 text-muted-foreground text-xs">
             {presetAmounts.map((amount) => (
               <div

--- a/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
@@ -243,7 +243,7 @@ function NewChannelInternal({ network }: { network: Network }) {
             }}
           />
           <div className="text-muted-foreground text-sm">
-            Balance:{" "}
+            Current savings balance:{" "}
             {new Intl.NumberFormat().format(balances.onchain.spendable)} sats
           </div>
           <div className="grid grid-cols-3 gap-1.5 text-muted-foreground text-xs">

--- a/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
@@ -126,9 +126,7 @@ function NewChannelInternal({ network }: { network: Network }) {
     }
   }, [order.paymentMethod, selectedPeer]);
 
-  const [showAdvanced, setShowAdvanced] = React.useState(
-    !channelPeerSuggestions?.length
-  );
+  const [showAdvanced, setShowAdvanced] = React.useState(false);
 
   function onSubmit(e: FormEvent) {
     e.preventDefault();


### PR DESCRIPTION
Fixes #282

<img width="600px" alt="Screenshot 2024-07-22 at 7 01 21 PM" src="https://github.com/user-attachments/assets/0ced5e1b-c4e7-473b-acc2-50bf5e0e4b40">


Done similar to extension:

<img width="400px" alt="Screenshot 2024-07-22 at 7 02 26 PM" src="https://github.com/user-attachments/assets/ed4db2c9-8600-4393-987a-3078762aad42">
