### PR TITLE
feat: unlink alby account

### DIFF
--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -48,6 +48,8 @@ const (
 	userIdentifierKey    = "AlbyUserIdentifier"
 )
 
+const ALBY_ACCOUNT_APP_NAME = "getalby.com"
+
 func NewAlbyOAuthService(db *gorm.DB, cfg config.Config, keys keys.Keys, eventPublisher events.EventPublisher) *albyOAuthService {
 	conf := &oauth2.Config{
 		ClientID:     cfg.GetEnv().AlbyClientId,
@@ -396,6 +398,12 @@ func (svc *albyOAuthService) GetAuthUrl() string {
 }
 
 func (svc *albyOAuthService) UnlinkAccount(ctx context.Context) error {
+	err := svc.destroyAlbyAccountNWCNode(ctx)
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to destroy Alby Account NWC node")
+	}
+	svc.deleteAlbyAccountApps()
+
 	svc.cfg.SetUpdate(userIdentifierKey, "", "")
 	svc.cfg.SetUpdate(accessTokenKey, "", "")
 	svc.cfg.SetUpdate(accessTokenExpiryKey, "", "")
@@ -405,10 +413,7 @@ func (svc *albyOAuthService) UnlinkAccount(ctx context.Context) error {
 }
 
 func (svc *albyOAuthService) LinkAccount(ctx context.Context, lnClient lnclient.LNClient, budget uint64, renewal string) error {
-	appName := "getalby.com"
-
-	// delete any existing getalby.com connections to ensure user only sees the new one
-	svc.db.Where("name = ?", appName).Delete(&db.App{})
+	svc.deleteAlbyAccountApps()
 
 	connectionPubkey, err := svc.createAlbyAccountNWCNode(ctx)
 	if err != nil {
@@ -427,7 +432,7 @@ func (svc *albyOAuthService) LinkAccount(ctx context.Context, lnClient lnclient.
 	}
 
 	app, _, err := db.NewDBService(svc.db, svc.eventPublisher).CreateApp(
-		appName,
+		ALBY_ACCOUNT_APP_NAME,
 		connectionPubkey,
 		budget,
 		renewal,
@@ -726,6 +731,40 @@ func (svc *albyOAuthService) createAlbyAccountNWCNode(ctx context.Context) (stri
 	}).Info("Created alby nwc node successfully")
 
 	return responsePayload.Pubkey, nil
+}
+
+func (svc *albyOAuthService) destroyAlbyAccountNWCNode(ctx context.Context) error {
+	token, err := svc.fetchUserToken(ctx)
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to fetch user token")
+	}
+
+	client := svc.oauthConf.Client(ctx, token)
+
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/internal/nwcs", svc.cfg.GetEnv().AlbyAPIURL), nil)
+	if err != nil {
+		logger.Logger.WithError(err).Error("Error creating request /internal/nwcs")
+		return err
+	}
+
+	setDefaultRequestHeaders(req)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to send request to /internal/nwcs")
+		return err
+	}
+
+	if resp.StatusCode >= 300 {
+		logger.Logger.WithFields(logrus.Fields{
+			"status": resp.StatusCode,
+		}).Error("Request to /internal/nwcs returned non-success status")
+		return errors.New("request to /internal/nwcs returned non-success status")
+	}
+
+	logger.Logger.Info("Removed alby account nwc node successfully")
+
+	return nil
 }
 
 func (svc *albyOAuthService) activateAlbyAccountNWCNode(ctx context.Context) error {
@@ -1062,4 +1101,12 @@ func (svc *albyOAuthService) getLSPInfo(ctx context.Context, url string) (pubkey
 func setDefaultRequestHeaders(req *http.Request) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "AlbyHub/"+version.Tag)
+}
+
+func (svc *albyOAuthService) deleteAlbyAccountApps() {
+	// delete any existing getalby.com connections so when re-linking the user only has one
+	err := svc.db.Where("name = ?", ALBY_ACCOUNT_APP_NAME).Delete(&db.App{}).Error
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to delete Alby Account apps")
+	}
 }

--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -395,6 +395,15 @@ func (svc *albyOAuthService) GetAuthUrl() string {
 	return svc.oauthConf.AuthCodeURL("unused")
 }
 
+func (svc *albyOAuthService) UnlinkAccount(ctx context.Context) error {
+	svc.cfg.SetUpdate(userIdentifierKey, "", "")
+	svc.cfg.SetUpdate(accessTokenKey, "", "")
+	svc.cfg.SetUpdate(accessTokenExpiryKey, "", "")
+	svc.cfg.SetUpdate(refreshTokenKey, "", "")
+
+	return nil
+}
+
 func (svc *albyOAuthService) LinkAccount(ctx context.Context, lnClient lnclient.LNClient, budget uint64, renewal string) error {
 	connectionPubkey, err := svc.createAlbyAccountNWCNode(ctx)
 	if err != nil {

--- a/alby/models.go
+++ b/alby/models.go
@@ -19,6 +19,7 @@ type AlbyOAuthService interface {
 	GetMe(ctx context.Context) (*AlbyMe, error)
 	SendPayment(ctx context.Context, invoice string) error
 	DrainSharedWallet(ctx context.Context, lnClient lnclient.LNClient) error
+	UnlinkAccount(ctx context.Context) error
 	RequestAutoChannel(ctx context.Context, lnClient lnclient.LNClient, isPublic bool) (*AutoChannelResponse, error)
 }
 

--- a/frontend/src/components/AuthCodeForm.tsx
+++ b/frontend/src/components/AuthCodeForm.tsx
@@ -13,11 +13,14 @@ import { handleRequestError } from "src/utils/handleRequestError";
 import { openLink } from "src/utils/openLink";
 import { request } from "src/utils/request"; // build the project for this to appear
 
-function AuthCodeForm() {
+type AuthCodeFormProps = {
+  url: string;
+};
+
+function AuthCodeForm({ url }: AuthCodeFormProps) {
   const [authCode, setAuthCode] = useState("");
   const navigate = useNavigate();
   const { data: csrf } = useCSRF();
-  const { data: info } = useInfo();
   const { mutate: refetchInfo } = useInfo();
 
   const [hasRequestedCode, setRequestedCode] = React.useState(false);
@@ -25,11 +28,11 @@ function AuthCodeForm() {
 
   async function requestAuthCode() {
     setRequestedCode((hasRequestedCode) => {
-      if (!info) {
+      if (!url) {
         return false;
       }
       if (!hasRequestedCode) {
-        openLink(info.albyAuthUrl);
+        openLink(url);
       }
       return true;
     });

--- a/frontend/src/components/layouts/SettingsLayout.tsx
+++ b/frontend/src/components/layouts/SettingsLayout.tsx
@@ -108,6 +108,7 @@ export default function SettingsLayout() {
             {hasNodeBackup && (
               <MenuItem to="/settings/node-backup">Migrate Node</MenuItem>
             )}
+            <MenuItem to="/settings/alby-account">Alby Account</MenuItem>
             <MenuItem to="/debug-tools">
               Debug Tools
               <ExternalLink className="w-4 h-4 ml-2" />

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -34,6 +34,7 @@ import BuyBitcoin from "src/screens/onchain/BuyBitcoin";
 import DepositBitcoin from "src/screens/onchain/DepositBitcoin";
 import ConnectPeer from "src/screens/peers/ConnectPeer";
 import Peers from "src/screens/peers/Peers";
+import { AlbyAccount } from "src/screens/settings/AlbyAccount";
 import { ChangeUnlockPassword } from "src/screens/settings/ChangeUnlockPassword";
 import DebugTools from "src/screens/settings/DebugTools";
 import Settings from "src/screens/settings/Settings";
@@ -128,6 +129,10 @@ const routes = [
               {
                 path: "node-backup",
                 element: <BackupNode />,
+              },
+              {
+                path: "alby-account",
+                element: <AlbyAccount />,
               },
             ],
           },

--- a/frontend/src/screens/alby/AlbyAuthRedirect.tsx
+++ b/frontend/src/screens/alby/AlbyAuthRedirect.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useLocation } from "react-router-dom";
 import AuthCodeForm from "src/components/AuthCodeForm";
 
 import Loading from "src/components/Loading";
@@ -6,15 +7,25 @@ import { useInfo } from "src/hooks/useInfo";
 
 export default function AlbyAuthRedirect() {
   const { data: info } = useInfo();
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const forceLogin = !!queryParams.get("force_login");
+  const url = info?.albyAuthUrl
+    ? `${info.albyAuthUrl}${forceLogin ? "&force_login=true" : ""}`
+    : undefined;
 
   React.useEffect(() => {
-    if (!info) {
+    if (!info || !url) {
       return;
     }
     if (info.oauthRedirect) {
-      window.location.href = info.albyAuthUrl;
+      window.location.href = url;
     }
-  }, [info]);
+  }, [info, url]);
 
-  return !info || info.oauthRedirect ? <Loading /> : <AuthCodeForm />;
+  return !info || info.oauthRedirect || !url ? (
+    <Loading />
+  ) : (
+    <AuthCodeForm url={url} />
+  );
 }

--- a/frontend/src/screens/settings/AlbyAccount.tsx
+++ b/frontend/src/screens/settings/AlbyAccount.tsx
@@ -1,5 +1,6 @@
 import { ExitIcon } from "@radix-ui/react-icons";
 import { ExternalLinkIcon } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 import ExternalLink from "src/components/ExternalLink";
 import SettingsHeader from "src/components/SettingsHeader";
@@ -11,25 +12,18 @@ import {
 } from "src/components/ui/card";
 import { useToast } from "src/components/ui/use-toast";
 import { useCSRF } from "src/hooks/useCSRF";
-import { useInfo } from "src/hooks/useInfo";
 import { request } from "src/utils/request";
 
 export function AlbyAccount() {
   const { data: csrf } = useCSRF();
   const { toast } = useToast();
-  const { mutate: refetchInfo } = useInfo();
+  const navigate = useNavigate();
 
   const unlink = async () => {
     if (
       !confirm(
-        "Please log out at https://getalby.com, then click ok to continue."
+        "Are you sure you want to change the Alby Account for your hub? Your Alby Account will be disconnected from your hub and you'll need to login with a new Alby Account to access your hub."
       )
-    ) {
-      return;
-    }
-
-    if (
-      !confirm("Are you sure you want to change the Alby Account for your hub?")
     ) {
       return;
     }
@@ -45,7 +39,7 @@ export function AlbyAccount() {
           "Content-Type": "application/json",
         },
       });
-      await refetchInfo();
+      navigate("/alby/auth?force_login=true");
       toast({
         title: "Alby Account Unlinked",
         description: "Please login with another Alby Account",

--- a/frontend/src/screens/settings/AlbyAccount.tsx
+++ b/frontend/src/screens/settings/AlbyAccount.tsx
@@ -1,0 +1,93 @@
+import { ExitIcon } from "@radix-ui/react-icons";
+import { ExternalLinkIcon } from "lucide-react";
+
+import ExternalLink from "src/components/ExternalLink";
+import SettingsHeader from "src/components/SettingsHeader";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "src/components/ui/card";
+import { useToast } from "src/components/ui/use-toast";
+import { useCSRF } from "src/hooks/useCSRF";
+import { useInfo } from "src/hooks/useInfo";
+import { request } from "src/utils/request";
+
+export function AlbyAccount() {
+  const { data: csrf } = useCSRF();
+  const { toast } = useToast();
+  const { mutate: refetchInfo } = useInfo();
+
+  const unlink = async () => {
+    if (
+      !confirm(
+        "Please log out at https://getalby.com, then click ok to continue."
+      )
+    ) {
+      return;
+    }
+
+    if (
+      !confirm("Are you sure you want to change the Alby Account for your hub?")
+    ) {
+      return;
+    }
+
+    try {
+      if (!csrf) {
+        throw new Error("No CSRF token");
+      }
+      await request("/api/alby/unlink-account", {
+        method: "POST",
+        headers: {
+          "X-CSRF-Token": csrf,
+          "Content-Type": "application/json",
+        },
+      });
+      await refetchInfo();
+      toast({
+        title: "Alby Account Unlinked",
+        description: "Please login with another Alby Account",
+      });
+    } catch (error) {
+      toast({
+        title: "Unlink account failed",
+        description: (error as Error).message,
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <>
+      <SettingsHeader
+        title="Alby Account"
+        description="Manage your Alby Account"
+      />
+      <ExternalLink
+        to="https://getalby.com/settings"
+        className="w-full flex flex-row items-center gap-2"
+      >
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle>Your Alby Account</CardTitle>
+            <CardDescription className="flex gap-2 items-center">
+              <ExternalLinkIcon className="w-4 h-4" /> Manage your Alby Account
+              Settings
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </ExternalLink>
+      <Card className="w-full cursor-pointer" onClick={unlink}>
+        <CardHeader>
+          <CardTitle>Change Alby Account</CardTitle>
+          <CardDescription className="flex gap-2 items-center">
+            <ExitIcon className="w-4 h-4" /> Link your Hub to a different Alby
+            Account
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    </>
+  );
+}

--- a/http/alby_http_service.go
+++ b/http/alby_http_service.go
@@ -33,6 +33,7 @@ func (albyHttpSvc *AlbyHttpService) RegisterSharedRoutes(e *echo.Echo, authMiddl
 	e.POST("/api/alby/drain", albyHttpSvc.albyDrainHandler, authMiddleware)
 	e.POST("/api/alby/link-account", albyHttpSvc.albyLinkAccountHandler, authMiddleware)
 	e.POST("/api/alby/auto-channel", albyHttpSvc.autoChannelHandler, authMiddleware)
+	e.POST("/api/alby/unlink-account", albyHttpSvc.unlinkHandler, authMiddleware)
 }
 
 func (albyHttpSvc *AlbyHttpService) autoChannelHandler(c echo.Context) error {
@@ -49,11 +50,25 @@ func (albyHttpSvc *AlbyHttpService) autoChannelHandler(c echo.Context) error {
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{
-			Message: fmt.Sprintf("Failed to request wrapped invoice: %s", err.Error()),
+			Message: fmt.Sprintf("Failed to request auto channel: %s", err.Error()),
 		})
 	}
 
 	return c.JSON(http.StatusOK, autoChannelResponseResponse)
+}
+
+func (albyHttpSvc *AlbyHttpService) unlinkHandler(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	err := albyHttpSvc.albyOAuthSvc.UnlinkAccount(ctx)
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Message: fmt.Sprintf("Failed to request wrapped invoice: %s", err.Error()),
+		})
+	}
+
+	return c.NoContent(http.StatusNoContent)
 }
 
 func (albyHttpSvc *AlbyHttpService) albyCallbackHandler(c echo.Context) error {

--- a/wails/wails_handlers.go
+++ b/wails/wails_handlers.go
@@ -281,6 +281,12 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
 		return WailsRequestRouterResponse{Body: nil, Error: ""}
+	case "/api/alby/unlink-account":
+		err := app.svc.GetAlbyOAuthSvc().UnlinkAccount(ctx)
+		if err != nil {
+			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
+		}
+		return WailsRequestRouterResponse{Body: nil, Error: ""}
 	case "/api/alby/pay":
 		payRequest := &alby.AlbyPayRequest{}
 		err := json.Unmarshal([]byte(body), payRequest)


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/289

Adds a new settings page http://localhost:5173/#/settings/alby-account

![image](https://github.com/user-attachments/assets/92745ca8-6f6a-480f-bd5a-82c20f9ea8fe)

This currently does not remote the Alby Oauth account's NWC connection. I don't think this should necessarily be the same action

The first link is a bit wrong because it always goes to your currently logged in account on getalby.com which might not be the one logged in in the hub. It would be cool if we can pass something to getalby.com to detect that?