### PR TITLE
feat: add metadata field to make_invoice command

### DIFF
--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -290,7 +290,7 @@ func (svc *albyOAuthService) DrainSharedWallet(ctx context.Context, lnClient lnc
 
 	logger.Logger.WithField("amount", amount).WithError(err).Error("Draining Alby shared wallet funds")
 
-	transaction, err := transactions.NewTransactionsService(svc.db).MakeInvoice(ctx, amount, "Send shared wallet funds to Alby Hub", "", 120, lnClient, nil, nil)
+	transaction, err := transactions.NewTransactionsService(svc.db).MakeInvoice(ctx, amount, "Send shared wallet funds to Alby Hub", "", 120, nil, lnClient, nil, nil)
 	if err != nil {
 		logger.Logger.WithField("amount", amount).WithError(err).Error("Failed to make invoice")
 		return err

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -15,7 +15,7 @@ func (api *api) CreateInvoice(ctx context.Context, amount int64, description str
 	if api.svc.GetLNClient() == nil {
 		return nil, errors.New("LNClient not started")
 	}
-	transaction, err := api.svc.GetTransactionsService().MakeInvoice(ctx, amount, description, "", 0, api.svc.GetLNClient(), nil, nil)
+	transaction, err := api.svc.GetTransactionsService().MakeInvoice(ctx, amount, description, "", 0, nil, api.svc.GetLNClient(), nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -29,3 +29,9 @@ const (
 	SIGN_MESSAGE_SCOPE      = "sign_message"
 	NOTIFICATIONS_SCOPE     = "notifications" // covers all notification types
 )
+
+// limit encoded metadata length, otherwise relays may have trouble listing multiple transactions
+// given a relay limit of 512000 bytes and ideally being able to list 50 transactions,
+// each transaction would have to have a maximum size of 10240
+// accounting for encryption and other metadata in the response, this is set to 2048 characters
+const INVOICE_METADATA_MAX_LENGTH = 2048

--- a/nip47/controllers/make_invoice_controller.go
+++ b/nip47/controllers/make_invoice_controller.go
@@ -10,10 +10,11 @@ import (
 )
 
 type makeInvoiceParams struct {
-	Amount          int64  `json:"amount"`
-	Description     string `json:"description"`
-	DescriptionHash string `json:"description_hash"`
-	Expiry          int64  `json:"expiry"`
+	Amount          int64       `json:"amount"`
+	Description     string      `json:"description"`
+	DescriptionHash string      `json:"description_hash"`
+	Expiry          int64       `json:"expiry"`
+	Metadata        interface{} `json:"metadata,omitempty"`
 }
 type makeInvoiceResponse struct {
 	models.Transaction
@@ -34,11 +35,12 @@ func (controller *nip47Controller) HandleMakeInvoiceEvent(ctx context.Context, n
 		"description":      makeInvoiceParams.Description,
 		"description_hash": makeInvoiceParams.DescriptionHash,
 		"expiry":           makeInvoiceParams.Expiry,
+		"metadata":         makeInvoiceParams.Metadata,
 	}).Info("Making invoice")
 
 	expiry := makeInvoiceParams.Expiry
 
-	transaction, err := controller.transactionsService.MakeInvoice(ctx, makeInvoiceParams.Amount, makeInvoiceParams.Description, makeInvoiceParams.DescriptionHash, expiry, controller.lnClient, &appId, &requestEventId)
+	transaction, err := controller.transactionsService.MakeInvoice(ctx, makeInvoiceParams.Amount, makeInvoiceParams.Description, makeInvoiceParams.DescriptionHash, expiry, makeInvoiceParams.Metadata, controller.lnClient, &appId, &requestEventId)
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
 			"request_event_id": requestEventId,

--- a/nip47/controllers/make_invoice_controller_test.go
+++ b/nip47/controllers/make_invoice_controller_test.go
@@ -20,8 +20,20 @@ const nip47MakeInvoiceJson = `
 	"method": "make_invoice",
 	"params": {
 		"amount": 1000,
-		"description": "[[\"text/identifier\",\"hello@getalby.com\"],[\"text/plain\",\"Sats for Alby\"]]",
-		"expiry": 3600
+		"description": "Hello, world",
+		"expiry": 3600,
+		"metadata": {
+		  "a": 1,
+			"b": "2",
+			"c": {
+			  "d": 3,
+				"e": [{
+					"f": "g"
+				},{
+					"h": "i"
+				}]
+			}
+		}
 	}
 }
 `
@@ -56,6 +68,19 @@ func TestHandleMakeInvoiceEvent(t *testing.T) {
 	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
 		HandleMakeInvoiceEvent(ctx, nip47Request, dbRequestEvent.ID, *dbRequestEvent.AppId, publishResponse)
 
+	expectedMetadata := map[string]interface{}{
+		"a": float64(1),
+		"b": "2",
+		"c": map[string]interface{}{
+			"d": float64(3),
+			"e": []interface{}{
+				map[string]interface{}{"f": "g"},
+				map[string]interface{}{"h": "i"},
+			},
+		},
+	}
+
 	assert.Nil(t, publishedResponse.Error)
 	assert.Equal(t, tests.MockLNClientTransaction.Invoice, publishedResponse.Result.(*makeInvoiceResponse).Invoice)
+	assert.Equal(t, expectedMetadata, publishedResponse.Result.(*makeInvoiceResponse).Metadata)
 }

--- a/transactions/make_invoice_test.go
+++ b/transactions/make_invoice_test.go
@@ -2,6 +2,7 @@ package transactions
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/getAlby/hub/constants"
@@ -17,13 +18,32 @@ func TestMakeInvoice_NoApp(t *testing.T) {
 	svc, err := tests.CreateTestService()
 	assert.NoError(t, err)
 
+	metadata := strings.Repeat("a", constants.INVOICE_METADATA_MAX_LENGTH-2) // json encoding adds 2 characters
+
 	transactionsService := NewTransactionsService(svc.DB)
-	transaction, err := transactionsService.MakeInvoice(ctx, 1234, "Hello world", "", 0, svc.LNClient, nil, nil)
+	transaction, err := transactionsService.MakeInvoice(ctx, 1234, "Hello world", "", 0, metadata, svc.LNClient, nil, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(tests.MockLNClientTransaction.Amount), transaction.AmountMsat)
 	assert.Equal(t, constants.TRANSACTION_STATE_PENDING, transaction.State)
 	assert.Equal(t, tests.MockLNClientTransaction.Preimage, *transaction.Preimage)
+	assert.Equal(t, `"`+metadata+`"`, transaction.Metadata) // json-encoded
+}
+
+func TestMakeInvoice_MetadataTooLarge(t *testing.T) {
+	ctx := context.TODO()
+
+	defer tests.RemoveTestService()
+	svc, err := tests.CreateTestService()
+	assert.NoError(t, err)
+	metadata := strings.Repeat("a", constants.INVOICE_METADATA_MAX_LENGTH-1) // json encoding adds 2 characters
+
+	transactionsService := NewTransactionsService(svc.DB)
+	transaction, err := transactionsService.MakeInvoice(ctx, 1234, "Hello world", "", 0, metadata, svc.LNClient, nil, nil)
+
+	assert.Error(t, err)
+	assert.Equal(t, "encoded invoice metadata provided is too large. Limit: 2048 Received: 2049", err.Error())
+	assert.Nil(t, transaction)
 }
 
 func TestMakeInvoice_App(t *testing.T) {
@@ -41,7 +61,7 @@ func TestMakeInvoice_App(t *testing.T) {
 	assert.NoError(t, err)
 
 	transactionsService := NewTransactionsService(svc.DB)
-	transaction, err := transactionsService.MakeInvoice(ctx, 1234, "Hello world", "", 0, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.MakeInvoice(ctx, 1234, "Hello world", "", 0, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(tests.MockLNClientTransaction.Amount), transaction.AmountMsat)


### PR DESCRIPTION
This enables apps to easily attach metadata to invoices rather than requiring an external database. This can currently be done by encoding data in the description field which will be included in the invoice itself, but there are a few downsides:
- it makes the invoice QR code harder to scan
- user doesn't understand the encoded content which should actually be a description
- description is limited to 639 bytes and then gets switched to a description hash, which can break apps

TODOs:
- [ ] add to JS SDK - https://github.com/getAlby/js-sdk/pull/232
- [ ] update Bitcoin Connect
- [x] test with Paper Scissors Rock game - https://github.com/rolznz/paper-scissors-hodl/pull/1
- [ ] review max metadata size (currently 2KB encoded)
- [ ] suggest change to NIP
