### PR TITLE
chore: no default invoice memo

### DIFF
--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -96,7 +96,7 @@ function TransactionItem({ tx }: Props) {
                 </p>
               </div>
               <p className="text-sm md:text-base text-muted-foreground break-all">
-                {tx.description || "Lightning invoice"}
+                {tx.description}
               </p>
             </div>
             <div className="flex ml-auto text-right space-x-3 shrink-0">


### PR DESCRIPTION
what value does it give? then all the entries say lightning invoice and it can only be a lightning invoice