### PR TITLE
chore: include whether the channel is public or not in channel ready event

### DIFF
--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -1244,12 +1244,15 @@ func (ls *LDKService) handleLdkEvent(event *ldk_node.Event) {
 			logger.Logger.WithField("event", eventType).Error("Failed to find channel by ID")
 			return
 		}
+		channel := channels[channelIndex]
 		ls.eventPublisher.Publish(&events.Event{
 			Event: "nwc_channel_ready",
 			Properties: map[string]interface{}{
 				"counterparty_node_id": eventType.CounterpartyNodeId,
 				"node_type":            config.LDKBackendType,
-				"public":               channels[channelIndex].IsPublic,
+				"public":               channel.IsPublic,
+				"capacity":             channel.ChannelValueSats,
+				"is_outbound":          channel.IsOutbound,
 			},
 		})
 

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -1236,11 +1236,20 @@ func (ls *LDKService) handleLdkEvent(event *ldk_node.Event) {
 
 	switch eventType := (*event).(type) {
 	case ldk_node.EventChannelReady:
+		channels := ls.node.ListChannels()
+		channelIndex := slices.IndexFunc(channels, func(c ldk_node.ChannelDetails) bool {
+			return c.ChannelId == eventType.ChannelId
+		})
+		if channelIndex == -1 {
+			logger.Logger.WithField("event", eventType).Error("Failed to find channel by ID")
+			return
+		}
 		ls.eventPublisher.Publish(&events.Event{
 			Event: "nwc_channel_ready",
 			Properties: map[string]interface{}{
 				"counterparty_node_id": eventType.CounterpartyNodeId,
 				"node_type":            config.LDKBackendType,
+				"public":               channels[channelIndex].IsPublic,
 			},
 		})
 


### PR DESCRIPTION
With this we can have custom emails and monitors/workflows if a user opens a public and private channel for example