### PR TITLE
Fix: cache alby user calls

### DIFF
--- a/frontend/src/hooks/useAlbyBalance.ts
+++ b/frontend/src/hooks/useAlbyBalance.ts
@@ -1,8 +1,10 @@
 import useSWR from "swr";
 
-import { swrFetcher } from "src/utils/swr";
 import { AlbyBalance } from "src/types";
+import { swrFetcher } from "src/utils/swr";
 
 export function useAlbyBalance() {
-  return useSWR<AlbyBalance>("/api/alby/balance", swrFetcher);
+  return useSWR<AlbyBalance>("/api/alby/balance", swrFetcher, {
+    dedupingInterval: 5 * 60 * 1000, // 5 minutes
+  });
 }

--- a/frontend/src/hooks/useAlbyMe.ts
+++ b/frontend/src/hooks/useAlbyMe.ts
@@ -4,5 +4,7 @@ import { AlbyMe } from "src/types";
 import { swrFetcher } from "src/utils/swr";
 
 export function useAlbyMe() {
-  return useSWR<AlbyMe>("/api/alby/me", swrFetcher);
+  return useSWR<AlbyMe>("/api/alby/me", swrFetcher, {
+    dedupingInterval: 5 * 60 * 1000, // 5 minutes
+  });
 }


### PR DESCRIPTION
fixes https://github.com/getAlby/hub/issues/373

Tested by navigating pages and checking XHR requests in my browser. Other calls deduplicate by default every 2 seconds - which we could review and possibly increase for some other calls too. However, this might be less important.