### PR TITLE
feat: add close channel dialog

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-navigation-menu": "^1.1.4",
     "@radix-ui/react-popover": "^1.1.1",
     "@radix-ui/react-progress": "^1.0.3",
+    "@radix-ui/react-radio-group": "^1.2.0",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",

--- a/frontend/src/components/CloseChannelDialog.tsx
+++ b/frontend/src/components/CloseChannelDialog.tsx
@@ -1,0 +1,243 @@
+import { AlertTriangleIcon, CopyIcon, ExternalLinkIcon } from "lucide-react";
+import React from "react";
+import ExternalLink from "src/components/ExternalLink";
+import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
+import { Button } from "src/components/ui/button";
+import { Checkbox } from "src/components/ui/checkbox";
+import { toast } from "src/components/ui/use-toast";
+import { useChannels } from "src/hooks/useChannels";
+import { useCSRF } from "src/hooks/useCSRF";
+import { copyToClipboard } from "src/lib/clipboard";
+import { Channel, CloseChannelResponse } from "src/types";
+import { request } from "src/utils/request";
+import {
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "./ui/alert-dialog";
+
+type Props = {
+  alias: string;
+  channel: Channel;
+};
+
+export function CloseChannelDialog({ alias, channel }: Props) {
+  const [closeType, setCloseType] = React.useState("normal");
+  const [step, setStep] = React.useState(channel.active ? 2 : 1);
+  const [fundingTxId, setFundingTxId] = React.useState("");
+  const { data: channels, mutate: reloadChannels } = useChannels();
+  const { data: csrf } = useCSRF();
+
+  const onContinue = () => {
+    setStep(step + 1);
+  };
+
+  const copy = (text: string) => {
+    copyToClipboard(text);
+    toast({ title: "Copied to clipboard." });
+  };
+
+  async function closeChannel() {
+    try {
+      if (!csrf) {
+        throw new Error("csrf not loaded");
+      }
+
+      console.info(`🎬 Closing channel with ${channel.remotePubkey}`);
+
+      const closeChannelResponse = await request<CloseChannelResponse>(
+        `/api/peers/${channel.remotePubkey}/channels/${channel.id}?force=${
+          closeType === "force"
+        }`,
+        {
+          method: "DELETE",
+          headers: {
+            "X-CSRF-Token": csrf,
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      if (!closeChannelResponse) {
+        throw new Error("Error closing channel");
+      }
+
+      const closedChannel = channels?.find(
+        (c) => c.id === channel.id && c.remotePubkey === channel.remotePubkey
+      );
+      console.info("Closed channel", closedChannel);
+      if (closedChannel) {
+        setFundingTxId(closedChannel.fundingTxId);
+        setStep(step + 1);
+      }
+      toast({ title: "Sucessfully closed channel" });
+    } catch (error) {
+      console.error(error);
+      toast({
+        variant: "destructive",
+        description: "Something went wrong: " + error,
+      });
+    }
+  }
+
+  return (
+    <AlertDialogContent>
+      {step === 1 && (
+        <>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Are you sure you want to close the channel with {alias}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This channel is inactive. Some channels require up to 6 onchain
+              confirmations before they are usable. Proceed only if you still
+              want to continue
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <Button onClick={onContinue}>Continue</Button>
+          </AlertDialogFooter>
+        </>
+      )}
+
+      {step === 2 && (
+        <>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Are you sure you want to close the channel with {alias}?
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-left">
+              <div>
+                <p className="text-primary font-medium">Node ID</p>
+                <p className="break-all">{channel.remotePubkey}</p>
+              </div>
+              <div className="mt-4">
+                <p className="text-primary font-medium">Channel ID</p>
+                <p className="break-all">{channel.id}</p>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <Button onClick={onContinue}>Continue</Button>
+          </AlertDialogFooter>
+        </>
+      )}
+
+      {step === 3 && (
+        <>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Select mode of channel closure</AlertDialogTitle>
+            <AlertDialogDescription className="text-left">
+              {closeType === "force" && (
+                <Alert className="mb-4">
+                  <AlertTriangleIcon className="h-4 w-4" />
+                  <AlertTitle>Heads up!</AlertTitle>
+                  <AlertDescription>
+                    Your channel balance will be locked for up to two weeks if
+                    you force close
+                  </AlertDescription>
+                </Alert>
+              )}
+              <div className="flex flex-col gap-4 text-xs mt-2">
+                <div className="items-top flex space-x-2">
+                  <Checkbox
+                    id="normal"
+                    onCheckedChange={() =>
+                      setCloseType(closeType === "normal" ? "force" : "normal")
+                    }
+                    checked={closeType === "normal"}
+                  />
+                  <div className="grid gap-1.5 leading-none">
+                    <label
+                      htmlFor="normal"
+                      className="text-primary text-sm font-medium leading-none cursor-pointer"
+                    >
+                      Normal Close
+                    </label>
+                    <p className="text-sm text-muted-foreground">
+                      Closes the channel cooperatively, usually faster and with
+                      lower fees
+                    </p>
+                  </div>
+                </div>
+                <div className="items-top flex space-x-2">
+                  <Checkbox
+                    id="force"
+                    onCheckedChange={() =>
+                      setCloseType(closeType === "force" ? "normal" : "force")
+                    }
+                    checked={closeType === "force"}
+                  />
+                  <div className="grid gap-1.5 leading-none">
+                    <label
+                      htmlFor="force"
+                      className="text-primary text-sm font-medium leading-none cursor-pointer"
+                    >
+                      Force Close
+                    </label>
+                    <p className="text-sm text-muted-foreground">
+                      Closes the channel unilaterally, can take longer and might
+                      incur higher fees
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <ExternalLink
+                to="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/faq-alby-hub/how-can-i-close-this-channel-what-happens-to-the-sats-in-this-channel"
+                className="underline flex items-center mt-4"
+              >
+                Learn more about closing channels
+                <ExternalLinkIcon className="w-4 h-4 ml-2" />
+              </ExternalLink>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <Button onClick={closeChannel}>Close Channel</Button>
+          </AlertDialogFooter>
+        </>
+      )}
+
+      {step === 4 && (
+        <>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Channel closed successfully</AlertDialogTitle>
+            <AlertDialogDescription className="text-left">
+              <p className="text-primary font-medium">Funding Transaction Id</p>
+              <div className="flex items-center justify-between gap-4">
+                <p className="break-all">{fundingTxId}</p>
+                <CopyIcon
+                  className="cursor-pointer text-muted-foreground w-4 h-4"
+                  onClick={() => {
+                    copy(fundingTxId);
+                  }}
+                />
+              </div>
+              <ExternalLink
+                to={`https://mempool.space/tx/${fundingTxId}`}
+                className="underline flex items-center mt-2"
+              >
+                View on Mempool
+                <ExternalLinkIcon className="w-4 h-4 ml-2" />
+              </ExternalLink>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              onClick={async () => {
+                await reloadChannels();
+              }}
+            >
+              Done
+            </AlertDialogCancel>
+          </AlertDialogFooter>
+        </>
+      )}
+    </AlertDialogContent>
+  );
+}

--- a/frontend/src/components/CloseChannelDialog.tsx
+++ b/frontend/src/components/CloseChannelDialog.tsx
@@ -162,11 +162,13 @@ export function CloseChannelDialog({ alias, channel }: Props) {
                       htmlFor="normal"
                       className="text-primary font-medium cursor-pointer"
                     >
-                      Normal Close
+                      Normal Close (Recommended)
                     </Label>
                     <p className="text-sm text-muted-foreground">
-                      Both parties agree to close the channel, usually quicker
-                      and with lower fees
+                      Attempt to agree to with your channel partner to close the
+                      channel, usually quicker and with lower fees. If an
+                      agreement cannot be met or your channel partner is
+                      offline, this will result in a force closure.
                     </p>
                   </div>
                 </div>
@@ -184,8 +186,9 @@ export function CloseChannelDialog({ alias, channel }: Props) {
                       Force Close
                     </Label>
                     <p className="text-sm text-muted-foreground">
-                      You close the channel alone. Takes longer and may incur
-                      higher fees
+                      You close the channel alone. Your funds may be locked for
+                      up to two weeks and may incur higher fees. Only try this
+                      if a normal closure does not work.
                     </p>
                   </div>
                 </div>

--- a/frontend/src/components/CloseChannelDialog.tsx
+++ b/frontend/src/components/CloseChannelDialog.tsx
@@ -3,7 +3,8 @@ import React from "react";
 import ExternalLink from "src/components/ExternalLink";
 import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
 import { Button } from "src/components/ui/button";
-import { Checkbox } from "src/components/ui/checkbox";
+import { Label } from "src/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "src/components/ui/radio-group";
 import { toast } from "src/components/ui/use-toast";
 import { useChannels } from "src/hooks/useChannels";
 import { useCSRF } from "src/hooks/useCSRF";
@@ -93,13 +94,12 @@ export function CloseChannelDialog({ alias, channel }: Props) {
             </AlertDialogTitle>
             <AlertDialogDescription>
               This channel is inactive. Some channels require up to 6 onchain
-              confirmations before they are usable. Proceed only if you still
-              want to continue
+              confirmations before they are usable.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <Button onClick={onContinue}>Continue</Button>
+            <Button onClick={onContinue}>Confirm</Button>
           </AlertDialogFooter>
         </>
       )}
@@ -143,50 +143,53 @@ export function CloseChannelDialog({ alias, channel }: Props) {
                   </AlertDescription>
                 </Alert>
               )}
-              <div className="flex flex-col gap-4 text-xs mt-2">
-                <div className="items-top flex space-x-2">
-                  <Checkbox
+              <RadioGroup
+                defaultValue="normal"
+                value={closeType}
+                onValueChange={() =>
+                  setCloseType(closeType === "normal" ? "force" : "normal")
+                }
+                className="mt-2"
+              >
+                <div className="flex items-start space-x-2 mb-2">
+                  <RadioGroupItem
+                    value="normal"
                     id="normal"
-                    onCheckedChange={() =>
-                      setCloseType(closeType === "normal" ? "force" : "normal")
-                    }
-                    checked={closeType === "normal"}
+                    className="shrink-0"
                   />
-                  <div className="grid gap-1.5 leading-none">
-                    <label
+                  <div className="grid gap-1.5">
+                    <Label
                       htmlFor="normal"
-                      className="text-primary text-sm font-medium leading-none cursor-pointer"
+                      className="text-primary font-medium cursor-pointer"
                     >
                       Normal Close
-                    </label>
+                    </Label>
                     <p className="text-sm text-muted-foreground">
                       Closes the channel cooperatively, usually faster and with
                       lower fees
                     </p>
                   </div>
                 </div>
-                <div className="items-top flex space-x-2">
-                  <Checkbox
+                <div className="flex items-start space-x-2">
+                  <RadioGroupItem
+                    value="force"
                     id="force"
-                    onCheckedChange={() =>
-                      setCloseType(closeType === "force" ? "normal" : "force")
-                    }
-                    checked={closeType === "force"}
+                    className="shrink-0"
                   />
-                  <div className="grid gap-1.5 leading-none">
-                    <label
+                  <div className="grid gap-1.5">
+                    <Label
                       htmlFor="force"
-                      className="text-primary text-sm font-medium leading-none cursor-pointer"
+                      className="text-primary font-medium cursor-pointer"
                     >
                       Force Close
-                    </label>
+                    </Label>
                     <p className="text-sm text-muted-foreground">
                       Closes the channel unilaterally, can take longer and might
                       incur higher fees
                     </p>
                   </div>
                 </div>
-              </div>
+              </RadioGroup>
               <ExternalLink
                 to="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/faq-alby-hub/how-can-i-close-this-channel-what-happens-to-the-sats-in-this-channel"
                 className="underline flex items-center mt-4"

--- a/frontend/src/components/CloseChannelDialog.tsx
+++ b/frontend/src/components/CloseChannelDialog.tsx
@@ -165,8 +165,8 @@ export function CloseChannelDialog({ alias, channel }: Props) {
                       Normal Close
                     </Label>
                     <p className="text-sm text-muted-foreground">
-                      Closes the channel cooperatively, usually faster and with
-                      lower fees
+                      Both parties agree to close the channel, usually quicker
+                      and with lower fees
                     </p>
                   </div>
                 </div>
@@ -184,8 +184,8 @@ export function CloseChannelDialog({ alias, channel }: Props) {
                       Force Close
                     </Label>
                     <p className="text-sm text-muted-foreground">
-                      Closes the channel unilaterally, can take longer and might
-                      incur higher fees
+                      You close the channel alone. Takes longer and may incur
+                      higher fees
                     </p>
                   </div>
                 </div>

--- a/frontend/src/components/channels/ChannelDropdownMenu.tsx
+++ b/frontend/src/components/channels/ChannelDropdownMenu.tsx
@@ -1,0 +1,80 @@
+import {
+  ExternalLinkIcon,
+  HandCoins,
+  MoreHorizontal,
+  Trash2,
+} from "lucide-react";
+import { CloseChannelDialog } from "src/components/CloseChannelDialog";
+import ExternalLink from "src/components/ExternalLink";
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+} from "src/components/ui/alert-dialog";
+import { Button } from "src/components/ui/button.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "src/components/ui/dropdown-menu.tsx";
+import { Channel } from "src/types";
+
+type ChannelDropdownMenuProps = {
+  alias: string;
+  channel: Channel;
+  editChannel(channel: Channel): void;
+};
+
+export function ChannelDropdownMenu({
+  alias,
+  channel,
+  editChannel,
+}: ChannelDropdownMenuProps) {
+  return (
+    <AlertDialog>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button size="icon" variant="ghost">
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
+            <ExternalLink
+              to={`https://mempool.space/tx/${channel.fundingTxId}`}
+              className="w-full flex flex-row items-center gap-2"
+            >
+              <ExternalLinkIcon className="w-4 h-4" />
+              <p>View Funding Transaction</p>
+            </ExternalLink>
+          </DropdownMenuItem>
+          <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
+            <ExternalLink
+              to={`https://amboss.space/node/${channel.remotePubkey}`}
+              className="w-full flex flex-row items-center gap-2"
+            >
+              <ExternalLinkIcon className="w-4 h-4" />
+              <p>View Node on amboss.space</p>
+            </ExternalLink>
+          </DropdownMenuItem>
+          {channel.public && (
+            <DropdownMenuItem
+              className="flex flex-row items-center gap-2 cursor-pointer"
+              onClick={() => editChannel(channel)}
+            >
+              <HandCoins className="h-4 w-4" />
+              Set Routing Fee
+            </DropdownMenuItem>
+          )}
+          <AlertDialogTrigger asChild>
+            <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
+              <Trash2 className="h-4 w-4 text-destructive" />
+              Close Channel
+            </DropdownMenuItem>
+          </AlertDialogTrigger>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <CloseChannelDialog alias={alias} channel={channel} />
+    </AlertDialog>
+  );
+}

--- a/frontend/src/components/channels/ChannelsCards.tsx
+++ b/frontend/src/components/channels/ChannelsCards.tsx
@@ -6,7 +6,12 @@ import {
   Trash2,
 } from "lucide-react";
 import { ChannelWarning } from "src/components/channels/ChannelWarning";
+import { CloseChannelDialog } from "src/components/CloseChannelDialog";
 import ExternalLink from "src/components/ExternalLink";
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+} from "src/components/ui/alert-dialog";
 import { Badge } from "src/components/ui/badge.tsx";
 import { Button } from "src/components/ui/button.tsx";
 import {
@@ -36,18 +41,12 @@ import { Channel, Node } from "src/types";
 type ChannelsCardsProps = {
   channels?: Channel[];
   nodes?: Node[];
-  closeChannel(
-    channelId: string,
-    counterpartyNodeId: string,
-    isActive: boolean
-  ): void;
   editChannel(channel: Channel): void;
 };
 
 export function ChannelsCards({
   channels,
   nodes,
-  closeChannel,
   editChannel,
 }: ChannelsCardsProps) {
   if (!channels?.length) {
@@ -80,55 +79,51 @@ export function ChannelsCards({
                         <div className="flex-1 whitespace-nowrap text-ellipsis overflow-hidden">
                           {alias}
                         </div>
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button size="icon" variant="ghost">
-                              <MoreHorizontal className="h-4 w-4" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
-                              <ExternalLink
-                                to={`https://mempool.space/tx/${channel.fundingTxId}`}
-                                className="w-full flex flex-row items-center gap-2"
-                              >
-                                <ExternalLinkIcon className="w-4 h-4" />
-                                <p>View Funding Transaction</p>
-                              </ExternalLink>
-                            </DropdownMenuItem>
-                            <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
-                              <ExternalLink
-                                to={`https://amboss.space/node/${channel.remotePubkey}`}
-                                className="w-full flex flex-row items-center gap-2"
-                              >
-                                <ExternalLinkIcon className="w-4 h-4" />
-                                <p>View Node on amboss.space</p>
-                              </ExternalLink>
-                            </DropdownMenuItem>
-                            {channel.public && (
-                              <DropdownMenuItem
-                                className="flex flex-row items-center gap-2 cursor-pointer"
-                                onClick={() => editChannel(channel)}
-                              >
-                                <HandCoins className="h-4 w-4" />
-                                Set Routing Fee
+                        <AlertDialog>
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button size="icon" variant="ghost">
+                                <MoreHorizontal className="h-4 w-4" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
+                                <ExternalLink
+                                  to={`https://mempool.space/tx/${channel.fundingTxId}`}
+                                  className="w-full flex flex-row items-center gap-2"
+                                >
+                                  <ExternalLinkIcon className="w-4 h-4" />
+                                  <p>View Funding Transaction</p>
+                                </ExternalLink>
                               </DropdownMenuItem>
-                            )}
-                            <DropdownMenuItem
-                              className="flex flex-row items-center gap-2 cursor-pointer"
-                              onClick={() =>
-                                closeChannel(
-                                  channel.id,
-                                  channel.remotePubkey,
-                                  channel.active
-                                )
-                              }
-                            >
-                              <Trash2 className="h-4 w-4 text-destructive" />
-                              Close Channel
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
+                              <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
+                                <ExternalLink
+                                  to={`https://amboss.space/node/${channel.remotePubkey}`}
+                                  className="w-full flex flex-row items-center gap-2"
+                                >
+                                  <ExternalLinkIcon className="w-4 h-4" />
+                                  <p>View Node on amboss.space</p>
+                                </ExternalLink>
+                              </DropdownMenuItem>
+                              {channel.public && (
+                                <DropdownMenuItem
+                                  className="flex flex-row items-center gap-2 cursor-pointer"
+                                  onClick={() => editChannel(channel)}
+                                >
+                                  <HandCoins className="h-4 w-4" />
+                                  Set Routing Fee
+                                </DropdownMenuItem>
+                              )}
+                              <AlertDialogTrigger asChild>
+                                <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
+                                  <Trash2 className="h-4 w-4 text-destructive" />
+                                  Close Channel
+                                </DropdownMenuItem>
+                              </AlertDialogTrigger>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                          <CloseChannelDialog alias={alias} channel={channel} />
+                        </AlertDialog>
                       </div>
                     </CardTitle>
                     <Separator className="mt-5" />

--- a/frontend/src/components/channels/ChannelsCards.tsx
+++ b/frontend/src/components/channels/ChannelsCards.tsx
@@ -1,19 +1,7 @@
-import {
-  ExternalLinkIcon,
-  HandCoins,
-  InfoIcon,
-  MoreHorizontal,
-  Trash2,
-} from "lucide-react";
+import { InfoIcon } from "lucide-react";
+import { ChannelDropdownMenu } from "src/components/channels/ChannelDropdownMenu";
 import { ChannelWarning } from "src/components/channels/ChannelWarning";
-import { CloseChannelDialog } from "src/components/CloseChannelDialog";
-import ExternalLink from "src/components/ExternalLink";
-import {
-  AlertDialog,
-  AlertDialogTrigger,
-} from "src/components/ui/alert-dialog";
 import { Badge } from "src/components/ui/badge.tsx";
-import { Button } from "src/components/ui/button.tsx";
 import {
   Card,
   CardContent,
@@ -21,12 +9,6 @@ import {
   CardHeader,
   CardTitle,
 } from "src/components/ui/card";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "src/components/ui/dropdown-menu.tsx";
 import { Progress } from "src/components/ui/progress.tsx";
 import { Separator } from "src/components/ui/separator";
 import {
@@ -79,51 +61,11 @@ export function ChannelsCards({
                         <div className="flex-1 whitespace-nowrap text-ellipsis overflow-hidden">
                           {alias}
                         </div>
-                        <AlertDialog>
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button size="icon" variant="ghost">
-                                <MoreHorizontal className="h-4 w-4" />
-                              </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
-                                <ExternalLink
-                                  to={`https://mempool.space/tx/${channel.fundingTxId}`}
-                                  className="w-full flex flex-row items-center gap-2"
-                                >
-                                  <ExternalLinkIcon className="w-4 h-4" />
-                                  <p>View Funding Transaction</p>
-                                </ExternalLink>
-                              </DropdownMenuItem>
-                              <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
-                                <ExternalLink
-                                  to={`https://amboss.space/node/${channel.remotePubkey}`}
-                                  className="w-full flex flex-row items-center gap-2"
-                                >
-                                  <ExternalLinkIcon className="w-4 h-4" />
-                                  <p>View Node on amboss.space</p>
-                                </ExternalLink>
-                              </DropdownMenuItem>
-                              {channel.public && (
-                                <DropdownMenuItem
-                                  className="flex flex-row items-center gap-2 cursor-pointer"
-                                  onClick={() => editChannel(channel)}
-                                >
-                                  <HandCoins className="h-4 w-4" />
-                                  Set Routing Fee
-                                </DropdownMenuItem>
-                              )}
-                              <AlertDialogTrigger asChild>
-                                <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
-                                  <Trash2 className="h-4 w-4 text-destructive" />
-                                  Close Channel
-                                </DropdownMenuItem>
-                              </AlertDialogTrigger>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                          <CloseChannelDialog alias={alias} channel={channel} />
-                        </AlertDialog>
+                        <ChannelDropdownMenu
+                          alias={alias}
+                          channel={channel}
+                          editChannel={editChannel}
+                        />
                       </div>
                     </CardTitle>
                     <Separator className="mt-5" />

--- a/frontend/src/components/channels/ChannelsTable.tsx
+++ b/frontend/src/components/channels/ChannelsTable.tsx
@@ -6,8 +6,13 @@ import {
   Trash2,
 } from "lucide-react";
 import { ChannelWarning } from "src/components/channels/ChannelWarning";
+import { CloseChannelDialog } from "src/components/CloseChannelDialog";
 import ExternalLink from "src/components/ExternalLink";
 import Loading from "src/components/Loading.tsx";
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+} from "src/components/ui/alert-dialog";
 import { Badge } from "src/components/ui/badge.tsx";
 import { Button } from "src/components/ui/button.tsx";
 import {
@@ -37,18 +42,12 @@ import { Channel, Node } from "src/types";
 type ChannelsTableProps = {
   channels?: Channel[];
   nodes?: Node[];
-  closeChannel(
-    channelId: string,
-    counterpartyNodeId: string,
-    isActive: boolean
-  ): void;
   editChannel(channel: Channel): void;
 };
 
 export function ChannelsTable({
   channels,
   nodes,
-  closeChannel,
   editChannel,
 }: ChannelsTableProps) {
   if (channels && !channels.length) {
@@ -176,55 +175,51 @@ export function ChannelsTable({
                         <ChannelWarning channel={channel} />
                       </TableCell>
                       <TableCell>
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button size="icon" variant="ghost">
-                              <MoreHorizontal className="h-4 w-4" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
-                              <ExternalLink
-                                to={`https://mempool.space/tx/${channel.fundingTxId}`}
-                                className="w-full flex flex-row items-center gap-2"
-                              >
-                                <ExternalLinkIcon className="w-4 h-4" />
-                                <p>View Funding Transaction</p>
-                              </ExternalLink>
-                            </DropdownMenuItem>
-                            <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
-                              <ExternalLink
-                                to={`https://amboss.space/node/${channel.remotePubkey}`}
-                                className="w-full flex flex-row items-center gap-2"
-                              >
-                                <ExternalLinkIcon className="w-4 h-4" />
-                                <p>View Node on amboss.space</p>
-                              </ExternalLink>
-                            </DropdownMenuItem>
-                            {channel.public && (
-                              <DropdownMenuItem
-                                className="flex flex-row items-center gap-2 cursor-pointer"
-                                onClick={() => editChannel(channel)}
-                              >
-                                <HandCoins className="h-4 w-4" />
-                                Set Routing Fee
+                        <AlertDialog>
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button size="icon" variant="ghost">
+                                <MoreHorizontal className="h-4 w-4" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
+                                <ExternalLink
+                                  to={`https://mempool.space/tx/${channel.fundingTxId}`}
+                                  className="w-full flex flex-row items-center gap-2"
+                                >
+                                  <ExternalLinkIcon className="w-4 h-4" />
+                                  <p>View Funding Transaction</p>
+                                </ExternalLink>
                               </DropdownMenuItem>
-                            )}
-                            <DropdownMenuItem
-                              className="flex flex-row items-center gap-2 cursor-pointer"
-                              onClick={() =>
-                                closeChannel(
-                                  channel.id,
-                                  channel.remotePubkey,
-                                  channel.active
-                                )
-                              }
-                            >
-                              <Trash2 className="h-4 w-4 text-destructive" />
-                              Close Channel
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
+                              <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
+                                <ExternalLink
+                                  to={`https://amboss.space/node/${channel.remotePubkey}`}
+                                  className="w-full flex flex-row items-center gap-2"
+                                >
+                                  <ExternalLinkIcon className="w-4 h-4" />
+                                  <p>View Node on amboss.space</p>
+                                </ExternalLink>
+                              </DropdownMenuItem>
+                              {channel.public && (
+                                <DropdownMenuItem
+                                  className="flex flex-row items-center gap-2 cursor-pointer"
+                                  onClick={() => editChannel(channel)}
+                                >
+                                  <HandCoins className="h-4 w-4" />
+                                  Set Routing Fee
+                                </DropdownMenuItem>
+                              )}
+                              <AlertDialogTrigger asChild>
+                                <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
+                                  <Trash2 className="h-4 w-4 text-destructive" />
+                                  Close Channel
+                                </DropdownMenuItem>
+                              </AlertDialogTrigger>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                          <CloseChannelDialog alias={alias} channel={channel} />
+                        </AlertDialog>
                       </TableCell>
                     </TableRow>
                   );

--- a/frontend/src/components/channels/ChannelsTable.tsx
+++ b/frontend/src/components/channels/ChannelsTable.tsx
@@ -1,26 +1,7 @@
-import {
-  ExternalLinkIcon,
-  HandCoins,
-  InfoIcon,
-  MoreHorizontal,
-  Trash2,
-} from "lucide-react";
+import { InfoIcon } from "lucide-react";
 import { ChannelWarning } from "src/components/channels/ChannelWarning";
-import { CloseChannelDialog } from "src/components/CloseChannelDialog";
-import ExternalLink from "src/components/ExternalLink";
 import Loading from "src/components/Loading.tsx";
-import {
-  AlertDialog,
-  AlertDialogTrigger,
-} from "src/components/ui/alert-dialog";
 import { Badge } from "src/components/ui/badge.tsx";
-import { Button } from "src/components/ui/button.tsx";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "src/components/ui/dropdown-menu.tsx";
 import { Progress } from "src/components/ui/progress.tsx";
 import {
   Table,
@@ -38,6 +19,7 @@ import {
 } from "src/components/ui/tooltip.tsx";
 import { formatAmount } from "src/lib/utils.ts";
 import { Channel, Node } from "src/types";
+import { ChannelDropdownMenu } from "./ChannelDropdownMenu";
 
 type ChannelsTableProps = {
   channels?: Channel[];
@@ -175,51 +157,11 @@ export function ChannelsTable({
                         <ChannelWarning channel={channel} />
                       </TableCell>
                       <TableCell>
-                        <AlertDialog>
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button size="icon" variant="ghost">
-                                <MoreHorizontal className="h-4 w-4" />
-                              </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
-                                <ExternalLink
-                                  to={`https://mempool.space/tx/${channel.fundingTxId}`}
-                                  className="w-full flex flex-row items-center gap-2"
-                                >
-                                  <ExternalLinkIcon className="w-4 h-4" />
-                                  <p>View Funding Transaction</p>
-                                </ExternalLink>
-                              </DropdownMenuItem>
-                              <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
-                                <ExternalLink
-                                  to={`https://amboss.space/node/${channel.remotePubkey}`}
-                                  className="w-full flex flex-row items-center gap-2"
-                                >
-                                  <ExternalLinkIcon className="w-4 h-4" />
-                                  <p>View Node on amboss.space</p>
-                                </ExternalLink>
-                              </DropdownMenuItem>
-                              {channel.public && (
-                                <DropdownMenuItem
-                                  className="flex flex-row items-center gap-2 cursor-pointer"
-                                  onClick={() => editChannel(channel)}
-                                >
-                                  <HandCoins className="h-4 w-4" />
-                                  Set Routing Fee
-                                </DropdownMenuItem>
-                              )}
-                              <AlertDialogTrigger asChild>
-                                <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
-                                  <Trash2 className="h-4 w-4 text-destructive" />
-                                  Close Channel
-                                </DropdownMenuItem>
-                              </AlertDialogTrigger>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                          <CloseChannelDialog alias={alias} channel={channel} />
-                        </AlertDialog>
+                        <ChannelDropdownMenu
+                          alias={alias}
+                          channel={channel}
+                          editChannel={editChannel}
+                        />
                       </TableCell>
                     </TableRow>
                   );

--- a/frontend/src/components/ui/radio-group.tsx
+++ b/frontend/src/components/ui/radio-group.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { CheckIcon } from "@radix-ui/react-icons";
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+
+import { cn } from "src/lib/utils";
+
+const RadioGroup = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn("grid gap-2", className)}
+      {...props}
+      ref={ref}
+    />
+  );
+});
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        "aspect-square h-4 w-4 rounded-full border border-primary text-primary shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+        <CheckIcon className="h-3.5 w-3.5 fill-primary" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+});
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+
+export { RadioGroup, RadioGroupItem };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -599,6 +599,16 @@
     "@radix-ui/react-primitive" "1.0.3"
     "@radix-ui/react-slot" "1.0.2"
 
+"@radix-ui/react-collection@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.0.tgz#f18af78e46454a2360d103c2251773028b7724ed"
+  integrity sha512-GZsZslMJEyo1VKm5L1ZJY8tGDxZNPAoUeQUIbKeJfoi7Q4kmig5AsgLMYYuyYbfjd8fBmFORAIwYAkXMnXZgZw==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-context" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-slot" "1.1.0"
+
 "@radix-ui/react-compose-refs@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz#7ed868b66946aa6030e580b1ffca386dd4d21989"
@@ -670,6 +680,11 @@
   integrity sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==
   dependencies:
     "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-direction@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.1.0.tgz#a7d39855f4d077adc2a1922f9c353c5977a09cdc"
+  integrity sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==
 
 "@radix-ui/react-dismissable-layer@1.0.5":
   version "1.0.5"
@@ -924,6 +939,22 @@
     "@radix-ui/react-context" "1.0.1"
     "@radix-ui/react-primitive" "1.0.3"
 
+"@radix-ui/react-radio-group@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-radio-group/-/react-radio-group-1.2.0.tgz#f937dd6b9436ded80c4bebdf3901c20cb8bcbb5a"
+  integrity sha512-yv+oiLaicYMBpqgfpSPw6q+RyXlLdIpQWDHZbUKURxe+nEh53hFXPPlfhfQQtYkS5MMK/5IWIa76SksleQZSzw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.0"
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-context" "1.1.0"
+    "@radix-ui/react-direction" "1.1.0"
+    "@radix-ui/react-presence" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-roving-focus" "1.1.0"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    "@radix-ui/react-use-previous" "1.1.0"
+    "@radix-ui/react-use-size" "1.1.0"
+
 "@radix-ui/react-roving-focus@1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz#e90c4a6a5f6ac09d3b8c1f5b5e81aab2f0db1974"
@@ -939,6 +970,21 @@
     "@radix-ui/react-primitive" "1.0.3"
     "@radix-ui/react-use-callback-ref" "1.0.1"
     "@radix-ui/react-use-controllable-state" "1.0.1"
+
+"@radix-ui/react-roving-focus@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.0.tgz#b30c59daf7e714c748805bfe11c76f96caaac35e"
+  integrity sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.0"
+    "@radix-ui/react-collection" "1.1.0"
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-context" "1.1.0"
+    "@radix-ui/react-direction" "1.1.0"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
 
 "@radix-ui/react-select@^2.0.0":
   version "2.0.0"
@@ -1103,6 +1149,11 @@
   integrity sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==
   dependencies:
     "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-previous@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz#d4dd37b05520f1d996a384eb469320c2ada8377c"
+  integrity sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==
 
 "@radix-ui/react-use-rect@1.0.1":
   version "1.0.1"


### PR DESCRIPTION
## Description
`window.alert`, `prompt` and `confirm` don't work in wails. We can use [Dialog](https://wails.io/docs/reference/runtime/dialog/) but it has some limitations in [MacOS](https://stackoverflow.com/questions/26898941/ios-wkwebview-not-showing-javascript-alert-dialog). Also the flow for closing a channel involves the user to type "force close" which is not ideal. This PR replaces those with AlertDialog from shadcn for Wails support as well as design consistency


<img width="100%" alt="Screenshot 2024-07-31 at 9 10 18 PM" src="https://github.com/user-attachments/assets/63a34845-8d5b-4045-8cb8-b078a5819bc3">
<img width="100%" alt="Screenshot 2024-07-31 at 9 10 30 PM" src="https://github.com/user-attachments/assets/242a4564-cc97-4ca5-a644-7d7570cc97fc">
<img width="100%" alt="Screenshot 2024-08-07 at 4 45 05 PM" src="https://github.com/user-attachments/assets/32b5c613-7602-4c16-9dbd-3e584b7cafbe">
<img width="100%" alt="Screenshot 2024-08-07 at 4 45 20 PM" src="https://github.com/user-attachments/assets/dd6eff9d-1c26-41ff-b6aa-984ec5e4f0b6">
<img width="100%" alt="Screenshot 2024-07-31 at 9 11 01 PM" src="https://github.com/user-attachments/assets/f82f5472-88af-4165-8964-d3b68588df45">
