### PR TITLE
chore: stop subscription goroutines if node is stopped

### DIFF
--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -522,7 +522,7 @@ func NewLNDService(ctx context.Context, eventPublisher events.EventPublisher, ln
 				for {
 					invoice, err := invoiceStream.Recv()
 					if err != nil {
-						logger.Logger.WithError(err).Error("Failed to receive payment")
+						logger.Logger.WithError(err).Error("Failed to receive invoice")
 						select {
 						case <-lndCtx.Done():
 							return


### PR DESCRIPTION
Fixes #388

We should also add a screen to display when the node is offline, which can be used by backends other than LDK, because currently Alby Hub goes blank if the node is offline with no message. But we can open a separate issue for that(?)