### PR TITLE
fix: use take instead of find for single record lookups

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -235,10 +235,18 @@ func (api *api) GetApp(dbApp *db.App) *App {
 func (api *api) ListApps() ([]App, error) {
 	// TODO: join dbApps and permissions
 	dbApps := []db.App{}
-	api.db.Find(&dbApps)
+	err := api.db.Find(&dbApps).Error
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to list apps")
+		return nil, err
+	}
 
 	appPermissions := []db.AppPermission{}
-	api.db.Find(&appPermissions)
+	err = api.db.Find(&appPermissions).Error
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to list app permissions")
+		return nil, err
+	}
 
 	permissionsMap := make(map[uint][]db.AppPermission)
 	for _, perm := range appPermissions {
@@ -272,7 +280,7 @@ func (api *api) ListApps() ([]App, error) {
 		}
 
 		var lastEvent db.RequestEvent
-		lastEventResult := api.db.Where("app_id = ?", dbApp.ID).Order("id desc").Limit(1).Find(&lastEvent)
+		lastEventResult := api.db.Where("app_id = ?", dbApp.ID).Order("id desc").Take(&lastEvent)
 		if lastEventResult.RowsAffected > 0 {
 			apiApp.LastEventAt = &lastEvent.CreatedAt
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -96,7 +96,7 @@ func (cfg *config) Get(key string, encryptionKey string) (string, error) {
 
 func (cfg *config) get(key string, encryptionKey string, gormDB *gorm.DB) (string, error) {
 	var userConfig db.UserConfig
-	err := gormDB.Where(&db.UserConfig{Key: key}).Limit(1).Find(&userConfig).Error
+	err := gormDB.Where(&db.UserConfig{Key: key}).Take(&userConfig).Error
 	if err != nil {
 		return "", fmt.Errorf("failed to get configuration value: %w", gormDB.Error)
 	}

--- a/nip47/notifications/nip47_notifier.go
+++ b/nip47/notifications/nip47_notifier.go
@@ -127,7 +127,7 @@ func (notifier *Nip47Notifier) notifySubscriber(ctx context.Context, app *db.App
 	logger.Logger.WithFields(logrus.Fields{
 		"notification": notification,
 		"appId":        app.ID,
-	}).Info("Notifying subscriber")
+	}).Debug("Notifying subscriber")
 
 	ss, err := nip04.ComputeSharedSecret(app.NostrPubkey, notifier.keys.GetNostrSecretKey())
 	if err != nil {
@@ -183,8 +183,8 @@ func (notifier *Nip47Notifier) notifySubscriber(ctx context.Context, app *db.App
 		return
 	}
 	logger.Logger.WithFields(logrus.Fields{
-		"notification": notification,
-		"appId":        app.ID,
+		// "notification": notification,
+		"appId": app.ID,
 	}).Info("Published notification event")
 
 }

--- a/nip47/notifications/nip47_notifier.go
+++ b/nip47/notifications/nip47_notifier.go
@@ -183,8 +183,6 @@ func (notifier *Nip47Notifier) notifySubscriber(ctx context.Context, app *db.App
 		return
 	}
 	logger.Logger.WithFields(logrus.Fields{
-		// "notification": notification,
 		"appId": app.ID,
-	}).Info("Published notification event")
-
+	}).Debug("Published notification event")
 }

--- a/nip47/notifications/nip47_notifier.go
+++ b/nip47/notifications/nip47_notifier.go
@@ -104,7 +104,11 @@ func (notifier *Nip47Notifier) notifySubscribers(ctx context.Context, notificati
 	apps := []db.App{}
 
 	// TODO: join apps and permissions
-	notifier.db.Find(&apps)
+	err := notifier.db.Find(&apps).Error
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to list apps")
+		return
+	}
 
 	for _, app := range apps {
 		if app.Isolated && (appId == nil || app.ID != *appId) {

--- a/nip47/permissions/permissions.go
+++ b/nip47/permissions/permissions.go
@@ -38,7 +38,7 @@ func NewPermissionsService(db *gorm.DB, eventPublisher events.EventPublisher) *p
 func (svc *permissionsService) HasPermission(app *db.App, scope string) (result bool, code string, message string) {
 
 	appPermission := db.AppPermission{}
-	findPermissionResult := svc.db.Find(&appPermission, &db.AppPermission{
+	findPermissionResult := svc.db.Take(&appPermission, &db.AppPermission{
 		AppId: app.ID,
 		Scope: scope,
 	})


### PR DESCRIPTION
Related to https://github.com/getAlby/hub/issues/422
Closes https://github.com/getAlby/hub/issues/414

Improves query performance. From gorm:

> Using Find without a limit for single object db.Find(&user) will query the full table and return only the first object which is not performant and nondeterministic