### PR TITLE
fix: use limit and find rather than take

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -280,7 +280,7 @@ func (api *api) ListApps() ([]App, error) {
 		}
 
 		var lastEvent db.RequestEvent
-		lastEventResult := api.db.Where("app_id = ?", dbApp.ID).Order("id desc").Take(&lastEvent)
+		lastEventResult := api.db.Where("app_id = ?", dbApp.ID).Order("id desc").Limit(1).Find(&lastEvent)
 		if lastEventResult.RowsAffected > 0 {
 			apiApp.LastEventAt = &lastEvent.CreatedAt
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -96,7 +96,7 @@ func (cfg *config) Get(key string, encryptionKey string) (string, error) {
 
 func (cfg *config) get(key string, encryptionKey string, gormDB *gorm.DB) (string, error) {
 	var userConfig db.UserConfig
-	err := gormDB.Where(&db.UserConfig{Key: key}).Take(&userConfig).Error
+	err := gormDB.Where(&db.UserConfig{Key: key}).Limit(1).Find(&userConfig).Error
 	if err != nil {
 		return "", fmt.Errorf("failed to get configuration value: %w", gormDB.Error)
 	}

--- a/nip47/permissions/permissions.go
+++ b/nip47/permissions/permissions.go
@@ -38,7 +38,7 @@ func NewPermissionsService(db *gorm.DB, eventPublisher events.EventPublisher) *p
 func (svc *permissionsService) HasPermission(app *db.App, scope string) (result bool, code string, message string) {
 
 	appPermission := db.AppPermission{}
-	findPermissionResult := svc.db.Take(&appPermission, &db.AppPermission{
+	findPermissionResult := svc.db.Limit(1).Find(&appPermission, &db.AppPermission{
 		AppId: app.ID,
 		Scope: scope,
 	})


### PR DESCRIPTION
Fixes some issues with https://github.com/getAlby/hub/pull/423

Take throws an error if a record is not found. With limit(1) and find, we can control what to do if the record does not exist.