### PR TITLE
feat: add secure middleware, move CSP to header

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,10 +8,6 @@
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/icon-512.png" />
     <meta name="theme-color" content="#000000" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; img-src 'self' https://uploads.getalby-assets.com https://getalby.com;"
-    />
   </head>
   <body class="min-h-screen">
     <div id="root" class="min-h-screen"></div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -45,7 +45,7 @@ export default defineConfig(({ command }) => ({
         globPatterns: ["**/*.{js,css,html,png,svg,ico}"],
       },
     }),
-    ...(command === "serve" ? [insertDevCSPNoncePlugin] : []),
+    ...(command === "serve" ? [insertDevCSPPlugin] : []),
   ],
   server: {
     proxy: {
@@ -64,19 +64,23 @@ export default defineConfig(({ command }) => ({
   html:
     command === "serve"
       ? {
-          cspNonce: "PLACEHOLDER",
+          cspNonce: "DEVELOPMENT",
         }
       : undefined,
 }));
 
-const insertDevCSPNoncePlugin: Plugin = {
-  name: "transform-html",
+const DEVELOPMENT_NONCE = "'nonce-DEVELOPMENT'";
+
+const insertDevCSPPlugin: Plugin = {
+  name: "dev-csp",
   transformIndexHtml: {
     enforce: "pre",
     transform(html) {
       return html.replace(
-        "default-src 'self'",
-        "default-src 'self' 'nonce-PLACEHOLDER'"
+        "<head>",
+        `<head>
+        <!-- DEV-ONLY CSP - when making changes here, also update the CSP header in http_service.go (without the nonce!) -->
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self' ${DEVELOPMENT_NONCE}; img-src 'self' https://uploads.getalby-assets.com https://getalby.com;"/>`
       );
     },
   },

--- a/http/http_service.go
+++ b/http/http_service.go
@@ -58,6 +58,12 @@ func NewHttpService(svc service.Service, eventPublisher events.EventPublisher) *
 func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	e.HideBanner = true
 
+	e.Use(middleware.SecureWithConfig(middleware.SecureConfig{
+		ContentTypeNosniff:    "nosniff",
+		XFrameOptions:         "DENY",
+		ContentSecurityPolicy: "default-src 'self'; img-src 'self' https://uploads.getalby-assets.com https://getalby.com;",
+		ReferrerPolicy:        "no-referrer",
+	}))
 	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
 		LogURI:       true,
 		LogStatus:    true,


### PR DESCRIPTION
CSP is moved to the header which is more secure (e.g. Alby Hub can no longer be loaded in an iframe).

In development, we use the vite server, so a dev CSP is injected in this case. We need to keep them in sync to ensure you don't fix something in development, only to realize it's still broken in production.