### PR TITLE
feat: process podcasting custom key/value records

### DIFF
--- a/frontend/src/screens/apps/ShowApp.tsx
+++ b/frontend/src/screens/apps/ShowApp.tsx
@@ -169,6 +169,12 @@ function AppInternal({ app, refetchApp, capabilities }: AppInternalProps) {
               <Table>
                 <TableBody>
                   <TableRow>
+                    <TableCell className="font-medium">Id</TableCell>
+                    <TableCell className="text-muted-foreground break-all">
+                      {app.id}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
                     <TableCell className="font-medium">Public Key</TableCell>
                     <TableCell className="text-muted-foreground break-all">
                       {app.nostrPubkey}

--- a/transactions/receive_keysend_test.go
+++ b/transactions/receive_keysend_test.go
@@ -1,0 +1,79 @@
+package transactions
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/getAlby/hub/events"
+	"github.com/getAlby/hub/lnclient"
+	"github.com/getAlby/hub/tests"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReceiveKeysendWithCustomKey(t *testing.T) {
+	ctx := context.TODO()
+
+	defer tests.RemoveTestService()
+	svc, err := tests.CreateTestService()
+	assert.NoError(t, err)
+
+	transactionsService := NewTransactionsService(svc.DB)
+	app, _, err := tests.CreateApp(svc)
+	// just to have another app in this test
+	_, _, err = tests.CreateApp(svc)
+
+	assert.NoError(t, err)
+
+	tlv := []lnclient.TLVRecord{
+		{
+			Type:  696969,
+			Value: strconv.FormatUint(uint64(app.ID), 16),
+		},
+	}
+	tx := lnclient.Transaction{
+		Type:            "incoming",
+		Description:     "mock invoice 1",
+		Preimage:        "9f59b18f80a77c2930deb8be5ff1143eacdd1891c63c23d61bc9f99c64e57325",
+		PaymentHash:     "ae4277b7be3ca1420cafd24c143866190f52b996856b0e4164763f936e61ea1b",
+		Amount:          1000,
+		FeesPaid:        50,
+		SettledAt:       &tests.MockTimeUnix,
+		Metadata: map[string]interface{}{
+			"tlv_records": tlv,
+		},
+	}
+
+	event := events.Event{
+		Event:      "nwc_payment_received",
+		Properties: tx,
+	}
+	transactionsService.ConsumeEvent(ctx, &event, map[string]interface{}{})
+
+	transaction, err := transactionsService.LookupTransaction(ctx, tx.PaymentHash, nil, svc.LNClient, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, app.ID, *transaction.AppId)
+}
+
+func TestReceiveKeysend(t *testing.T) {
+	ctx := context.TODO()
+
+	defer tests.RemoveTestService()
+	svc, err := tests.CreateTestService()
+	assert.NoError(t, err)
+
+	transactionsService := NewTransactionsService(svc.DB)
+	_, _, err = tests.CreateApp(svc)
+	assert.NoError(t, err)
+
+	tx := tests.MockLNClientTransaction
+	event := events.Event{
+		Event:      "nwc_payment_received",
+		Properties: tx,
+	}
+	transactionsService.ConsumeEvent(ctx, &event, map[string]interface{}{})
+
+	transaction, err := transactionsService.LookupTransaction(ctx, tx.PaymentHash, nil, svc.LNClient, nil)
+	assert.NoError(t, err)
+	assert.Nil(t, *transaction.AppId)
+}

--- a/transactions/transactions_service.go
+++ b/transactions/transactions_service.go
@@ -586,8 +586,7 @@ func (svc *transactionsService) ConsumeEvent(ctx context.Context, event *events.
 						description = extractedDescription
 					}
 					// find app by custom key/value records
-					app := svc.getAppFromCustomRecords(customRecords)
-					appId = &app.ID
+					appId = svc.getAppIdFromCustomRecords(customRecords)
 				}
 				var expiresAt *time.Time
 				if lnClientTransaction.ExpiresAt != nil {
@@ -852,7 +851,7 @@ func (svc *transactionsService) getDescriptionFromCustomRecords(customRecords []
 	return description
 }
 
-func (svc *transactionsService) getAppFromCustomRecords(customRecords []lnclient.TLVRecord) *db.App {
+func (svc *transactionsService) getAppIdFromCustomRecords(customRecords []lnclient.TLVRecord) *uint {
 	app := db.App{}
 	for _, record := range customRecords {
 		if record.Type == CustomKeyTlvType {
@@ -868,7 +867,8 @@ func (svc *transactionsService) getAppFromCustomRecords(customRecords []lnclient
 				logger.Logger.WithError(err).Error("Failed to find app by id from custom key TLV record")
 				continue
 			}
+			return &app.ID
 		}
 	}
-	return &app
+	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/437

This loads the app for a keysend transaction from the custom key/value data.

it is using the app ID as costum value - the nostr key of the connection is a bit more private than the app id of the hub