### PR TITLE
feat: add alby cloud link

### DIFF
--- a/frontend/src/components/layouts/AppLayout.tsx
+++ b/frontend/src/components/layouts/AppLayout.tsx
@@ -1,5 +1,6 @@
 import {
   Cable,
+  Cloud,
   EllipsisVertical,
   ExternalLinkIcon,
   Home,
@@ -179,6 +180,18 @@ export default function AppLayout() {
           <MessageCircleQuestion className="h-4 w-4" />
           Live Support
         </MenuItem>
+        {!albyMe?.hub.name && (
+          <MenuItem
+            to="/"
+            onClick={(e) => {
+              openLink("https://getalby.com/subscription/new");
+              e.preventDefault();
+            }}
+          >
+            <Cloud className="h-4 w-4" />
+            Alby Cloud
+          </MenuItem>
+        )}
       </nav>
     );
   }


### PR DESCRIPTION
Links to Alby Cloud for users who don't have an Alby Cloud hub deployment

![image](https://github.com/user-attachments/assets/9a8d69b6-8bb4-4d4d-b2fc-9e95175c9788)
