### PR TITLE
fix: migrate node

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -71,6 +71,11 @@ func Stop(db *gorm.DB) error {
 		return fmt.Errorf("failed to get database connection: %w", err)
 	}
 
+	err = db.Exec("PRAGMA wal_checkpoint(FULL)", nil).Error
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to execute wal endpoint")
+	}
+
 	err = sqlDB.Close()
 	if err != nil {
 		return fmt.Errorf("failed to close database connection: %w", err)

--- a/frontend/src/screens/BackupNodeSuccess.tsx
+++ b/frontend/src/screens/BackupNodeSuccess.tsx
@@ -27,7 +27,8 @@ export function BackupNodeSuccess() {
                   <PowerOff className="w-6 h-6" />
                 </div>
                 <span>
-                  Alby Hub has now shut down.{" "}
+                  This Alby Hub has is now in a halted state to prevent further
+                  changes.{" "}
                   <b>
                     Do not restart it otherwise your backup will be invalidated.
                   </b>

--- a/http/http_service.go
+++ b/http/http_service.go
@@ -96,6 +96,7 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	e.POST("/api/start", httpSvc.startHandler, unlockRateLimiter)
 	e.POST("/api/unlock", httpSvc.unlockHandler, unlockRateLimiter)
 	e.PATCH("/api/unlock-password", httpSvc.changeUnlockPasswordHandler, unlockRateLimiter)
+	e.POST("/api/backup", httpSvc.createBackupHandler, unlockRateLimiter)
 
 	frontend.RegisterHandlers(e)
 
@@ -146,7 +147,6 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	restrictedGroup.POST("/api/send-payment-probes", httpSvc.sendPaymentProbesHandler)
 	restrictedGroup.POST("/api/send-spontaneous-payment-probes", httpSvc.sendSpontaneousPaymentProbesHandler)
 	restrictedGroup.GET("/api/log/:type", httpSvc.getLogOutputHandler)
-	restrictedGroup.POST("/api/backup", httpSvc.createBackupHandler)
 
 	httpSvc.albyHttpSvc.RegisterSharedRoutes(restrictedGroup, e)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -215,6 +215,7 @@ func (svc *service) Shutdown() {
 	svc.eventPublisher.Publish(&events.Event{
 		Event: "nwc_stopped",
 	})
+	db.Stop(svc.db)
 	// wait for any remaining events
 	time.Sleep(1 * time.Second)
 }


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/472

We weren't shutting down the DB correctly which didn't save the full write-ahead log to the DB. This was causing issues when importing - it was using the old -shm and -wal files which were causing the imported nwc.db to be discarded.

- ensure full wal checkpoint is executed on shutdown
- correctly shutdown DB on normal exit
- shutdown service before exiting on backup restore
- remove JWT middleware from backup endpoint
- delete old nwc db files before backup restore to ensure restored files are used

Tests:
- [x] Http Mode - Backup
- [x] Http Mode - Restore
- [x] Wails mode - Backup
- [x] Wails mode - Restore