### PR TITLE
chore: bump ldk node dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/breez/breez-sdk-go v0.3.4
 	github.com/elnosh/gonuts v0.1.1-0.20240602162005-49da741613e4
 	github.com/getAlby/glalby-go v0.0.0-20240621192717-95673c864d59
-	github.com/getAlby/ldk-node-go v0.0.0-20240814182444-37f58362f832
+	github.com/getAlby/ldk-node-go v0.0.0-20240815144818-6fa575b0a3f5
 	github.com/go-gormigrate/gormigrate/v2 v2.1.2
 	github.com/labstack/echo/v4 v4.12.0
 	github.com/nbd-wtf/go-nostr v0.34.5

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwV
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/getAlby/glalby-go v0.0.0-20240621192717-95673c864d59 h1:fSqdXE9uKhLcOOQaLtzN+D8RN3oEcZQkGX5E8PyiKy0=
 github.com/getAlby/glalby-go v0.0.0-20240621192717-95673c864d59/go.mod h1:ViyJvjlvv0GCesTJ7mb3fBo4G+/qsujDAFN90xZ7a9U=
-github.com/getAlby/ldk-node-go v0.0.0-20240814182444-37f58362f832 h1:9rGL1k3aeEs8QIyviZ1K5WoAqzoFCZNA8Ad1g9ZAWmg=
-github.com/getAlby/ldk-node-go v0.0.0-20240814182444-37f58362f832/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20240815144818-6fa575b0a3f5 h1:FY32CuHXa86wwXfBl+vcscVpwQ8yKhBSaL4ZVhTgfi4=
+github.com/getAlby/ldk-node-go v0.0.0-20240815144818-6fa575b0a3f5/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/379

this version supports log rotation without having to restart the node for the rotation to occur