### PR TITLE
fix: ldk use info log level by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ AUTO_LINK_ALBY_ACCOUNT=false
 # Optionally LDK debug log level to get more info
 #LDK_LOG_LEVEL=2
 # Logrus debug log level
-LOG_LEVEL=5
+LOG_LEVEL=4
 
 #WORK_DIR=.data
 #DATABASE_URI=nwc.db

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ LOG_EVENTS=false
 # do not link your current account when you run a dev instance (so it stays pointing at your mainnet one)
 AUTO_LINK_ALBY_ACCOUNT=false
 
-# LDK trace log level
+# Optionally LDK debug log level to get more info
 #LDK_LOG_LEVEL=2
 # Logrus debug log level
 LOG_LEVEL=5

--- a/config/models.go
+++ b/config/models.go
@@ -27,7 +27,7 @@ type AppConfig struct {
 	LDKNetwork            string `envconfig:"LDK_NETWORK" default:"bitcoin"`
 	LDKEsploraServer      string `envconfig:"LDK_ESPLORA_SERVER" default:"https://electrs.getalbypro.com"` // TODO: remove LDK prefix
 	LDKGossipSource       string `envconfig:"LDK_GOSSIP_SOURCE"`
-	LDKLogLevel           string `envconfig:"LDK_LOG_LEVEL"`
+	LDKLogLevel           string `envconfig:"LDK_LOG_LEVEL" default:"3"`
 	MempoolApi            string `envconfig:"MEMPOOL_API" default:"https://mempool.space/api"`
 	AlbyAPIURL            string `envconfig:"ALBY_API_URL" default:"https://api.getalby.com"`
 	AlbyClientId          string `envconfig:"ALBY_OAUTH_CLIENT_ID" default:"J2PbXS1yOf"`

--- a/fly.toml
+++ b/fly.toml
@@ -12,7 +12,7 @@ swap_size_mb = 2048
 
 [env]
   DATABASE_URI = '/data/nwc.db'
-  LDK_LOG_LEVEL = '2'
+  LDK_LOG_LEVEL = '3'
   LOG_LEVEL = '5'
   WORK_DIR = '/data'
 


### PR DESCRIPTION
DEBUG can cause a lot of spam messages and the log files to get too large.