### PR TITLE
fix: increase max dust htlc exposure from fee rate multiplier for trusted counterparties

### DIFF
--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -126,9 +126,10 @@ type CloseChannelRequest struct {
 }
 
 type UpdateChannelRequest struct {
-	ChannelId             string `json:"channelId"`
-	NodeId                string `json:"nodeId"`
-	ForwardingFeeBaseMsat uint32 `json:"forwardingFeeBaseMsat"`
+	ChannelId                                string `json:"channelId"`
+	NodeId                                   string `json:"nodeId"`
+	ForwardingFeeBaseMsat                    uint32 `json:"forwardingFeeBaseMsat"`
+	MaxDustHtlcExposureFromFeeRateMultiplier uint64 `json:"maxDustHtlcExposureFromFeeRateMultiplier"`
 }
 
 type CloseChannelResponse struct {


### PR DESCRIPTION
Stops FC if counterparty fee rates are too high.

:warning: I haven't been able to reliably test this. Waiting for LDK to reply...

We have another workaround in place which bumps the fee estimates for the OnchainSweep block target.