### PR TITLE
feat: better error handling on setup

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -658,20 +658,20 @@ func (api *api) SetNextBackupReminder(backupReminderRequest *BackupReminderReque
 var startMutex sync.Mutex
 
 func (api *api) Start(startRequest *StartRequest) error {
-	defer startMutex.Unlock()
 	if !startMutex.TryLock() {
 		// do not allow to start twice in case this is somehow called twice
 		return errors.New("app is already starting")
 	}
+	defer startMutex.Unlock()
 	return api.svc.StartApp(startRequest.UnlockPassword)
 }
 
 func (api *api) Setup(ctx context.Context, setupRequest *SetupRequest) error {
-	defer startMutex.Unlock()
 	if !startMutex.TryLock() {
 		// do not allow to start twice in case this is somehow called twice
 		return errors.New("app is already starting")
 	}
+	defer startMutex.Unlock()
 	info, err := api.GetInfo(ctx)
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to get info")

--- a/api/api.go
+++ b/api/api.go
@@ -604,8 +604,7 @@ func (api *api) RequestMempoolApi(endpoint string) (interface{}, error) {
 func (api *api) GetInfo(ctx context.Context) (*InfoResponse, error) {
 	info := InfoResponse{}
 	backendType, _ := api.cfg.Get("LNBackendType", "")
-	unlockPasswordCheck, _ := api.cfg.Get("UnlockPasswordCheck", "")
-	info.SetupCompleted = unlockPasswordCheck != ""
+	info.SetupCompleted = api.cfg.SetupCompleted()
 	info.Running = api.svc.GetLNClient() != nil
 	info.BackendType = backendType
 	info.AlbyAuthUrl = api.albyOAuthSvc.GetAuthUrl()
@@ -659,15 +658,20 @@ func (api *api) SetNextBackupReminder(backupReminderRequest *BackupReminderReque
 var startMutex sync.Mutex
 
 func (api *api) Start(startRequest *StartRequest) error {
+	defer startMutex.Unlock()
 	if !startMutex.TryLock() {
 		// do not allow to start twice in case this is somehow called twice
 		return errors.New("app is already starting")
 	}
-	defer startMutex.Unlock()
 	return api.svc.StartApp(startRequest.UnlockPassword)
 }
 
 func (api *api) Setup(ctx context.Context, setupRequest *SetupRequest) error {
+	defer startMutex.Unlock()
+	if !startMutex.TryLock() {
+		// do not allow to start twice in case this is somehow called twice
+		return errors.New("app is already starting")
+	}
 	info, err := api.GetInfo(ctx)
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to get info")
@@ -676,6 +680,10 @@ func (api *api) Setup(ctx context.Context, setupRequest *SetupRequest) error {
 	if info.SetupCompleted {
 		logger.Logger.Error("Cannot re-setup node")
 		return errors.New("setup already completed")
+	}
+
+	if setupRequest.UnlockPassword == "" {
+		return errors.New("no unlock password provided")
 	}
 
 	api.cfg.Setup(setupRequest.UnlockPassword)

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/logger"
+	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -79,6 +80,18 @@ func (cfg *config) init(env *AppConfig) {
 		}
 		cfg.JWTSecret, _ = cfg.Get("JWTSecret", "")
 	}
+}
+
+func (cfg *config) SetupCompleted() bool {
+	// TODO: remove access token check after 2025/01/01
+	// to give time for users to update to 1.6.0+
+	accessToken, _ := cfg.Get("AlbyOAuthAccessToken", "")
+	nodeLastStartTime, _ := cfg.Get("NodeLastStartTime", "")
+	logger.Logger.WithFields(logrus.Fields{
+		"has_access_token":         accessToken != "",
+		"has_node_last_start_time": nodeLastStartTime != "",
+	}).Debug("Checking if setup is completed")
+	return accessToken != "" || nodeLastStartTime != ""
 }
 
 func (cfg *config) GetJWTSecret() string {

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/logger"
@@ -83,15 +84,19 @@ func (cfg *config) init(env *AppConfig) {
 }
 
 func (cfg *config) SetupCompleted() bool {
-	// TODO: remove access token check after 2025/01/01
+	// TODO: remove AlbyUserIdentifier and hasLdkDir checks after 2025/01/01
 	// to give time for users to update to 1.6.0+
-	accessToken, _ := cfg.Get("AlbyOAuthAccessToken", "")
+	albyUserIdentifier, _ := cfg.Get("AlbyUserIdentifier", "")
 	nodeLastStartTime, _ := cfg.Get("NodeLastStartTime", "")
+	ldkDir, err := os.Stat(path.Join(cfg.GetEnv().Workdir, "ldk"))
+	hasLdkDir := err == nil && ldkDir != nil && ldkDir.IsDir()
+
 	logger.Logger.WithFields(logrus.Fields{
-		"has_access_token":         accessToken != "",
+		"has_ldk_dir":              hasLdkDir,
+		"has_alby_user_identifier": albyUserIdentifier != "",
 		"has_node_last_start_time": nodeLastStartTime != "",
 	}).Debug("Checking if setup is completed")
-	return accessToken != "" || nodeLastStartTime != ""
+	return albyUserIdentifier != "" || nodeLastStartTime != "" || hasLdkDir
 }
 
 func (cfg *config) GetJWTSecret() string {

--- a/config/models.go
+++ b/config/models.go
@@ -58,4 +58,5 @@ type Config interface {
 	CheckUnlockPassword(password string) bool
 	ChangeUnlockPassword(currentUnlockPassword string, newUnlockPassword string) error
 	Setup(encryptionKey string)
+	SetupCompleted() bool
 }

--- a/frontend/src/screens/setup/SetupFinish.tsx
+++ b/frontend/src/screens/setup/SetupFinish.tsx
@@ -38,10 +38,11 @@ export function SetupFinish() {
     }
     const timer = setTimeout(() => {
       // SetupRedirect takes care of redirection once info.running is true
-      // if it still didn't redirect after 3 minutes, we show an error
+      // if it still didn't redirect after 30 seconds, we show an error
+      // Typically initial startup should complete in less than 10 seconds.
       setLoading(false);
       setConnectionError(true);
-    }, 180000);
+    }, 30000);
 
     return () => {
       clearTimeout(timer);

--- a/lnclient/cashu/cashu.go
+++ b/lnclient/cashu/cashu.go
@@ -54,7 +54,7 @@ func NewCashuService(workDir string, mintUrl string) (result lnclient.LNClient, 
 	}
 
 	// try to make an invoice to ensure the mint is running
-	// TODO: remove once LoadWallet is improved
+	// TODO: remove once LoadWallet is improved - see https://github.com/elnosh/gonuts/issues/49
 	_, err = cs.MakeInvoice(context.Background(), 10000, "", "", 0)
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to load cashu wallet")

--- a/lnclient/cashu/cashu.go
+++ b/lnclient/cashu/cashu.go
@@ -31,6 +31,9 @@ func NewCashuService(workDir string, mintUrl string) (result lnclient.LNClient, 
 
 	//create dir if not exists
 	newpath := filepath.Join(workDir)
+	_, err = os.Stat(newpath)
+	isFirstSetup := err != nil && errors.Is(err, os.ErrNotExist)
+
 	err = os.MkdirAll(newpath, os.ModePerm)
 	if err != nil {
 		log.Printf("Failed to create cashu working dir: %v", err)
@@ -48,6 +51,22 @@ func NewCashuService(workDir string, mintUrl string) (result lnclient.LNClient, 
 
 	cs := CashuService{
 		wallet: wallet,
+	}
+
+	// try to make an invoice to ensure the mint is running
+	// TODO: remove once LoadWallet is improved
+	_, err = cs.MakeInvoice(context.Background(), 10000, "", "", 0)
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to load cashu wallet")
+		if isFirstSetup {
+			// delete wallet to ensure user gets a fresh start when they try a different mint
+			// otherwise the wallet freezes on next startup
+			fileErr := os.RemoveAll(newpath)
+			if fileErr != nil {
+				logger.Logger.WithError(fileErr).Error("Failed to remove broken wallet directory")
+			}
+		}
+		return nil, err
 	}
 
 	return &cs, nil

--- a/service/start.go
+++ b/service/start.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/nbd-wtf/go-nostr"
@@ -219,6 +220,10 @@ func (svc *service) launchLNBackend(ctx context.Context, encryptionKey string) e
 		svc.eventPublisher.SetGlobalProperty("node_id", info.Pubkey)
 		svc.eventPublisher.SetGlobalProperty("network", info.Network)
 	}
+
+	// Mark that the node has successfully started
+	// This will ensure the user cannot go through the setup again
+	svc.cfg.SetUpdate("NodeLastStartTime", strconv.FormatInt(time.Now().Unix(), 10), "")
 
 	svc.eventPublisher.Publish(&events.Event{
 		Event: "nwc_node_started",

--- a/service/start.go
+++ b/service/start.go
@@ -211,6 +211,10 @@ func (svc *service) launchLNBackend(ctx context.Context, encryptionKey string) e
 		return err
 	}
 
+	// TODO: call a method on the LNClient here to check the LNClient is actually connectable,
+	// (e.g. lnClient.CheckConnection()) Rather than it being a side-effect
+	// in the LNClient init function
+
 	svc.lnClient = lnClient
 	info, err := lnClient.GetInfo(ctx)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/396

When running 1.6.0 the first time, the SetupCompleted check will rely on the user having an `AlbyUserIdentifier` or an existent LDK directory. This is not perfect, but I think the chance both are not set is very slim - and if a user does encounter this, we can give them instructions on how to do a db edit to set their user ID.

- finish can now be run again if node has never successfully started
- fix: use mutex for both setup and start endpoints
- fix: reduce setup finish timeout to 30 seconds from 3 minutes
- fix: cashu start does not handle invalid mints