### PR TITLE
chore: secure password label id

### DIFF
--- a/frontend/src/screens/setup/SetupPassword.tsx
+++ b/frontend/src/screens/setup/SetupPassword.tsx
@@ -116,7 +116,7 @@ export function SetupPassword() {
                     }
                   />
                   <Label
-                    htmlFor="securePassword"
+                    htmlFor="securePassword2"
                     className="ml-2 leading-4 font-semibold text-destructive"
                   >
                     I understand this password cannot be recovered


### PR DESCRIPTION
Clicking on "I understand this password cannot be recovered" toggles the above checkbox which feels buggy