### PR TITLE
feat: add new auto channel flow that works with existing channels

### DIFF
--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -27,6 +27,9 @@ import Channels from "src/screens/channels/Channels";
 import { CurrentChannelOrder } from "src/screens/channels/CurrentChannelOrder";
 import IncreaseIncomingCapacity from "src/screens/channels/IncreaseIncomingCapacity";
 import IncreaseOutgoingCapacity from "src/screens/channels/IncreaseOutgoingCapacity";
+import { AutoChannel } from "src/screens/channels/auto/AutoChannel";
+import { OpenedAutoChannel } from "src/screens/channels/auto/OpenedAutoChannel";
+import { OpeningAutoChannel } from "src/screens/channels/auto/OpeningAutoChannel";
 import { FirstChannel } from "src/screens/channels/first/FirstChannel";
 import { OpenedFirstChannel } from "src/screens/channels/first/OpenedFirstChannel";
 import { OpeningFirstChannel } from "src/screens/channels/first/OpeningFirstChannel";
@@ -222,18 +225,39 @@ const routes = [
           },
           {
             path: "first",
-            element: <FirstChannel />,
-            handle: { crumb: () => "Open Your First Channel" },
+            handle: { crumb: () => "Your First Channel" },
+            children: [
+              {
+                index: true,
+                element: <FirstChannel />,
+              },
+              {
+                path: "opening",
+                element: <OpeningFirstChannel />,
+              },
+              {
+                path: "opened",
+                element: <OpenedFirstChannel />,
+              },
+            ],
           },
           {
-            path: "first/opening",
-            element: <OpeningFirstChannel />,
-            handle: { crumb: () => "Opening Your First Channel" },
-          },
-          {
-            path: "first/opened",
-            element: <OpenedFirstChannel />,
-            handle: { crumb: () => "First Channel Opened!" },
+            path: "auto",
+            handle: { crumb: () => "New Channel" },
+            children: [
+              {
+                index: true,
+                element: <AutoChannel />,
+              },
+              {
+                path: "opening",
+                element: <OpeningAutoChannel />,
+              },
+              {
+                path: "opened",
+                element: <OpenedAutoChannel />,
+              },
+            ],
           },
           {
             path: "outgoing",

--- a/frontend/src/screens/channels/auto/AutoChannel.tsx
+++ b/frontend/src/screens/channels/auto/AutoChannel.tsx
@@ -107,7 +107,7 @@ export function AutoChannel() {
         <div className="flex flex-col gap-4 items-center justify-center max-w-md">
           <p className="text-muted-foreground">
             Please pay the lightning invoice below which will cover the costs of
-            opening your first channel. You will receive a channel with{" "}
+            opening your channel. You will receive a channel with{" "}
             {new Intl.NumberFormat().format(channelSize)} sats of incoming
             liquidity.
           </p>

--- a/frontend/src/screens/channels/auto/AutoChannel.tsx
+++ b/frontend/src/screens/channels/auto/AutoChannel.tsx
@@ -1,0 +1,201 @@
+import { Payment } from "@getalby/bitcoin-connect-react";
+import { ChevronDown } from "lucide-react";
+import React from "react";
+import { Link, useNavigate } from "react-router-dom";
+import AppHeader from "src/components/AppHeader";
+import ExternalLink from "src/components/ExternalLink";
+import Loading from "src/components/Loading";
+import { Button } from "src/components/ui/button";
+import { Checkbox } from "src/components/ui/checkbox";
+import { Label } from "src/components/ui/label";
+import { LoadingButton } from "src/components/ui/loading-button";
+import { Separator } from "src/components/ui/separator";
+import { useToast } from "src/components/ui/use-toast";
+import { useChannels } from "src/hooks/useChannels";
+
+import { useInfo } from "src/hooks/useInfo";
+import { AutoChannelRequest, AutoChannelResponse } from "src/types";
+import { request } from "src/utils/request";
+
+import { MempoolAlert } from "src/components/MempoolAlert";
+
+export function AutoChannel() {
+  const { data: info } = useInfo();
+  const { data: channels } = useChannels(true);
+  const [isLoading, setLoading] = React.useState(false);
+  const [showAdvanced, setShowAdvanced] = React.useState(false);
+  const [isPublic, setPublic] = React.useState(false);
+
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [invoice, setInvoice] = React.useState<string>();
+  const [channelSize, setChannelSize] = React.useState<number>();
+  const [, setPrevChannelIds] = React.useState<string[]>();
+
+  React.useEffect(() => {
+    if (channels) {
+      setPrevChannelIds((current) => {
+        if (current) {
+          const newChannelId = channels.find(
+            (channel) => !current?.includes(channel.id) && channel.fundingTxId
+          )?.id;
+
+          if (newChannelId) {
+            console.info("Found new channel", newChannelId);
+            navigate("/channels/auto/opening", {
+              state: {
+                newChannelId,
+              },
+            });
+          }
+
+          return current;
+        }
+
+        return channels.map((channel) => channel.id);
+      });
+    }
+  }, [channels, navigate]);
+
+  if (!info || !channels) {
+    return <Loading />;
+  }
+
+  async function openChannel() {
+    if (!info || !channels) {
+      return;
+    }
+    setLoading(true);
+    try {
+      const newInstantChannelInvoiceRequest: AutoChannelRequest = {
+        isPublic,
+      };
+      const autoChannelResponse = await request<AutoChannelResponse>(
+        "/api/alby/auto-channel",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(newInstantChannelInvoiceRequest),
+        }
+      );
+      if (!autoChannelResponse) {
+        throw new Error("unexpected auto channel response");
+      }
+
+      setInvoice(autoChannelResponse.invoice);
+      setChannelSize(autoChannelResponse.channelSize);
+    } catch (error) {
+      setLoading(false);
+      console.error(error);
+      toast({
+        title: "Something went wrong. Please try again",
+        variant: "destructive",
+      });
+    }
+  }
+
+  return (
+    <>
+      <AppHeader
+        title="Open a lightning channel"
+        description="Open a channel to another node on the lightning network"
+      />
+      <MempoolAlert />
+      {invoice && channelSize && (
+        <div className="flex flex-col gap-4 items-center justify-center max-w-md">
+          <p className="text-muted-foreground">
+            Please pay the lightning invoice below which will cover the costs of
+            opening your first channel. You will receive a channel with{" "}
+            {new Intl.NumberFormat().format(channelSize)} sats of incoming
+            liquidity.
+          </p>
+          <Payment invoice={invoice} paymentMethods="external" />
+
+          <Separator className="mt-8" />
+          <p className="mt-8 text-sm mb-2 text-muted-foreground">
+            Other options
+          </p>
+          <Link to="/channels/outgoing" className="w-full">
+            <Button className="w-full" variant="secondary">
+              Open Channel with On-Chain Bitcoin
+            </Button>
+          </Link>
+          <ExternalLink to="https://www.getalby.com/topup" className="w-full">
+            <Button className="w-full" variant="secondary">
+              Buy Bitcoin
+            </Button>
+          </ExternalLink>
+        </div>
+      )}
+      {!invoice && (
+        <>
+          <div className="flex flex-col gap-6 max-w-md text-muted-foreground">
+            <img
+              src="/images/illustrations/lightning-network-dark.svg"
+              className="w-full hidden dark:block"
+            />
+            <img
+              src="/images/illustrations/lightning-network-light.svg"
+              className="w-full dark:hidden"
+            />
+
+            <>
+              <p>
+                You're now going to open a new lightning channel that you can
+                use to send and receive payments using your Hub in the booming
+                bitcoin economy! To make things easy, Alby has picked a channel
+                partner for you from one of our recommended channel partners.
+              </p>
+              <p>
+                After paying a lightning invoice to cover on-chain fees, you'll
+                immediately be able to receive and send bitcoin through this
+                channel with your Hub.
+              </p>
+            </>
+            {showAdvanced && (
+              <>
+                <div className="mt-2 flex items-top space-x-2">
+                  <Checkbox
+                    id="public-channel"
+                    onCheckedChange={() => setPublic(!isPublic)}
+                    className="mr-2"
+                  />
+                  <div className="grid gap-1.5 leading-none">
+                    <Label
+                      htmlFor="public-channel"
+                      className="flex items-center gap-2"
+                    >
+                      Public Channel
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Only enable if you want to receive keysend payments. (e.g.
+                      podcasting)
+                    </p>
+                  </div>
+                </div>
+              </>
+            )}
+            {!showAdvanced && (
+              <div>
+                <Button
+                  type="button"
+                  variant="link"
+                  className="text-muted-foreground text-xs px-0"
+                  onClick={() => setShowAdvanced((current) => !current)}
+                >
+                  Advanced Options
+                  <ChevronDown className="w-4 h-4 ml-1" />
+                </Button>
+              </div>
+            )}
+            <LoadingButton loading={isLoading} onClick={openChannel}>
+              Open Channel
+            </LoadingButton>
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/frontend/src/screens/channels/auto/OpenedAutoChannel.tsx
+++ b/frontend/src/screens/channels/auto/OpenedAutoChannel.tsx
@@ -1,0 +1,53 @@
+import confetti from "canvas-confetti";
+import React from "react";
+import { Link } from "react-router-dom";
+import ExternalLink from "src/components/ExternalLink";
+import TwoColumnLayoutHeader from "src/components/TwoColumnLayoutHeader";
+import { Button } from "src/components/ui/button";
+
+export function OpenedAutoChannel() {
+  React.useEffect(() => {
+    for (let i = 0; i < 10; i++) {
+      setTimeout(
+        () => {
+          confetti({
+            origin: {
+              x: Math.random(),
+              y: Math.random(),
+            },
+            colors: ["#000", "#333", "#666", "#999", "#BBB", "#FFF"],
+          });
+        },
+        Math.floor(Math.random() * 1000)
+      );
+    }
+  }, []);
+
+  return (
+    <div className="flex flex-col justify-center gap-5 p-5 max-w-md items-stretch">
+      <TwoColumnLayoutHeader
+        title="Channel Opened"
+        description="Your new lightning channel is ready to use"
+      />
+
+      <p>
+        Congratulations! Your lightning channel is active and can be used to
+        send and receive payments.
+      </p>
+      <p>
+        To ensure you can both send and receive, make sure to balance your{" "}
+        <ExternalLink
+          to="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/liquidity"
+          className="underline"
+        >
+          channel's liquidity
+        </ExternalLink>
+        .
+      </p>
+
+      <Link to="/wallet" className="flex justify-center mt-8">
+        <Button>Go To Your Wallet</Button>
+      </Link>
+    </div>
+  );
+}

--- a/frontend/src/screens/channels/auto/OpeningAutoChannel.tsx
+++ b/frontend/src/screens/channels/auto/OpeningAutoChannel.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { ChannelWaitingForConfirmations } from "src/components/channels/ChannelWaitingForConfirmations";
+import { useChannels } from "src/hooks/useChannels";
+import { useSyncWallet } from "src/hooks/useSyncWallet";
+
+export function OpeningAutoChannel() {
+  useSyncWallet();
+  const { data: channels } = useChannels(true);
+  const navigate = useNavigate();
+
+  const { state } = useLocation();
+  const newChannelId = state?.newChannelId as string | undefined;
+
+  const channel = channels?.find(
+    (channel) => channel.id && channel.id === newChannelId
+  );
+
+  React.useEffect(() => {
+    if (channel?.active) {
+      navigate("/channels/auto/opened");
+    }
+  }, [channel, navigate]);
+
+  return <ChannelWaitingForConfirmations channel={channel} />;
+}

--- a/frontend/src/screens/setup/SetupPassword.tsx
+++ b/frontend/src/screens/setup/SetupPassword.tsx
@@ -110,6 +110,7 @@ export function SetupPassword() {
                 <div className="flex items-center">
                   <Checkbox
                     id="securePassword2"
+                    className="border-destructive"
                     required
                     onCheckedChange={() =>
                       setIsPasswordSecured2(!isPasswordSecured2)


### PR DESCRIPTION
Closes https://github.com/getAlby/hub/issues/540

This flow is not linked from the UI. This is a way channels could possibly be offered for free after a force closure event. It is mostly a copy of the first channel flow, but without the alby funds migration logic and the copy has been updated to fit with any number of channels. Instead of checking for the existence of a channel, it'll check for a new channel and monitor that one. The entry point is `/channels/auto`.

![image](https://github.com/user-attachments/assets/81244186-767a-40fa-a9ea-7e71589604e3)

![image](https://github.com/user-attachments/assets/51a34359-9a05-46c2-b28e-3043f6747fd5)

![image](https://github.com/user-attachments/assets/d0fbb8d0-fedd-4a59-bd91-e11a13a8c537)

![image](https://github.com/user-attachments/assets/2a2669ea-b2e1-4de6-9134-6067290ce2f6)
