### PR TITLE
doc: Correct phoenixd install script instructions in readme

### DIFF
--- a/scripts/linux-x86_64/phoenixd/README.md
+++ b/scripts/linux-x86_64/phoenixd/README.md
@@ -27,6 +27,7 @@ Make sure to backup the `albyhub-phoenixd` which is used as volume for albyhub a
 ### Installation (non-Docker)
 
     $ wget https://raw.githubusercontent.com/getAlby/hub/master/scripts/linux-x86_64/phoenixd/install.sh
+    $ chmod +x install.sh
     $ ./install.sh
 
 The install script will prompt you for a installation folder and will install phoenixd and Alby Hub there.


### PR DESCRIPTION
Add command to make the install script executable in the instructions.