### PR TITLE
[WIP] feat: display recently closed channels

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -309,21 +309,19 @@ func (api *api) ListChannels(ctx context.Context) ([]Channel, error) {
 	if api.svc.GetLNClient() == nil {
 		return nil, errors.New("LNClient not started")
 	}
-	channels, err := api.svc.GetLNClient().ListChannels(ctx)
+
+	channels, err := api.svc.GetChannelsService().ListChannels(ctx, api.svc.GetLNClient())
+
 	if err != nil {
 		return nil, err
 	}
 
 	apiChannels := []Channel{}
 	for _, channel := range channels {
-		status := "offline"
-		if channel.Active {
-			status = "online"
-		} else if channel.Confirmations != nil && channel.ConfirmationsRequired != nil && *channel.ConfirmationsRequired > *channel.Confirmations {
-			status = "opening"
-		}
 
 		apiChannels = append(apiChannels, Channel{
+			Open:                                     channel.Open,
+			ChannelSizeSat:                           channel.ChannelSizeSat,
 			LocalBalance:                             channel.LocalBalance,
 			LocalSpendableBalance:                    channel.LocalSpendableBalance,
 			RemoteBalance:                            channel.RemoteBalance,
@@ -340,7 +338,7 @@ func (api *api) ListChannels(ctx context.Context) ([]Channel, error) {
 			CounterpartyUnspendablePunishmentReserve: channel.CounterpartyUnspendablePunishmentReserve,
 			Error:                                    channel.Error,
 			IsOutbound:                               channel.IsOutbound,
-			Status:                                   status,
+			Status:                                   channel.Status,
 		})
 	}
 	return apiChannels, nil

--- a/api/models.go
+++ b/api/models.go
@@ -315,9 +315,11 @@ type WalletCapabilitiesResponse struct {
 }
 
 type Channel struct {
-	LocalBalance                             int64       `json:"localBalance"`
-	LocalSpendableBalance                    int64       `json:"localSpendableBalance"`
-	RemoteBalance                            int64       `json:"remoteBalance"`
+	Open                                     bool        `json:"open"`
+	ChannelSizeSat                           uint64      `json:"channelSizeSat"`
+	LocalBalance                             uint64      `json:"localBalance"`
+	LocalSpendableBalance                    uint64      `json:"localSpendableBalance"`
+	RemoteBalance                            uint64      `json:"remoteBalance"`
 	Id                                       string      `json:"id"`
 	RemotePubkey                             string      `json:"remotePubkey"`
 	FundingTxId                              string      `json:"fundingTxId"`

--- a/channels/channels_service.go
+++ b/channels/channels_service.go
@@ -1,0 +1,157 @@
+package channels
+
+import (
+	"context"
+	"slices"
+	"time"
+
+	"github.com/getAlby/hub/db"
+	"github.com/getAlby/hub/lnclient"
+	"gorm.io/gorm"
+)
+
+type channelsService struct {
+	db *gorm.DB
+}
+
+type ChannelsService interface {
+	// TODO: consume channel events
+	ListChannels(ctx context.Context, lnClient lnclient.LNClient) (channels []Channel, err error)
+}
+
+type Channel struct {
+	Open                                     bool
+	ChannelSizeSat                           uint64
+	LocalBalance                             uint64
+	LocalSpendableBalance                    uint64
+	RemoteBalance                            uint64
+	Id                                       string
+	RemotePubkey                             string
+	FundingTxId                              string
+	Active                                   bool
+	Public                                   bool
+	InternalChannel                          interface{}
+	Confirmations                            *uint32
+	ConfirmationsRequired                    *uint32
+	ForwardingFeeBaseMsat                    uint32
+	UnspendablePunishmentReserve             uint64
+	CounterpartyUnspendablePunishmentReserve uint64
+	Error                                    *string
+	Status                                   string
+	IsOutbound                               bool
+}
+
+func NewChannelsService(db *gorm.DB) *channelsService {
+	return &channelsService{
+		db: db,
+	}
+}
+
+func (svc *channelsService) ListChannels(ctx context.Context, lnClient lnclient.LNClient) (channels []Channel, err error) {
+
+	lnClientChannels, err := lnClient.ListChannels(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	channels = []Channel{}
+	for _, lnClientChannel := range lnClientChannels {
+		status := "offline"
+		if lnClientChannel.Active {
+			status = "online"
+		} else if lnClientChannel.Confirmations != nil && lnClientChannel.ConfirmationsRequired != nil && *lnClientChannel.ConfirmationsRequired > *lnClientChannel.Confirmations {
+			status = "opening"
+		}
+
+		// create or update channel in our DB
+		var dbChannel db.Channel
+		result := svc.db.Limit(1).Find(&dbChannel, &db.Channel{
+			ChannelID: lnClientChannel.Id,
+		})
+
+		if result.Error != nil {
+			return nil, result.Error
+		}
+
+		if result.RowsAffected == 0 {
+			// channel not saved yet
+			dbChannel.ChannelID = lnClientChannel.Id
+			dbChannel.PeerID = lnClientChannel.RemotePubkey
+			dbChannel.ChannelSizeSat = uint64((lnClientChannel.LocalBalanceMsat + lnClientChannel.RemoteBalanceMsat) / 1000)
+			dbChannel.FundingTxID = lnClientChannel.FundingTxId
+			dbChannel.Open = true
+			svc.db.Create(&dbChannel)
+		}
+
+		// update channel with latest status
+		svc.db.Model(&dbChannel).Updates(&db.Channel{
+			Status: status,
+		})
+
+		channels = append(channels, Channel{
+			Open:                                     true,
+			ChannelSizeSat:                           dbChannel.ChannelSizeSat,
+			LocalBalance:                             lnClientChannel.LocalBalanceMsat,
+			LocalSpendableBalance:                    lnClientChannel.LocalSpendableBalanceMsat,
+			RemoteBalance:                            lnClientChannel.RemoteBalanceMsat,
+			Id:                                       lnClientChannel.Id,
+			RemotePubkey:                             lnClientChannel.RemotePubkey,
+			FundingTxId:                              lnClientChannel.FundingTxId,
+			Active:                                   lnClientChannel.Active,
+			Public:                                   lnClientChannel.Public,
+			InternalChannel:                          lnClientChannel.InternalChannel,
+			Confirmations:                            lnClientChannel.Confirmations,
+			ConfirmationsRequired:                    lnClientChannel.ConfirmationsRequired,
+			ForwardingFeeBaseMsat:                    lnClientChannel.ForwardingFeeBaseMsat,
+			UnspendablePunishmentReserve:             lnClientChannel.UnspendablePunishmentReserve,
+			CounterpartyUnspendablePunishmentReserve: lnClientChannel.CounterpartyUnspendablePunishmentReserve,
+			Error:                                    lnClientChannel.Error,
+			IsOutbound:                               lnClientChannel.IsOutbound,
+			Status:                                   status,
+		})
+	}
+
+	// review channels in our db
+	dbChannels := []db.Channel{}
+	result := svc.db.Find(&dbChannels)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	for _, dbChannel := range dbChannels {
+		if !slices.ContainsFunc(channels, func(channel Channel) bool { return channel.Id == dbChannel.ChannelID }) {
+			if dbChannel.Open {
+				// ideally this should never happen as we should subscribe to events
+				// but currently we do not
+				result := svc.db.Model(&dbChannel).Updates(&db.Channel{
+					Status: "closing",
+					Open:   false,
+				})
+				if result.Error != nil {
+					return nil, result.Error
+				}
+			}
+
+			// show channels closed within the last 2 weeks
+			// NOTE: we do not know how much balance the channel had at closing.
+			if time.Since(dbChannel.UpdatedAt) < 2*7*24*time.Hour {
+				channels = append(channels, Channel{
+					ChannelSizeSat:        dbChannel.ChannelSizeSat,
+					LocalBalance:          0,
+					LocalSpendableBalance: 0,
+					RemoteBalance:         0,
+					Id:                    dbChannel.ChannelID,
+					RemotePubkey:          dbChannel.PeerID,
+					FundingTxId:           dbChannel.FundingTxID,
+					Active:                false,
+					Status:                dbChannel.Status,
+				})
+			}
+		}
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return channels, nil
+}

--- a/db/migrations/202409021648_channels.go
+++ b/db/migrations/202409021648_channels.go
@@ -1,0 +1,41 @@
+package migrations
+
+import (
+	_ "embed"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+var _202409021648_channels = &gormigrate.Migration{
+	ID: "202409021648_channels",
+	Migrate: func(tx *gorm.DB) error {
+
+		if err := tx.Exec(`
+CREATE TABLE channels(
+	id integer PRIMARY KEY AUTOINCREMENT,
+	status text,
+	created_at datetime,
+	updated_at datetime,
+	channel_id text,
+	peer_id text,
+	channel_size_sat integer,
+	funding_tx_id text,
+	open boolean
+);
+
+CREATE INDEX idx_channels_status ON channels(status);
+CREATE INDEX idx_channels_created_at ON channels(created_at);
+CREATE INDEX idx_channels_channel_id ON channels(channel_id);
+CREATE INDEX idx_channels_peer_id ON channels(peer_id);
+CREATE INDEX idx_channels_funding_tx_id ON channels(funding_tx_id);
+`).Error; err != nil {
+			return err
+		}
+
+		return nil
+	},
+	Rollback: func(tx *gorm.DB) error {
+		return nil
+	},
+}

--- a/db/migrations/migrate.go
+++ b/db/migrations/migrate.go
@@ -21,6 +21,7 @@ func Migrate(gormDB *gorm.DB) error {
 		_202407262257_remove_invalid_scopes,
 		_202408061737_add_boostagrams_and_use_json,
 		_202408191242_transaction_failure_reason,
+		_202409021648_channels,
 	})
 
 	return m.Migrate()

--- a/db/models.go
+++ b/db/models.go
@@ -85,6 +85,20 @@ type Transaction struct {
 	FailureReason   string
 }
 
+type Channel struct {
+	ID             uint
+	Status         string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	ChannelID      string
+	PeerID         string
+	ChannelSizeSat uint64
+	FundingTxID    string
+	Open           bool
+
+	// TODO: add other props like PeerAlias so frontend does not need to fetch it
+}
+
 type DBService interface {
 	CreateApp(name string, pubkey string, maxAmountSat uint64, budgetRenewal string, expiresAt *time.Time, scopes []string, isolated bool) (*App, string, error)
 }

--- a/frontend/src/components/CloseChannelDialogContent.tsx
+++ b/frontend/src/components/CloseChannelDialogContent.tsx
@@ -70,6 +70,7 @@ export function CloseChannelDialogContent({ alias, channel }: Props) {
         setStep(step + 1);
       }
       toast({ title: "Sucessfully closed channel" });
+      await reloadChannels();
     } catch (error) {
       console.error(error);
       toast({

--- a/frontend/src/components/channels/ChannelDropdownMenu.tsx
+++ b/frontend/src/components/channels/ChannelDropdownMenu.tsx
@@ -76,15 +76,17 @@ export function ChannelDropdownMenu({
               </DropdownMenuItem>
             </AlertDialogTrigger>
           )}
-          <AlertDialogTrigger asChild>
-            <DropdownMenuItem
-              className="flex flex-row items-center gap-2 cursor-pointer"
-              onClick={() => setDialog("closeChannel")}
-            >
-              <Trash2 className="h-4 w-4 text-destructive" />
-              Close Channel
-            </DropdownMenuItem>
-          </AlertDialogTrigger>
+          {channel.open && (
+            <AlertDialogTrigger asChild>
+              <DropdownMenuItem
+                className="flex flex-row items-center gap-2 cursor-pointer"
+                onClick={() => setDialog("closeChannel")}
+              >
+                <Trash2 className="h-4 w-4 text-destructive" />
+                Close Channel
+              </DropdownMenuItem>
+            </AlertDialogTrigger>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
       {dialog === "closeChannel" && (

--- a/frontend/src/components/channels/ChannelStatusBadge.tsx
+++ b/frontend/src/components/channels/ChannelStatusBadge.tsx
@@ -1,0 +1,36 @@
+import { InfoIcon } from "lucide-react";
+import { Badge } from "src/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "src/components/ui/tooltip";
+import { Channel } from "src/types";
+
+export function ChannelStatusBadge({ status }: { status: Channel["status"] }) {
+  return status == "online" ? (
+    <Badge variant="positive">Online</Badge>
+  ) : status == "opening" ? (
+    <Badge variant="outline">Opening</Badge>
+  ) : status == "closing" ? (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <Badge variant="outline" className="text-muted-foreground">
+            Closing&nbsp;
+            <InfoIcon className="h-4 w-4 shrink-0" />
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent className="w-[400px]">
+          Any funds on your side of the channel at the time of closing will be
+          returned to your savings account once the closing channel transaction
+          has been broadcast. In case of force closures, this may take up to 2
+          weeks.
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  ) : (
+    <Badge variant="warning">Offline</Badge>
+  );
+}

--- a/frontend/src/components/channels/ChannelsCards.tsx
+++ b/frontend/src/components/channels/ChannelsCards.tsx
@@ -1,7 +1,7 @@
 import { InfoIcon } from "lucide-react";
 import { ChannelDropdownMenu } from "src/components/channels/ChannelDropdownMenu";
+import { ChannelStatusBadge } from "src/components/channels/ChannelStatusBadge";
 import { ChannelWarning } from "src/components/channels/ChannelWarning";
-import { Badge } from "src/components/ui/badge.tsx";
 import {
   Card,
   CardContent,
@@ -45,7 +45,7 @@ export function ChannelsCards({ channels, nodes }: ChannelsCardsProps) {
               (n) => n.public_key === channel.remotePubkey
             );
             const alias = node?.alias || "Unknown";
-            const capacity = channel.localBalance + channel.remoteBalance;
+            const capacity = channel.channelSizeSat * 1000;
 
             return (
               <Card>
@@ -65,13 +65,7 @@ export function ChannelsCards({ channels, nodes }: ChannelsCardsProps) {
                         <p className="text-muted-foreground font-medium">
                           Status
                         </p>
-                        {channel.status == "online" ? (
-                          <Badge variant="positive">Online</Badge>
-                        ) : channel.status == "opening" ? (
-                          <Badge variant="outline">Opening</Badge>
-                        ) : (
-                          <Badge variant="warning">Offline</Badge>
-                        )}
+                        <ChannelStatusBadge status={channel.status} />
                       </div>
                       <div className="flex w-full justify-between items-center">
                         <p className="text-muted-foreground font-medium">

--- a/frontend/src/components/channels/ChannelsTable.tsx
+++ b/frontend/src/components/channels/ChannelsTable.tsx
@@ -1,4 +1,5 @@
 import { InfoIcon } from "lucide-react";
+import { ChannelStatusBadge } from "src/components/channels/ChannelStatusBadge";
 import { ChannelWarning } from "src/components/channels/ChannelWarning";
 import Loading from "src/components/Loading.tsx";
 import { Badge } from "src/components/ui/badge.tsx";
@@ -82,18 +83,12 @@ export function ChannelsTable({ channels, nodes }: ChannelsTableProps) {
                     (n) => n.public_key === channel.remotePubkey
                   );
                   const alias = node?.alias || "Unknown";
-                  const capacity = channel.localBalance + channel.remoteBalance;
+                  const capacity = channel.channelSizeSat * 1000;
 
                   return (
                     <TableRow key={channel.id} className="channel">
                       <TableCell>
-                        {channel.status == "online" ? (
-                          <Badge variant="positive">Online</Badge>
-                        ) : channel.status == "opening" ? (
-                          <Badge variant="outline">Opening</Badge>
-                        ) : (
-                          <Badge variant="warning">Offline</Badge>
-                        )}
+                        <ChannelStatusBadge status={channel.status} />
                       </TableCell>
                       <TableCell>
                         <span className="font-medium mr-2">{alias}</span>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -184,6 +184,7 @@ export type UpdateAppRequest = {
 };
 
 export type Channel = {
+  channelSizeSat: number;
   localBalance: number;
   localSpendableBalance: number;
   remoteBalance: number;
@@ -192,13 +193,14 @@ export type Channel = {
   fundingTxId: string;
   active: boolean;
   public: boolean;
+  open: boolean;
   confirmations?: number;
   confirmationsRequired?: number;
   forwardingFeeBaseMsat: number;
   unspendablePunishmentReserve: number;
   counterpartyUnspendablePunishmentReserve: number;
   error?: string;
-  status: "online" | "opening" | "offline";
+  status: "online" | "opening" | "offline" | "closing";
   isOutbound: boolean;
 };
 

--- a/lnclient/greenlight/greenlight.go
+++ b/lnclient/greenlight/greenlight.go
@@ -389,13 +389,13 @@ func (gs *GreenlightService) ListChannels(ctx context.Context) ([]lnclient.Chann
 		}
 
 		channels = append(channels, lnclient.Channel{
-			LocalBalance:          int64(localAmount),
-			LocalSpendableBalance: int64(localAmount),
-			RemoteBalance:         int64(totalAmount - localAmount),
-			RemotePubkey:          glChannel.PeerId,
-			Id:                    *glChannel.ChannelId,
-			Active:                glChannel.State == 2,
-			FundingTxId:           glChannel.FundingTxid,
+			LocalBalanceMsat:          localAmount,
+			LocalSpendableBalanceMsat: localAmount,
+			RemoteBalanceMsat:         totalAmount - localAmount,
+			RemotePubkey:              glChannel.PeerId,
+			Id:                        *glChannel.ChannelId,
+			Active:                    glChannel.State == 2,
+			FundingTxId:               glChannel.FundingTxid,
 			// TODO: add Public property
 		})
 	}

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -820,9 +820,9 @@ func (ls *LDKService) ListChannels(ctx context.Context) ([]lnclient.Channel, err
 
 		channels = append(channels, lnclient.Channel{
 			InternalChannel:                          internalChannel,
-			LocalBalance:                             int64(ldkChannel.ChannelValueSats*1000 - ldkChannel.InboundCapacityMsat - ldkChannel.CounterpartyUnspendablePunishmentReserve*1000),
-			LocalSpendableBalance:                    int64(ldkChannel.OutboundCapacityMsat),
-			RemoteBalance:                            int64(ldkChannel.InboundCapacityMsat),
+			LocalBalanceMsat:                         ldkChannel.ChannelValueSats*1000 - ldkChannel.InboundCapacityMsat - ldkChannel.CounterpartyUnspendablePunishmentReserve*1000,
+			LocalSpendableBalanceMsat:                ldkChannel.OutboundCapacityMsat,
+			RemoteBalanceMsat:                        ldkChannel.InboundCapacityMsat,
 			RemotePubkey:                             ldkChannel.CounterpartyNodeId,
 			Id:                                       ldkChannel.UserChannelId, // CloseChannel takes the UserChannelId
 			Active:                                   isActive,

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -196,9 +196,9 @@ func (svc *LNDService) ListChannels(ctx context.Context) ([]lnclient.Channel, er
 
 		channels[i] = lnclient.Channel{
 			InternalChannel:                          lndChannel,
-			LocalBalance:                             lndChannel.LocalBalance * 1000,
-			LocalSpendableBalance:                    int64(math.Max(float64((lndChannel.LocalBalance-int64(lndChannel.LocalConstraints.ChanReserveSat))*1000), float64(0))),
-			RemoteBalance:                            lndChannel.RemoteBalance * 1000,
+			LocalBalanceMsat:                         uint64(lndChannel.LocalBalance * 1000),
+			LocalSpendableBalanceMsat:                uint64(math.Max(float64((lndChannel.LocalBalance-int64(lndChannel.LocalConstraints.ChanReserveSat))*1000), float64(0))),
+			RemoteBalanceMsat:                        uint64(lndChannel.RemoteBalance * 1000),
 			RemotePubkey:                             lndChannel.RemotePubkey,
 			Id:                                       strconv.FormatUint(lndChannel.ChanId, 10),
 			Active:                                   lndChannel.Active,
@@ -230,8 +230,8 @@ func (svc *LNDService) ListChannels(ctx context.Context) ([]lnclient.Channel, er
 
 		channels[j+len(activeResp.Channels)] = lnclient.Channel{
 			InternalChannel:       lndChannel,
-			LocalBalance:          lndChannel.Channel.LocalBalance * 1000,
-			RemoteBalance:         lndChannel.Channel.RemoteBalance * 1000,
+			LocalBalanceMsat:      uint64(lndChannel.Channel.LocalBalance * 1000),
+			RemoteBalanceMsat:     uint64(lndChannel.Channel.RemoteBalance * 1000),
 			RemotePubkey:          lndChannel.Channel.RemoteNodePub,
 			Public:                !lndChannel.Channel.Private,
 			FundingTxId:           fundingTxId,

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -81,9 +81,9 @@ type LNClient interface {
 }
 
 type Channel struct {
-	LocalBalance                             int64
-	LocalSpendableBalance                    int64
-	RemoteBalance                            int64
+	LocalBalanceMsat                         uint64
+	LocalSpendableBalanceMsat                uint64
+	RemoteBalanceMsat                        uint64
 	Id                                       string
 	RemotePubkey                             string
 	FundingTxId                              string

--- a/service/models.go
+++ b/service/models.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"github.com/getAlby/hub/alby"
+	"github.com/getAlby/hub/channels"
 	"github.com/getAlby/hub/config"
 	"github.com/getAlby/hub/events"
 	"github.com/getAlby/hub/lnclient"
@@ -20,6 +21,7 @@ type Service interface {
 	GetEventPublisher() events.EventPublisher
 	GetLNClient() lnclient.LNClient
 	GetTransactionsService() transactions.TransactionsService
+	GetChannelsService() channels.ChannelsService
 	GetDB() *gorm.DB
 	GetConfig() config.Config
 	GetKeys() keys.Keys

--- a/service/service.go
+++ b/service/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 
 	"github.com/getAlby/hub/alby"
+	"github.com/getAlby/hub/channels"
 	"github.com/getAlby/hub/events"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/service/keys"
@@ -36,6 +37,7 @@ type service struct {
 	db                  *gorm.DB
 	lnClient            lnclient.LNClient
 	transactionsService transactions.TransactionsService
+	channelsService     channels.ChannelsService
 	albyOAuthSvc        alby.AlbyOAuthService
 	eventPublisher      events.EventPublisher
 	ctx                 context.Context
@@ -89,7 +91,6 @@ func NewService(ctx context.Context) (*service, error) {
 
 	eventPublisher := events.NewEventPublisher()
 
-
 	keys := keys.NewKeys()
 
 	var wg sync.WaitGroup
@@ -101,6 +102,7 @@ func NewService(ctx context.Context) (*service, error) {
 		albyOAuthSvc:        alby.NewAlbyOAuthService(gormDB, cfg, keys, eventPublisher),
 		nip47Service:        nip47.NewNip47Service(gormDB, cfg, keys, eventPublisher),
 		transactionsService: transactions.NewTransactionsService(gormDB, eventPublisher),
+		channelsService:     channels.NewChannelsService(gormDB),
 		db:                  gormDB,
 		keys:                keys,
 	}
@@ -239,6 +241,10 @@ func (svc *service) GetLNClient() lnclient.LNClient {
 
 func (svc *service) GetTransactionsService() transactions.TransactionsService {
 	return svc.transactionsService
+}
+
+func (svc *service) GetChannelsService() channels.ChannelsService {
+	return svc.channelsService
 }
 
 func (svc *service) GetKeys() keys.Keys {


### PR DESCRIPTION
Partially addresses https://github.com/getAlby/hub/issues/114

- [ ] pass a query param to include closed channels so it doesn't break other parts of the app which expect only open channels
- [ ] Use pending_balances_from_channel_closures to get the local channel balance for the closed channel
  - [ ] research how to get the local balance in LND - maybe the event is sufficient
- [ ] Consume Close Channel Events to get the reason for the closure and so we only show "closing" state for force closures

There is currently a big downside: we do not know how much local balance the channel has at time of closing.

And we do not check if the funding transaction funds have moved, so we also cannot show the balance of the closed channel as pending balance on the savings balance card.

For channels older than 2 weeks, these are currently not shown.

![image](https://github.com/user-attachments/assets/e94b76b9-124b-4ab3-9440-77e28cf5cceb)

![image](https://github.com/user-attachments/assets/adb67385-1e89-487c-a3fd-2ab430052dc8)


