### PR TITLE
chore: add error handling for echo shutdown

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -53,7 +53,10 @@ func main() {
 	logger.Logger.Info("Shutting down echo server...")
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	e.Shutdown(ctx)
+	err := e.Shutdown(ctx)
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to shutdown echo server")
+	}
 	logger.Logger.Info("Echo server exited")
 	svc.Shutdown()
 	logger.Logger.Info("Service exited")


### PR DESCRIPTION
We noticed logs of the echo server still handling requests after shutting down. Not sure why, but this is good to add anyway.