### PR TITLE
fix: do not return LNClient while shutting down

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -33,16 +33,17 @@ import (
 type service struct {
 	cfg config.Config
 
-	db                  *gorm.DB
-	lnClient            lnclient.LNClient
-	transactionsService transactions.TransactionsService
-	albyOAuthSvc        alby.AlbyOAuthService
-	eventPublisher      events.EventPublisher
-	ctx                 context.Context
-	wg                  *sync.WaitGroup
-	nip47Service        nip47.Nip47Service
-	appCancelFn         context.CancelFunc
-	keys                keys.Keys
+	db                     *gorm.DB
+	lnClient               lnclient.LNClient
+	transactionsService    transactions.TransactionsService
+	albyOAuthSvc           alby.AlbyOAuthService
+	eventPublisher         events.EventPublisher
+	ctx                    context.Context
+	wg                     *sync.WaitGroup
+	nip47Service           nip47.Nip47Service
+	appCancelFn            context.CancelFunc
+	keys                   keys.Keys
+	isLNClientShuttingDown bool
 }
 
 func NewService(ctx context.Context) (*service, error) {
@@ -88,7 +89,6 @@ func NewService(ctx context.Context) (*service, error) {
 	cfg := config.NewConfig(appConfig, gormDB)
 
 	eventPublisher := events.NewEventPublisher()
-
 
 	keys := keys.NewKeys()
 
@@ -234,6 +234,9 @@ func (svc *service) GetEventPublisher() events.EventPublisher {
 }
 
 func (svc *service) GetLNClient() lnclient.LNClient {
+	if svc.isLNClientShuttingDown {
+		return nil
+	}
 	return svc.lnClient
 }
 

--- a/service/stop.go
+++ b/service/stop.go
@@ -17,7 +17,11 @@ func (svc *service) StopApp() {
 }
 
 func (svc *service) stopLNClient() {
-	defer svc.wg.Done()
+	svc.isLNClientShuttingDown = true
+	defer func() {
+		svc.wg.Done()
+		svc.isLNClientShuttingDown = false
+	}()
 	if svc.lnClient == nil {
 		return
 	}


### PR DESCRIPTION
Fixes #391 - This issue is actually because migrate node is not working and is giving the user a 0-byte file, hence resulting in an EOF error while reading

## Description

Sometimes during backup, calls to get the LNClient information are invoked (not exactly sure why, but it happens randomly), in between the LNClient stop process (see screenshot where calls to get node info and channels are requested between LDK shutdown initiation and complete) which causes the app to panic, this PR adds an `isLNClientShuttingDown` var so that `GetLNClient` returns nil without making calls to LDK during shutdown.

<img width="100%" alt="Screenshot 2024-09-03 at 10 15 45 PM" src="https://github.com/user-attachments/assets/304049d0-3ad2-4d94-80d3-b75cb3159ee3">

