### PR TITLE
feat: show pending balances from channel closures (LDK)

### DIFF
--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -7,6 +7,7 @@ import {
   CopyIcon,
   Heart,
   Hotel,
+  HourglassIcon,
   InfoIcon,
   Unplug,
 } from "lucide-react";
@@ -300,11 +301,15 @@ export default function Channels() {
                   {new Intl.NumberFormat().format(balances.onchain.spendable)}{" "}
                   sats
                   {balances &&
-                    balances.onchain.spendable !== balances.onchain.total && (
+                    (balances.onchain.spendable !== balances.onchain.total ||
+                      balances.onchain.pendingBalancesFromChannelClosures >
+                        0) && (
                       <p className="text-xs text-muted-foreground animate-pulse">
                         +
                         {new Intl.NumberFormat().format(
-                          balances.onchain.total - balances.onchain.spendable
+                          balances.onchain.total -
+                            balances.onchain.spendable +
+                            balances.onchain.pendingBalancesFromChannelClosures
                         )}{" "}
                         sats incoming
                       </p>
@@ -402,6 +407,27 @@ export default function Channels() {
           </CardFooter>
         </Card>
       </div>
+
+      {balances && balances.onchain.pendingBalancesFromChannelClosures > 0 && (
+        <Alert>
+          <HourglassIcon className="h-4 w-4" />
+          <AlertTitle>Pending Closed Channels</AlertTitle>
+          <AlertDescription>
+            You have{" "}
+            {new Intl.NumberFormat().format(
+              balances.onchain.pendingBalancesFromChannelClosures
+            )}{" "}
+            sats pending from one or more closed channels. These may take up to
+            2 weeks to return to your savings balance.{" "}
+            <ExternalLink
+              to="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/faq-alby-hub/why-was-my-lightning-channel-closed-and-what-to-do-next"
+              className="underline"
+            >
+              Learn more
+            </ExternalLink>
+          </AlertDescription>
+        </Alert>
+      )}
 
       {channels && channels.length === 0 && (
         <EmptyState

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -417,8 +417,8 @@ export default function Channels() {
             {new Intl.NumberFormat().format(
               balances.onchain.pendingBalancesFromChannelClosures
             )}{" "}
-            sats pending from one or more closed channels. Once spendable again these 
-            will become available in your savings balance.{" "}
+            sats pending from one or more closed channels. Once spendable again
+            these will become available in your savings balance.{" "}
             <ExternalLink
               to="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/faq-alby-hub/why-was-my-lightning-channel-closed-and-what-to-do-next"
               className="underline"

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -417,8 +417,8 @@ export default function Channels() {
             {new Intl.NumberFormat().format(
               balances.onchain.pendingBalancesFromChannelClosures
             )}{" "}
-            sats pending from one or more closed channels. These may take up to
-            2 weeks to return to your savings balance.{" "}
+            sats pending from one or more closed channels. Once spendable again these 
+            will become available in your savings balance.{" "}
             <ExternalLink
               to="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/faq-alby-hub/why-was-my-lightning-channel-closed-and-what-to-do-next"
               className="underline"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -269,6 +269,7 @@ export type OnchainBalanceResponse = {
   spendable: number;
   total: number;
   reserved: number;
+  pendingBalancesFromChannelClosures: number;
 };
 
 // from https://mempool.space/docs/api/rest#get-node-stats

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -135,9 +135,10 @@ type CloseChannelResponse struct {
 }
 
 type OnchainBalanceResponse struct {
-	Spendable int64 `json:"spendable"`
-	Total     int64 `json:"total"`
-	Reserved  int64 `json:"reserved"`
+	Spendable                          int64  `json:"spendable"`
+	Total                              int64  `json:"total"`
+	Reserved                           int64  `json:"reserved"`
+	PendingBalancesFromChannelClosures uint64 `json:"pendingBalancesFromChannelClosures"`
 }
 
 type PeerDetails struct {


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/601

Only LDK is supported for now.

![image](https://github.com/user-attachments/assets/fb7eb31e-0dc2-4952-bd6e-ba434391c44f)

The LDK API is not so easy to deal with here so a lot of code to gather all the different balances, but it's isolated in one place.