### PR TITLE
Removes any existing albyhub.service to prevent duplicating

### DIFF
--- a/scripts/linux-x86_64/install.sh
+++ b/scripts/linux-x86_64/install.sh
@@ -59,11 +59,7 @@ then
   exit
 fi
 
-if [ -s /etc/systemd/system/albyhub.service ]; then
-  sudo truncate -s 0 /etc/systemd/system/albyhub.service
-fi
-
-sudo tee -a /etc/systemd/system/albyhub.service > /dev/null << EOF
+sudo tee /etc/systemd/system/albyhub.service > /dev/null << EOF
 [Unit]
 Description=Alby Hub
 After=network-online.target

--- a/scripts/linux-x86_64/install.sh
+++ b/scripts/linux-x86_64/install.sh
@@ -59,6 +59,10 @@ then
   exit
 fi
 
+if [ -s /etc/systemd/system/albyhub.service ]; then
+  sudo truncate -s 0 /etc/systemd/system/albyhub.service
+fi
+
 sudo tee -a /etc/systemd/system/albyhub.service > /dev/null << EOF
 [Unit]
 Description=Alby Hub


### PR DESCRIPTION
Albyhub service had a config error after re-running the Linux installation script [here](https://github.com/getAlby/hub/tree/master/scripts/linux-x86_64#alby-hub-on-a-linux-server) caused by the albyhub.service written twice.