### PR TITLE
fix: remove lud16 from isolated app secrets

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -104,7 +104,7 @@ func (api *api) CreateApp(createAppRequest *CreateAppRequest) (*CreateAppRespons
 			query := returnToUrl.Query()
 			query.Add("relay", relayUrl)
 			query.Add("pubkey", api.keys.GetNostrPublicKey())
-			if lightningAddress != "" {
+			if lightningAddress != "" && !app.Isolated {
 				query.Add("lud16", lightningAddress)
 			}
 			returnToUrl.RawQuery = query.Encode()
@@ -113,7 +113,7 @@ func (api *api) CreateApp(createAppRequest *CreateAppRequest) (*CreateAppRespons
 	}
 
 	var lud16 string
-	if lightningAddress != "" {
+	if lightningAddress != "" && !app.Isolated {
 		lud16 = fmt.Sprintf("&lud16=%s", lightningAddress)
 	}
 	responseBody.PairingUri = fmt.Sprintf("nostr+walletconnect://%s?relay=%s&secret=%s%s", api.keys.GetNostrPublicKey(), relayUrl, pairingSecretKey, lud16)


### PR DESCRIPTION
Isolated apps should not have anything shared from the main account. The isolated connection would also not see any transaction from that lud16.