### PR TITLE
feat: show pending balance from channel closures in lnd

### DIFF
--- a/frontend/src/components/CloseChannelDialogContent.tsx
+++ b/frontend/src/components/CloseChannelDialogContent.tsx
@@ -7,6 +7,7 @@ import { Button } from "src/components/ui/button";
 import { Label } from "src/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "src/components/ui/radio-group";
 import { useToast } from "src/components/ui/use-toast";
+import { useBalances } from "src/hooks/useBalances";
 import { useChannels } from "src/hooks/useChannels";
 import { copyToClipboard } from "src/lib/clipboard";
 import { Channel, CloseChannelResponse } from "src/types";
@@ -29,6 +30,7 @@ export function CloseChannelDialogContent({ alias, channel }: Props) {
   const [closeType, setCloseType] = React.useState("normal");
   const [step, setStep] = React.useState(channel.active ? 2 : 1);
   const [fundingTxId, setFundingTxId] = React.useState("");
+  const { mutate: reloadBalances } = useBalances();
   const { data: channels, mutate: reloadChannels } = useChannels();
   const { toast } = useToast();
 
@@ -234,6 +236,7 @@ export function CloseChannelDialogContent({ alias, channel }: Props) {
             <AlertDialogCancel
               onClick={async () => {
                 await reloadChannels();
+                await reloadBalances();
               }}
             >
               Done


### PR DESCRIPTION
Fixes #603 

## Screenshots

### Before closing
<img width="100%" alt="Screenshot 2024-09-05 at 5 54 46 PM" src="https://github.com/user-attachments/assets/b538daeb-01fe-4b10-80fc-eb23753393f0">

### 144 blocks after force-closing
<img width="100%" alt="Screenshot 2024-09-05 at 5 55 05 PM" src="https://github.com/user-attachments/assets/2a353047-9383-4a8b-95e2-5e217e9d9b2b">

### 145 blocks after force-closing
<img width="100%" alt="Screenshot 2024-09-05 at 5 55 33 PM" src="https://github.com/user-attachments/assets/a7d10ea5-e436-46d6-8907-73024552881e">

### 146 blocks after force-closing (Closure Complete)
<img width="100%" alt="Screenshot 2024-09-05 at 5 55 45 PM" src="https://github.com/user-attachments/assets/105cdc53-25ab-45da-b748-a68936719db6">
