### PR TITLE
fix: improve delete connection confirmation dialog copy

### DIFF
--- a/frontend/src/screens/apps/ShowApp.tsx
+++ b/frontend/src/screens/apps/ShowApp.tsx
@@ -190,10 +190,18 @@ function AppInternal({ app, refetchApp, capabilities }: AppInternalProps) {
                 </AlertDialogTrigger>
                 <AlertDialogContent>
                   <AlertDialogHeader>
-                    <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+                    <AlertDialogTitle>
+                      Are you sure you want to delete this connection?
+                    </AlertDialogTitle>
                     <AlertDialogDescription>
-                      This will revoke the permission and will no longer allow
-                      calls from this public key.
+                      Connected apps will no longer be able to use this
+                      connection.
+                      {app.isolated && app.balance > 0 && (
+                        <div>
+                          No funds will be lost during this process. The balance
+                          will remain in your wallet.
+                        </div>
+                      )}
                     </AlertDialogDescription>
                   </AlertDialogHeader>
                   <AlertDialogFooter>


### PR DESCRIPTION
Fixing https://feedback.getalby.com/-alby-hub-request-a-feature/posts/message-when-deleting-isolated-connection

> When deleting an isolated connection I think it would be good if there was a message advising what happens to the sats that are associated with that connection.

> I think it could be easy to get the fear that sats may be lost. Perhaps a line advising people that no funds will be removed and will still be available from the main wallet could be added to the message in the included screenshot.

**Screenshot**
![image](https://github.com/user-attachments/assets/b3651eca-c40b-43ea-8545-b22008c11950)
