### PR TITLE
feat: mobile UI fixes

### DIFF
--- a/frontend/src/components/AppAvatar.tsx
+++ b/frontend/src/components/AppAvatar.tsx
@@ -39,7 +39,7 @@ export default function AppAvatar({ app, className }: Props) {
         />
       )}
       {!image && (
-        <span className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-white text-xl font-medium capitalize">
+        <span className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-white text-sm font-medium capitalize">
           {app.name.charAt(0)}
         </span>
       )}

--- a/frontend/src/components/SidebarHint.tsx
+++ b/frontend/src/components/SidebarHint.tsx
@@ -84,7 +84,7 @@ function SidebarHintCard({
   buttonLink,
 }: SidebarHintCardProps) {
   return (
-    <div className="md:m-4">
+    <div className="my-4 md:mx-4">
       <Card>
         <CardHeader className="p-4">
           <Icon className="h-8 w-8 mb-4" />

--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -89,7 +89,7 @@ function TransactionItem({ tx }: Props) {
               )}
             </div>
           </div>
-          <div className="overflow-hidden mr-3 max-w-full text-left">
+          <div className="overflow-hidden mr-3 max-w-full text-left flex flex-col items-start justify-center">
             <div>
               <p className="flex items-center gap-2 truncate">
                 <span className="md:text-xl font-semibold">
@@ -100,8 +100,8 @@ function TransactionItem({ tx }: Props) {
                 </span>
               </p>
             </div>
-            <p className="text-sm md:text-base text-muted-foreground break-all flex">
-              <p className="truncate">{tx.description}</p>
+            <p className="text-sm md:text-base text-muted-foreground break-all w-full truncate">
+              {tx.description}
             </p>
           </div>
           <div className="flex ml-auto text-right space-x-3 shrink-0">

--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -57,8 +57,7 @@ function TransactionItem({ tx }: Props) {
       }}
     >
       <DialogTrigger className="p-3 mb-4 hover:bg-muted/50 data-[state=selected]:bg-muted cursor-pointer rounded-md slashed-zero transaction sensitive">
-        {/* flex wrap is used as a last resort to stop horizontal scrollbar on mobile. */}
-        <div className="flex gap-3 flex-wrap">
+        <div className="flex gap-3">
           <div className="flex items-center">
             <div
               className={cn(
@@ -90,21 +89,23 @@ function TransactionItem({ tx }: Props) {
               )}
             </div>
           </div>
-          <div className="overflow-hidden mr-3 flex flex-col items-start justify-center">
-            <div className="flex items-center gap-2 truncate">
-              <p className="text-lg md:text-xl font-semibold">
-                {type == "incoming" ? "Received" : "Sent"}
-              </p>
-              <p className="text-sm md:text-base truncate text-muted-foreground">
-                {dayjs(tx.settledAt).fromNow()}
+          <div className="overflow-hidden mr-3 max-w-full text-left">
+            <div>
+              <p className="flex items-center gap-2 truncate">
+                <span className="md:text-xl font-semibold">
+                  {type == "incoming" ? "Received" : "Sent"}
+                </span>
+                <span className="text-xs md:text-base truncate text-muted-foreground">
+                  {dayjs(tx.settledAt).fromNow()}
+                </span>
               </p>
             </div>
             <p className="text-sm md:text-base text-muted-foreground break-all flex">
-              {tx.description}
+              <p className="truncate">{tx.description}</p>
             </p>
           </div>
           <div className="flex ml-auto text-right space-x-3 shrink-0">
-            <div className="flex items-center gap-2 text-xl">
+            <div className="flex items-center gap-2 md:text-xl">
               <p
                 className={cn(
                   "font-semibold",

--- a/frontend/src/components/connections/AppCard.tsx
+++ b/frontend/src/components/connections/AppCard.tsx
@@ -23,7 +23,7 @@ export default function AppCard({ app }: Props) {
 
   return (
     <Card
-      className="h-full flex flex-col group cursor-pointer"
+      className="flex flex-col group cursor-pointer"
       onClick={() => navigate(`/apps/${app.nostrPubkey}`)}
     >
       <CardHeader>

--- a/frontend/src/components/layouts/AppLayout.tsx
+++ b/frontend/src/components/layouts/AppLayout.tsx
@@ -202,7 +202,7 @@ export default function AppLayout() {
   return (
     <>
       <div className="font-sans min-h-screen w-full flex flex-col">
-        <div className="flex-1 h-full grid md:grid-cols-[280px_1fr]">
+        <div className="flex-1 h-full md:grid md:grid-cols-[280px_minmax(0,1fr)]">
           <div className="hidden border-r bg-muted/40 md:block">
             <div className="flex h-full max-h-screen flex-col gap-2 sticky top-0 overflow-y-auto">
               <div className="flex-1">

--- a/frontend/src/components/layouts/AppLayout.tsx
+++ b/frontend/src/components/layouts/AppLayout.tsx
@@ -138,7 +138,7 @@ export default function AppLayout() {
   function MainNavSecondary() {
     const { hasChannelManagement } = useInfo();
     return (
-      <nav className="grid items-start px-4 py-2 text-sm font-medium">
+      <nav className="grid items-start md:px-4 md:py-2 text-sm font-medium">
         {hasChannelManagement && (
           <MenuItem to="/channels">
             <CubeIcon className="h-4 w-4" />
@@ -242,7 +242,7 @@ export default function AppLayout() {
             </div>
           </div>
           <main className="flex flex-col">
-            <header className="md:hidden flex h-14 items-center gap-4 border-b bg-muted/40 px-4 lg:h-[60px] lg:px-6 justify-between">
+            <header className="md:hidden sticky top-0 z-50 flex h-14 items-center gap-4 border-b bg-muted/40 backdrop-blur px-4 lg:h-[60px] lg:px-6 justify-between">
               <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
                 <SheetTrigger asChild>
                   <Button
@@ -256,15 +256,15 @@ export default function AppLayout() {
                 </SheetTrigger>
                 <SheetContent
                   side="left"
-                  className="flex flex-col justify-between max-h-screen"
+                  className="flex flex-col justify-between max-h-screen px-4"
                 >
-                  <nav className="grid gap-2 text-lg font-medium">
+                  <nav className="grid text-sm font-medium">
                     <div className="p-3 pr-0 flex justify-between items-center">
                       <Link to="/">
                         <AlbyHubLogo className="text-foreground" />
                       </Link>
                       {/* align shield with x icon */}
-                      <div className="-mr-2">
+                      <div className="mr-2">
                         <AppVersion />
                       </div>
                     </div>

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,8 +1,8 @@
-import * as React from "react";
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+import * as React from "react";
 
-import { cn } from "src/lib/utils";
 import { buttonVariants } from "src/components/ui/button";
+import { cn } from "src/lib/utils";
 
 const AlertDialog = AlertDialogPrimitive.Root;
 
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg max-w-[calc(100%-1rem)] sm:max-w-lg p-5 sm:p-6",
         className
       )}
       {...props}
@@ -126,14 +126,14 @@ AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
 
 export {
   AlertDialog,
-  AlertDialogPortal,
-  AlertDialogOverlay,
-  AlertDialogTrigger,
-  AlertDialogContent,
-  AlertDialogHeader,
-  AlertDialogFooter,
-  AlertDialogTitle,
-  AlertDialogDescription,
   AlertDialogAction,
   AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
 };

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed max-h-[90%] overflow-y-auto left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed max-h-[90%] overflow-y-auto left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg max-w-[calc(100%-1rem)] sm:max-w-lg p-5 sm:p-6",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 sm:text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/frontend/src/screens/Home.tsx
+++ b/frontend/src/screens/Home.tsx
@@ -52,7 +52,7 @@ function Home() {
           <Card>
             <CardHeader>
               <div className="flex flex-row items-center">
-                <div className="flex-1">
+                <div className="flex-shrink-0">
                   <AlbyHead className="w-12 h-12 rounded-xl p-1 border" />
                 </div>
                 <div>

--- a/frontend/src/screens/Home.tsx
+++ b/frontend/src/screens/Home.tsx
@@ -52,7 +52,9 @@ function Home() {
           <Card>
             <CardHeader>
               <div className="flex flex-row items-center">
-                <AlbyHead className="w-12 h-12 rounded-xl p-1 border" />
+                <div className="flex-1">
+                  <AlbyHead className="w-12 h-12 rounded-xl p-1 border" />
+                </div>
                 <div>
                   <CardTitle>
                     <div className="flex-1 leading-5 font-semibold text-xl whitespace-nowrap text-ellipsis overflow-hidden ml-4">
@@ -78,7 +80,9 @@ function Home() {
             <Card>
               <CardHeader>
                 <div className="flex flex-row items-center">
-                  <AlbyHead className="w-12 h-12 rounded-xl p-1 border bg-[#FFDF6F]" />
+                  <div className="flex-1">
+                    <AlbyHead className="w-12 h-12 rounded-xl p-1 border bg-[#FFDF6F]" />
+                  </div>
                   <div>
                     <CardTitle>
                       <div className="flex-1 leading-5 font-semibold text-xl whitespace-nowrap text-ellipsis overflow-hidden ml-4">

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -118,7 +118,7 @@ export default function Channels() {
               <DropdownMenuTrigger asChild>
                 {isDesktop ? (
                   <Button
-                    className="hidden md:inline-flex"
+                    className="inline-flex"
                     variant="outline"
                     size="default"
                   >
@@ -126,7 +126,7 @@ export default function Channels() {
                     <ChevronDown />
                   </Button>
                 ) : (
-                  <Button className="md:hidden" variant="outline" size="icon">
+                  <Button variant="outline" size="icon">
                     <Settings2 className="w-4 h-4" />
                   </Button>
                 )}

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -9,6 +9,7 @@ import {
   Hotel,
   HourglassIcon,
   InfoIcon,
+  Settings2,
   Unplug,
 } from "lucide-react";
 import React from "react";
@@ -115,10 +116,20 @@ export default function Channels() {
           <div className="flex gap-3 items-center justify-center">
             <DropdownMenu modal={false}>
               <DropdownMenuTrigger asChild>
-                <Button variant="outline" size="default">
-                  Advanced
-                  <ChevronDown />
-                </Button>
+                {isDesktop ? (
+                  <Button
+                    className="hidden md:inline-flex"
+                    variant="outline"
+                    size="default"
+                  >
+                    Advanced
+                    <ChevronDown />
+                  </Button>
+                ) : (
+                  <Button className="md:hidden" variant="outline" size="icon">
+                    <Settings2 className="w-4 h-4" />
+                  </Button>
+                )}
               </DropdownMenuTrigger>
               <DropdownMenuContent className="w-56">
                 <DropdownMenuGroup>


### PR DESCRIPTION
## Description

Fixes quite some UI issues in mobile. See screenshots for Before vs After:

## Transaction lists are now in one line
<table>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/d24608f1-b92d-4611-80d0-73674f459b1e" width="100%"/>
</td>
<td>
<img src="https://github.com/user-attachments/assets/2052ec83-8ac6-49ea-bf62-a69faeeec445" width="100%"/>
</td>
</tr>
</table>

## Dialogs look cleaner (added margin on the sides and made them rounded)
<table>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/a538eb48-4a5c-43c0-8fec-fb577149bb0c" width="100%"/>
</td>
<td>
<img src="https://github.com/user-attachments/assets/cf752a23-2c65-4ac6-bf08-1e3a78da76f9" width="100%"/>
</td>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/4ed19b53-2574-44cd-8817-d47ebe1df1c8" width="100%"/>
</td>
<td>
<img src="https://github.com/user-attachments/assets/821403c6-e9ed-4a38-add7-199b1e08464a" width="100%"/>
</td>
</tr>
</table>

## Sidebar used to look ugly with different font sizes and spacing - cleaned now
<table>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/576cac46-b5c8-4151-8d65-483bb5abe19f" width="100%"/>
</td>
<td>
<img src="https://github.com/user-attachments/assets/3085a3d0-9a01-4d5d-a7a1-20e5bbb941cb" width="100%"/>
</td>
</tr>
</table>

## Font size for input is 14px which led mobile browsers to zoom automatically (they do it if it's less than 16px) - changed text size to 16px now (only in mobiles)
<table>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/fa09d848-ce82-461a-b0fa-b9012e77af13" width="100%"/>
</td>
<td>
<img src="https://github.com/user-attachments/assets/42356f75-b575-4dae-8cba-ef03137952de" width="100%"/>
</td>
</tr>
</table>

## Advanced dropdown in Node page
<table>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/bf2694b6-5850-4317-bf11-fd6ca78645bc" width="100%"/>
</td>
<td>
<img src="https://github.com/user-attachments/assets/81a14313-e866-4266-a212-643002366c1d" width="100%"/>
</td>
</tr>
</table>

## AppCard using full height because of h-full
<table>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/5879503f-3100-4d5a-95c5-3fd9a4174f86" width="100%"/>
</td>
<td>
<img src="https://github.com/user-attachments/assets/62dcb8d2-89ac-490f-8951-4575c90a38ef" width="100%"/>
</td>
</tr>
</table>

## Home card logos compressing in mobile
<table>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/baaee117-4a81-467f-9a5d-08c7cf48cda7" width="100%"/>
</td>
<td>
<img src="https://github.com/user-attachments/assets/c2bff8df-6ab4-4983-9b0f-d42d3b76bcd8" width="100%"/>
</td>
</tr>
</table>
