### PR TITLE
fix: use 1 channel confirmation for non-LDK node types

### DIFF
--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -940,10 +940,14 @@ func (svc *albyOAuthService) requestAutoChannel(ctx context.Context, url string,
 		NodeType        string `json:"node_type"`
 	}
 
+	backendType, err := svc.cfg.Get("LNBackendType", "")
+	if err != nil {
+		return nil, errors.New("failed to get LN backend type")
+	}
 	newAutoChannelRequest := autoChannelRequest{
 		NodePubkey:      pubkey,
 		AnnounceChannel: isPublic,
-		NodeType:        svc.cfg.GetEnv().LNBackendType,
+		NodeType:        backendType,
 	}
 
 	payloadBytes, err := json.Marshal(newAutoChannelRequest)

--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -937,11 +937,13 @@ func (svc *albyOAuthService) requestAutoChannel(ctx context.Context, url string,
 	type autoChannelRequest struct {
 		NodePubkey      string `json:"node_pubkey"`
 		AnnounceChannel bool   `json:"announce_channel"`
+		NodeType        string `json:"node_type"`
 	}
 
 	newAutoChannelRequest := autoChannelRequest{
 		NodePubkey:      pubkey,
 		AnnounceChannel: isPublic,
+		NodeType:        svc.cfg.GetEnv().LNBackendType,
 	}
 
 	payloadBytes, err := json.Marshal(newAutoChannelRequest)

--- a/api/lsp.go
+++ b/api/lsp.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/getAlby/hub/config"
 	"github.com/getAlby/hub/lnclient"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/lsp"
@@ -213,6 +214,10 @@ func (api *api) requestLSPS1Invoice(ctx context.Context, request *LSPOrderReques
 	}
 
 	var requiredChannelConfirmations uint64 = 0
+
+	if api.cfg.GetEnv().LNBackendType != config.LDKBackendType {
+		requiredChannelConfirmations = 1
+	}
 
 	if request.Public {
 		// as per BOLT-7 6 confirmations are required for the channel to be gossiped

--- a/api/lsp.go
+++ b/api/lsp.go
@@ -215,7 +215,12 @@ func (api *api) requestLSPS1Invoice(ctx context.Context, request *LSPOrderReques
 
 	var requiredChannelConfirmations uint64 = 0
 
-	if api.cfg.GetEnv().LNBackendType != config.LDKBackendType {
+	backendType, err := api.cfg.Get("LNBackendType", "")
+	if err != nil {
+		return "", 0, errors.New("failed to get LN backend type")
+	}
+
+	if backendType != config.LDKBackendType {
 		requiredChannelConfirmations = 1
 	}
 


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/634

I unfortunately cannot test this currently on Mutinynet