### PR TITLE
fix: only log a warning if there is no preimage when settling an incoming transaction

### DIFF
--- a/transactions/transactions_service.go
+++ b/transactions/transactions_service.go
@@ -897,7 +897,13 @@ func (svc *transactionsService) markTransactionSettled(tx *gorm.DB, dbTransactio
 	}
 
 	if preimage == "" {
-		return nil, errors.New("no preimage in payment")
+		// outgoing payments MUST have a preimage
+		if dbTransaction.Type == constants.TRANSACTION_TYPE_OUTGOING {
+			return nil, errors.New("no preimage in payment")
+		}
+		// incoming payments SHOULD have a preimage
+		// (currently cashu backend does not)
+		logger.Logger.WithField("payment_hash", dbTransaction.PaymentHash).Warn("no preimage in settled incoming transaction")
 	}
 
 	now := time.Now()


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/651

Alternative fix as the cashu connector is a bit broken right now (incoming payments do not show because of a check to ensure there is a preimage set) and there is nothing in the cashu spec to reveal preimages for receiving payments.

I am not really sure this is good or not - ideally all the settled transactions in our DB have preimages.