### PR TITLE
fix: use channel balance api in get balances (LND)

### DIFF
--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -1464,15 +1464,17 @@ func (ls *LDKService) GetBalances(ctx context.Context) (*lnclient.BalancesRespon
 	channels := ls.node.ListChannels()
 	for _, channel := range channels {
 		if channel.IsUsable {
-			channelMinSpendable := min(int64(channel.OutboundCapacityMsat), int64(*channel.CounterpartyOutboundHtlcMaximumMsat))
-			channelMinReceivable := min(int64(channel.InboundCapacityMsat), int64(*channel.InboundHtlcMaximumMsat))
+			// spending or receiving amount may be constrained by channel configuration (e.g. ACINQ does this)
+			channelConstrainedSpendable := min(int64(channel.OutboundCapacityMsat), int64(*channel.CounterpartyOutboundHtlcMaximumMsat))
+			channelConstrainedReceivable := min(int64(channel.InboundCapacityMsat), int64(*channel.InboundHtlcMaximumMsat))
 
-			nextMaxSpendable = max(nextMaxSpendable, channelMinSpendable)
-			nextMaxReceivable = max(nextMaxReceivable, channelMinReceivable)
+			nextMaxSpendable = max(nextMaxSpendable, channelConstrainedSpendable)
+			nextMaxReceivable = max(nextMaxReceivable, channelConstrainedReceivable)
 
-			nextMaxSpendableMPP += channelMinSpendable
-			nextMaxReceivableMPP += channelMinReceivable
+			nextMaxSpendableMPP += channelConstrainedSpendable
+			nextMaxReceivableMPP += channelConstrainedReceivable
 
+			// these are what the wallet can send and receive, but not necessarily in one go
 			totalSpendable += int64(channel.OutboundCapacityMsat)
 			totalReceivable += int64(channel.InboundCapacityMsat)
 		}


### PR DESCRIPTION
Fixes #644

We recently saw an issue where people saw balance differently in Umbrel, Hub and the Extension

For example:

`1 748 499` - Umbrel
`1 747 569` - Extension
`  987 439` - Hub Node page

This PR makes the Hub Node page return the same balance as the extension. The difference of 930 between Umbrel and Extension is not solved by this PR as it is because of an unsettled HTLC (again, I suspect that it is an invoice of value 500 sats but this additional 430 sats is cut from the balance and I don't know why that is the case)