### PR TITLE
chore: remove get balance method from LN client

### DIFF
--- a/lnclient/breez/breez.go
+++ b/lnclient/breez/breez.go
@@ -148,14 +148,6 @@ func (bs *BreezService) SendKeysend(ctx context.Context, amount uint64, destinat
 	return nil, errors.New("not supported")
 }
 
-func (bs *BreezService) GetBalance(ctx context.Context) (balance int64, err error) {
-	info, err := bs.svc.NodeInfo()
-	if err != nil {
-		return 0, err
-	}
-	return int64(info.MaxPayableMsat), nil
-}
-
 func (bs *BreezService) MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64) (transaction *lnclient.Transaction, err error) {
 	if expiry == 0 {
 		expiry = lnclient.DEFAULT_INVOICE_EXPIRY

--- a/lnclient/cashu/cashu.go
+++ b/lnclient/cashu/cashu.go
@@ -112,17 +112,6 @@ func (cs *CashuService) SendKeysend(ctx context.Context, amount uint64, destinat
 	return nil, errors.New("keysend not supported")
 }
 
-func (cs *CashuService) GetBalance(ctx context.Context) (balance int64, err error) {
-	balanceByMints := cs.wallet.GetBalanceByMints()
-	totalBalance := uint64(0)
-
-	for _, balance := range balanceByMints {
-		totalBalance += balance
-	}
-
-	return int64(totalBalance * 1000), nil
-}
-
 func (cs *CashuService) MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64) (transaction *lnclient.Transaction, err error) {
 	// TODO: support expiry
 	if expiry == 0 {
@@ -280,11 +269,15 @@ func (cs *CashuService) UpdateChannel(ctx context.Context, updateChannelRequest 
 }
 
 func (cs *CashuService) GetBalances(ctx context.Context) (*lnclient.BalancesResponse, error) {
-	balance, err := cs.GetBalance(ctx)
-	if err != nil {
-		logger.Logger.WithError(err).Error("Failed to get balance")
-		return nil, err
+	balanceByMints := cs.wallet.GetBalanceByMints()
+	totalBalance := uint64(0)
+
+	for _, balance := range balanceByMints {
+		totalBalance += balance
 	}
+
+	balance := int64(totalBalance * 1000)
+
 	return &lnclient.BalancesResponse{
 		Onchain: lnclient.OnchainBalanceResponse{
 			Spendable: 0,

--- a/lnclient/greenlight/greenlight.go
+++ b/lnclient/greenlight/greenlight.go
@@ -158,24 +158,6 @@ func (gs *GreenlightService) SendKeysend(ctx context.Context, amount uint64, des
 	return nil, errors.New("not supported")
 }
 
-func (gs *GreenlightService) GetBalance(ctx context.Context) (balance int64, err error) {
-	response, err := gs.client.ListFunds(glalby.ListFundsRequest{})
-
-	if err != nil {
-		logger.Logger.Errorf("Failed to list funds: %v", err)
-		return 0, err
-	}
-
-	balance = 0
-	for _, channel := range response.Channels {
-		if channel.OurAmountMsat != nil && channel.Connected {
-			balance += int64(*channel.OurAmountMsat)
-		}
-	}
-
-	return balance, nil
-}
-
 func (gs *GreenlightService) MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64) (transaction *lnclient.Transaction, err error) {
 	if expiry == 0 {
 		expiry = lnclient.DEFAULT_INVOICE_EXPIRY

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -594,19 +594,6 @@ func (ls *LDKService) SendKeysend(ctx context.Context, amount uint64, destinatio
 	}, nil
 }
 
-func (ls *LDKService) GetBalance(ctx context.Context) (balance int64, err error) {
-	channels := ls.node.ListChannels()
-
-	balance = 0
-	for _, channel := range channels {
-		if channel.IsUsable {
-			balance += int64(channel.OutboundCapacityMsat)
-		}
-	}
-
-	return balance, nil
-}
-
 func (ls *LDKService) getMaxReceivable() int64 {
 	var receivable int64 = 0
 	channels := ls.node.ListChannels()

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -36,14 +36,6 @@ type LNDService struct {
 	cancel   context.CancelFunc
 }
 
-func (svc *LNDService) GetBalance(ctx context.Context) (balance int64, err error) {
-	resp, err := svc.client.ChannelBalance(ctx, &lnrpc.ChannelBalanceRequest{})
-	if err != nil {
-		return 0, err
-	}
-	return int64(resp.LocalBalance.Msat), nil
-}
-
 // FIXME: this always returns limit * 2 transactions and offset is not used correctly
 func (svc *LNDService) ListTransactions(ctx context.Context, from, until, limit, offset uint64, unpaid bool, invoiceType string) (transactions []lnclient.Transaction, err error) {
 	// Fetch invoices

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -48,7 +48,6 @@ type NodeConnectionInfo struct {
 type LNClient interface {
 	SendPaymentSync(ctx context.Context, payReq string) (*PayInvoiceResponse, error)
 	SendKeysend(ctx context.Context, amount uint64, destination string, customRecords []TLVRecord, preimage string) (*PayKeysendResponse, error)
-	GetBalance(ctx context.Context) (balance int64, err error)
 	GetPubkey() string
 	GetInfo(ctx context.Context) (info *NodeInfo, err error)
 	MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64) (transaction *Transaction, err error)

--- a/lnclient/phoenixd/phoenixd.go
+++ b/lnclient/phoenixd/phoenixd.go
@@ -89,32 +89,25 @@ func NewPhoenixService(address string, authorization string) (result lnclient.LN
 	return phoenixService, nil
 }
 
-func (svc *PhoenixService) GetBalance(ctx context.Context) (balance int64, err error) {
+func (svc *PhoenixService) GetBalances(ctx context.Context) (*lnclient.BalancesResponse, error) {
 	req, err := http.NewRequest(http.MethodGet, svc.Address+"/getbalance", nil)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	req.Header.Add("Authorization", "Basic "+svc.Authorization)
 	client := &http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	var balanceRes BalanceResponse
 	if err := json.NewDecoder(resp.Body).Decode(&balanceRes); err != nil {
-		return 0, err
-	}
-
-	return balanceRes.BalanceSat * 1000, nil
-}
-
-func (svc *PhoenixService) GetBalances(ctx context.Context) (*lnclient.BalancesResponse, error) {
-	balance, err := svc.GetBalance(ctx)
-	if err != nil {
 		return nil, err
 	}
+
+	balance := balanceRes.BalanceSat * 1000
 
 	return &lnclient.BalancesResponse{
 		Onchain: lnclient.OnchainBalanceResponse{

--- a/nip47/controllers/get_balance_controller.go
+++ b/nip47/controllers/get_balance_controller.go
@@ -33,8 +33,8 @@ func (controller *nip47Controller) HandleGetBalanceEvent(ctx context.Context, ni
 	if app.Isolated {
 		balance = queries.GetIsolatedBalance(controller.db, app.ID)
 	} else {
-		balance_signed, err := controller.lnClient.GetBalance(ctx)
-		balance = uint64(balance_signed)
+		balances, err := controller.lnClient.GetBalances(ctx)
+		balance = uint64(balances.Lightning.TotalSpendable)
 		if err != nil {
 			logger.Logger.WithFields(logrus.Fields{
 				"request_event_id": requestEventId,

--- a/tests/mock_ln_client.go
+++ b/tests/mock_ln_client.go
@@ -23,6 +23,12 @@ var MockNodeInfo = lnclient.NodeInfo{
 	BlockHash:   "123blockhash",
 }
 
+var MockLNClientBalances = lnclient.BalancesResponse{
+	Lightning: lnclient.LightningBalanceResponse{
+		TotalSpendable: 21000,
+	},
+}
+
 var MockTime = time.Unix(1693876963, 0)
 var MockTimeUnix = MockTime.Unix()
 
@@ -88,10 +94,6 @@ func (mln *MockLn) SendKeysend(ctx context.Context, amount uint64, destination s
 	}, nil
 }
 
-func (mln *MockLn) GetBalance(ctx context.Context) (balance int64, err error) {
-	return 21000, nil
-}
-
 func (mln *MockLn) GetInfo(ctx context.Context) (info *lnclient.NodeInfo, err error) {
 	return &MockNodeInfo, nil
 }
@@ -133,7 +135,7 @@ func (mln *MockLn) GetNewOnchainAddress(ctx context.Context) (string, error) {
 	return "", nil
 }
 func (mln *MockLn) GetBalances(ctx context.Context) (*lnclient.BalancesResponse, error) {
-	return nil, nil
+	return &MockLNClientBalances, nil
 }
 func (mln *MockLn) GetOnchainBalance(ctx context.Context) (*lnclient.OnchainBalanceResponse, error) {
 	return nil, nil


### PR DESCRIPTION
Fixes #669

This removes the repeated `GetBalance` method which is redundant due to `GetBalances` and uses the latter in NIP47 Get Balance Handler