### PR TITLE
feat: show pending and failed outgoing transactions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ FRONTEND_URL=http://localhost:5173
 #RELAY=ws://localhost:7447/v1
 #PORT=8080
 
+#LOG_DB_QUERIES=true
 
 # Alby OAuth configuration
 #ALBY_OAUTH_CLIENT_SECRET=

--- a/api/models.go
+++ b/api/models.go
@@ -208,6 +208,7 @@ type ListTransactionsResponse = []Transaction
 // TODO: camelCase
 type Transaction struct {
 	Type            string      `json:"type"`
+	State           string      `json:"state"`
 	Invoice         string      `json:"invoice"`
 	Description     string      `json:"description"`
 	DescriptionHash string      `json:"descriptionHash"`

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/getAlby/hub/logger"
@@ -38,7 +39,7 @@ func (api *api) ListTransactions(ctx context.Context, limit uint64, offset uint6
 	if api.svc.GetLNClient() == nil {
 		return nil, errors.New("LNClient not started")
 	}
-	transactions, err := api.svc.GetTransactionsService().ListTransactions(ctx, 0, 0, limit, offset, false, nil, api.svc.GetLNClient(), nil)
+	transactions, err := api.svc.GetTransactionsService().ListTransactions(ctx, 0, 0, limit, offset, true, false, nil, api.svc.GetLNClient(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -99,6 +100,7 @@ func toApiTransaction(transaction *transactions.Transaction) *Transaction {
 
 	return &Transaction{
 		Type:            transaction.Type,
+		State:           strings.ToLower(transaction.State),
 		Invoice:         transaction.PaymentRequest,
 		Description:     transaction.Description,
 		DescriptionHash: transaction.DescriptionHash,

--- a/config/models.go
+++ b/config/models.go
@@ -41,6 +41,7 @@ type AppConfig struct {
 	DdProfilerEnabled     bool   `envconfig:"DD_PROFILER_ENABLED" default:"false"`
 	EnableAdvancedSetup   bool   `envconfig:"ENABLE_ADVANCED_SETUP" default:"true"`
 	AutoUnlockPassword    string `envconfig:"AUTO_UNLOCK_PASSWORD"`
+	LogDBQueries          bool   `envconfig:"LOG_DB_QUERIES" default:"false"`
 }
 
 func (c *AppConfig) IsDefaultClientId() bool {

--- a/db/db.go
+++ b/db/db.go
@@ -7,11 +7,18 @@ import (
 	"github.com/getAlby/hub/logger"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	gorm_logger "gorm.io/gorm/logger"
 )
 
-func NewDB(uri string) (*gorm.DB, error) {
+func NewDB(uri string, logDBQueries bool) (*gorm.DB, error) {
+
+	config := &gorm.Config{}
+	if logDBQueries {
+		config.Logger = gorm_logger.Default.LogMode(gorm_logger.Info)
+	}
+
 	// avoid SQLITE_BUSY errors with _txlock=IMMEDIATE
-	gormDB, err := gorm.Open(sqlite.Open(uri+"?_txlock=IMMEDIATE"), &gorm.Config{})
+	gormDB, err := gorm.Open(sqlite.Open(uri+"?_txlock=IMMEDIATE"), config)
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/src/components/AppAvatar.tsx
+++ b/frontend/src/components/AppAvatar.tsx
@@ -39,7 +39,7 @@ export default function AppAvatar({ app, className }: Props) {
         />
       )}
       {!image && (
-        <span className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-white text-sm font-medium capitalize">
+        <span className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-white text-sm font-medium capitalize pointer-events-none">
           {app.name.charAt(0)}
         </span>
       )}

--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -127,7 +127,7 @@ function TransactionItem({ tx }: Props) {
                   {typeStateText}
                 </span>
                 <span className="text-xs md:text-base truncate text-muted-foreground">
-                  {dayjs(tx.settledAt).fromNow()}
+                  {dayjs(tx.settledAt || tx.createdAt).fromNow()}
                 </span>
               </p>
             </div>
@@ -194,7 +194,7 @@ function TransactionItem({ tx }: Props) {
             <div className="mt-6">
               <p>Date & Time</p>
               <p className="text-muted-foreground">
-                {dayjs(tx.settledAt)
+                {dayjs(tx.settledAt || tx.createdAt)
                   .tz(dayjs.tz.guess())
                   .format("D MMMM YYYY, HH:mm")}
               </p>

--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -69,9 +69,11 @@ function TransactionItem({ tx }: Props) {
           "flex justify-center items-center rounded-full w-10 h-10 md:w-14 md:h-14 relative",
           tx.state === "failed"
             ? "bg-red-100 dark:bg-red-950"
-            : type === "outgoing"
-              ? "bg-orange-100 dark:bg-orange-950"
-              : "bg-green-100 dark:bg-emerald-950"
+            : tx.state === "pending"
+              ? "bg-gray-100 dark:bg-gray-950"
+              : type === "outgoing"
+                ? "bg-orange-100 dark:bg-orange-950"
+                : "bg-green-100 dark:bg-emerald-950"
         )}
       >
         <Icon
@@ -80,9 +82,11 @@ function TransactionItem({ tx }: Props) {
             "w-6 h-6 md:w-8 md:h-8",
             tx.state === "failed"
               ? "stroke-rose-400 dark:stroke-red-600"
-              : type === "outgoing"
-                ? "stroke-orange-400 dark:stroke-amber-600"
-                : "stroke-green-400 dark:stroke-emerald-500"
+              : tx.state === "pending"
+                ? "stroke-gray-400 dark:stroke-gray-600"
+                : type === "outgoing"
+                  ? "stroke-orange-400 dark:stroke-amber-600"
+                  : "stroke-green-400 dark:stroke-emerald-500"
           )}
         />
         {app && (

--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   ChevronUp,
   CopyIcon,
+  XIcon,
 } from "lucide-react";
 import React from "react";
 import { Link } from "react-router-dom";
@@ -38,7 +39,20 @@ function TransactionItem({ tx }: Props) {
   const { toast } = useToast();
   const [showDetails, setShowDetails] = React.useState(false);
   const type = tx.type;
-  const Icon = tx.type == "outgoing" ? ArrowUpIcon : ArrowDownIcon;
+  const typeStateText =
+    type == "incoming"
+      ? "Received"
+      : tx.state === "settled" // we only fetch settled incoming payments
+        ? "Sent"
+        : tx.state === "pending"
+          ? "Sending"
+          : "Failed";
+  const Icon =
+    tx.state === "failed"
+      ? XIcon
+      : tx.type == "outgoing"
+        ? ArrowUpIcon
+        : ArrowDownIcon;
   const app =
     tx.appId !== undefined
       ? apps?.find((app) => app.id === tx.appId)
@@ -47,6 +61,44 @@ function TransactionItem({ tx }: Props) {
   const copy = (text: string) => {
     copyToClipboard(text, toast);
   };
+
+  const typeStateIcon = (
+    <div className="flex items-center">
+      <div
+        className={cn(
+          "flex justify-center items-center rounded-full w-10 h-10 md:w-14 md:h-14 relative",
+          tx.state === "failed"
+            ? "bg-red-100 dark:bg-red-950"
+            : type === "outgoing"
+              ? "bg-orange-100 dark:bg-orange-950"
+              : "bg-green-100 dark:bg-emerald-950"
+        )}
+      >
+        <Icon
+          strokeWidth={3}
+          className={cn(
+            "w-6 h-6 md:w-8 md:h-8",
+            tx.state === "failed"
+              ? "stroke-rose-400 dark:stroke-red-600"
+              : type === "outgoing"
+                ? "stroke-orange-400 dark:stroke-amber-600"
+                : "stroke-green-400 dark:stroke-emerald-500"
+          )}
+        />
+        {app && (
+          <div
+            className="absolute -bottom-1 -right-1"
+            title={`${typeStateText} via ${app.name === "getalby.com" ? "Alby Account" : app.name}`}
+          >
+            <AppAvatar
+              app={app}
+              className="border-none p-0 rounded-full w-[18px] h-[18px] md:w-6 md:h-6 shadow-sm"
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
 
   return (
     <Dialog
@@ -57,43 +109,18 @@ function TransactionItem({ tx }: Props) {
       }}
     >
       <DialogTrigger className="p-3 mb-4 hover:bg-muted/50 data-[state=selected]:bg-muted cursor-pointer rounded-md slashed-zero transaction sensitive">
-        <div className="flex gap-3">
-          <div className="flex items-center">
-            <div
-              className={cn(
-                "flex justify-center items-center rounded-full w-10 h-10 md:w-14 md:h-14 relative",
-                type === "outgoing"
-                  ? "bg-orange-100 dark:bg-orange-950"
-                  : "bg-green-100 dark:bg-emerald-950"
-              )}
-            >
-              <Icon
-                strokeWidth={3}
-                className={cn(
-                  "w-6 h-6 md:w-8 md:h-8",
-                  type === "outgoing"
-                    ? "stroke-orange-400 dark:stroke-amber-600"
-                    : "stroke-green-400 dark:stroke-emerald-500"
-                )}
-              />
-              {app && (
-                <div
-                  className="absolute -bottom-1 -right-1"
-                  title={`${type == "incoming" ? "Received" : "Sent"} via ${app.name === "getalby.com" ? "Alby Account" : app.name}`}
-                >
-                  <AppAvatar
-                    app={app}
-                    className="border-none p-0 rounded-full w-[18px] h-[18px] md:w-6 md:h-6 shadow-sm"
-                  />
-                </div>
-              )}
-            </div>
-          </div>
+        <div
+          className={cn(
+            "flex gap-3",
+            tx.state === "pending" && "animate-pulse"
+          )}
+        >
+          {typeStateIcon}
           <div className="overflow-hidden mr-3 max-w-full text-left flex flex-col items-start justify-center">
             <div>
               <p className="flex items-center gap-2 truncate">
                 <span className="md:text-xl font-semibold">
-                  {type == "incoming" ? "Received" : "Sent"}
+                  {typeStateText}
                 </span>
                 <span className="text-xs md:text-base truncate text-muted-foreground">
                   {dayjs(tx.settledAt).fromNow()}
@@ -132,50 +159,31 @@ function TransactionItem({ tx }: Props) {
       </DialogTrigger>
       <DialogContent className="slashed-zero">
         <DialogHeader>
-          <DialogTitle>{`${type == "outgoing" ? "Sent" : "Received"} Bitcoin`}</DialogTitle>
+          <DialogTitle
+            className={cn(tx.state === "pending" && "animate-pulse")}
+          >{`${typeStateText} Bitcoin Payment`}</DialogTitle>
           <DialogDescription className="text-start text-foreground">
-            <div className="flex items-center mt-6">
-              <div
-                className={cn(
-                  "flex justify-center items-center rounded-full w-10 h-10 md:w-14 md:h-14",
-                  type === "outgoing"
-                    ? "bg-orange-100 dark:bg-orange-950"
-                    : "bg-green-100 dark:bg-emerald-950"
-                )}
-              >
-                <Icon
-                  strokeWidth={3}
-                  className={cn(
-                    "w-6 h-6 md:w-8 md:h-8",
-                    type === "outgoing"
-                      ? "stroke-orange-400 dark:stroke-amber-600"
-                      : "stroke-green-400 dark:stroke-emerald-500"
-                  )}
-                />
-              </div>
+            <div
+              className={cn(
+                "flex items-center mt-6",
+                tx.state === "pending" && "animate-pulse"
+              )}
+            >
+              {typeStateIcon}
               <div className="ml-4">
                 <p className="text-xl md:text-2xl font-semibold">
                   {new Intl.NumberFormat().format(Math.floor(tx.amount / 1000))}{" "}
                   {Math.floor(tx.amount / 1000) == 1 ? "sat" : "sats"}
                 </p>
-                {/* <p className="text-sm md:text-base text-muted-foreground">
-                Fiat Amount
-              </p> */}
               </div>
             </div>
             {app && (
               <div className="mt-8">
                 <p>App</p>
                 <Link to={`/apps/${app.nostrPubkey}`}>
-                  <div className="flex items-center justify-start gap-1 mt-1">
-                    <AppAvatar
-                      app={app}
-                      className="border-none p-0 rounded-full w-6 h-6"
-                    />
-                    <p className="text-muted-foreground">
-                      {app.name === "getalby.com" ? "Alby Account" : app.name}
-                    </p>
-                  </div>
+                  <p className="font-semibold">
+                    {app.name === "getalby.com" ? "Alby Account" : app.name}
+                  </p>
                 </Link>
               </div>
             )}

--- a/frontend/src/components/layouts/SendLayout.tsx
+++ b/frontend/src/components/layouts/SendLayout.tsx
@@ -1,17 +1,22 @@
-import { ArrowUp } from "lucide-react";
+import { ArrowUp, InfoIcon } from "lucide-react";
 import { Outlet } from "react-router-dom";
 import AppHeader from "src/components/AppHeader";
 import BalanceCard from "src/components/BalanceCard";
 import Loading from "src/components/Loading";
 import { useBalances } from "src/hooks/useBalances";
 import { useChannels } from "src/hooks/useChannels";
+import { useTransactions } from "src/hooks/useTransactions";
 
+import dayjs from "dayjs";
+import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
+import { LinkButton } from "src/components/ui/button";
 import { useInfo } from "src/hooks/useInfo";
 
 export default function Send() {
   const { hasChannelManagement } = useInfo();
   const { data: balances } = useBalances();
   const { data: channels } = useChannels();
+  const { data: transactions } = useTransactions();
 
   if (!balances || !channels) {
     return <Loading />;
@@ -23,6 +28,26 @@ export default function Send() {
         title="Send"
         description="Pay a lightning invoice created by any bitcoin lightning wallet"
       />
+      {transactions?.some(
+        (tx) =>
+          tx.state === "pending" &&
+          dayjs().diff(dayjs(tx.createdAt)) <
+            1000 * 60 * 60 * 24 /* payment pending in last 24h */
+        /* TODO: remove diff check when expired transactions are marked as failed */
+      ) && (
+        <Alert>
+          <InfoIcon className="h-4 w-4" />
+          <AlertTitle>Pending Payment</AlertTitle>
+          <AlertDescription>
+            <div className="mb-2">
+              You have one or more payments that have not settled.
+            </div>
+            <LinkButton to={"/wallet"} size={"sm"}>
+              View Payments
+            </LinkButton>
+          </AlertDescription>
+        </Alert>
+      )}
       <div className="flex gap-12 w-full">
         <div className="w-full max-w-lg">
           <Outlet />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -390,6 +390,7 @@ export type BalancesResponse = {
 
 export type Transaction = {
   type: "incoming" | "outgoing";
+  state: "settled" | "pending" | "failed";
   appId: number | undefined;
   invoice: string;
   description: string;

--- a/nip47/controllers/list_transactions_controller.go
+++ b/nip47/controllers/list_transactions_controller.go
@@ -48,7 +48,8 @@ func (controller *nip47Controller) HandleListTransactionsEvent(ctx context.Conte
 		transactionType = &listParams.Type
 	}
 
-	dbTransactions, err := controller.transactionsService.ListTransactions(ctx, listParams.From, listParams.Until, limit, listParams.Offset, listParams.Unpaid, transactionType, controller.lnClient, &appId)
+	// TODO: listParams.Unpaid needs to be updated to support ability to fetch only unpaid outgoing transactions
+	dbTransactions, err := controller.transactionsService.ListTransactions(ctx, listParams.From, listParams.Until, limit, listParams.Offset, listParams.Unpaid, listParams.Unpaid, transactionType, controller.lnClient, &appId)
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
 			"params":           listParams,

--- a/nip47/controllers/list_transactions_controller_test.go
+++ b/nip47/controllers/list_transactions_controller_test.go
@@ -63,7 +63,7 @@ func TestHandleListTransactionsEvent(t *testing.T) {
 			SettledAt:       &settledAt,
 			State:           constants.TRANSACTION_STATE_SETTLED,
 			AppId:           &app.ID,
-			CreatedAt:       time.Now().Add(time.Duration(-i) * time.Hour),
+			UpdatedAt:       time.Now().Add(time.Duration(-i) * time.Hour),
 		}).Error
 		assert.NoError(t, err)
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -80,7 +80,7 @@ func NewService(ctx context.Context) (*service, error) {
 		}
 	}
 
-	gormDB, err := db.NewDB(appConfig.DatabaseUri)
+	gormDB, err := db.NewDB(appConfig.DatabaseUri, appConfig.LogDBQueries)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/test_service.go
+++ b/tests/test_service.go
@@ -17,7 +17,7 @@ import (
 const testDB = "test.db"
 
 func CreateTestService() (svc *TestService, err error) {
-	gormDb, err := db.NewDB(testDB)
+	gormDb, err := db.NewDB(testDB, true)
 	if err != nil {
 		return nil, err
 	}

--- a/transactions/list_transactions_test.go
+++ b/transactions/list_transactions_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestListTransactions(t *testing.T) {
+func TestListTransactions_Paid(t *testing.T) {
 	ctx := context.TODO()
 
 	defer tests.RemoveTestService()
@@ -35,10 +35,18 @@ func TestListTransactions(t *testing.T) {
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
 	})
+	svc.DB.Create(&db.Transaction{
+		State:          constants.TRANSACTION_STATE_PENDING,
+		Type:           constants.TRANSACTION_TYPE_OUTGOING,
+		PaymentRequest: tests.MockLNClientTransaction.Invoice,
+		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
+		Preimage:       &mockPreimage,
+		AmountMsat:     123000,
+	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
 
-	incomingTransactions, err := transactionsService.ListTransactions(ctx, 0, 0, 0, 0, false, nil, svc.LNClient, nil)
+	incomingTransactions, err := transactionsService.ListTransactions(ctx, 0, 0, 0, 0, false, false, nil, svc.LNClient, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(incomingTransactions))
 	assert.Equal(t, uint64(123000), incomingTransactions[0].AmountMsat)
@@ -47,7 +55,7 @@ func TestListTransactions(t *testing.T) {
 	assert.Zero(t, incomingTransactions[0].FeeReserveMsat)
 }
 
-func TestListTransactions_Unsettled(t *testing.T) {
+func TestListTransactions_UnpaidIncoming(t *testing.T) {
 	ctx := context.TODO()
 
 	defer tests.RemoveTestService()
@@ -62,6 +70,16 @@ func TestListTransactions_Unsettled(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
+		CreatedAt:      time.Now(),
+	})
+	svc.DB.Create(&db.Transaction{
+		State:          constants.TRANSACTION_STATE_FAILED,
+		Type:           constants.TRANSACTION_TYPE_INCOMING,
+		PaymentRequest: tests.MockLNClientTransaction.Invoice,
+		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
+		Preimage:       &mockPreimage,
+		AmountMsat:     123000,
+		CreatedAt:      time.Now().Add(-1 * time.Second),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_PENDING,
@@ -70,13 +88,166 @@ func TestListTransactions_Unsettled(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
+		CreatedAt:      time.Now().Add(-2 * time.Second),
+	})
+	svc.DB.Create(&db.Transaction{
+		State:          constants.TRANSACTION_STATE_FAILED,
+		Type:           constants.TRANSACTION_TYPE_OUTGOING,
+		PaymentRequest: tests.MockLNClientTransaction.Invoice,
+		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
+		Preimage:       &mockPreimage,
+		AmountMsat:     123000,
+		CreatedAt:      time.Now().Add(-2 * time.Second),
+	})
+	svc.DB.Create(&db.Transaction{
+		State:          constants.TRANSACTION_STATE_PENDING,
+		Type:           constants.TRANSACTION_TYPE_OUTGOING,
+		PaymentRequest: tests.MockLNClientTransaction.Invoice,
+		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
+		Preimage:       &mockPreimage,
+		AmountMsat:     123000,
+		CreatedAt:      time.Now().Add(-2 * time.Second),
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
 
-	incomingTransactions, err := transactionsService.ListTransactions(ctx, 0, 0, 0, 0, true, nil, svc.LNClient, nil)
+	incomingTransactions, err := transactionsService.ListTransactions(ctx, 0, 0, 0, 0, false, true, nil, svc.LNClient, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(incomingTransactions))
+	assert.Equal(t, 3, len(incomingTransactions))
+	assert.Equal(t, constants.TRANSACTION_STATE_SETTLED, incomingTransactions[0].State)
+	assert.Equal(t, constants.TRANSACTION_STATE_FAILED, incomingTransactions[1].State)
+	assert.Equal(t, constants.TRANSACTION_STATE_PENDING, incomingTransactions[2].State)
+	for _, transaction := range incomingTransactions {
+		assert.Equal(t, constants.TRANSACTION_TYPE_INCOMING, transaction.Type)
+	}
+}
+
+func TestListTransactions_UnpaidOutgoing(t *testing.T) {
+	ctx := context.TODO()
+
+	defer tests.RemoveTestService()
+	svc, err := tests.CreateTestService()
+	assert.NoError(t, err)
+
+	mockPreimage := tests.MockLNClientTransaction.Preimage
+	svc.DB.Create(&db.Transaction{
+		State:          constants.TRANSACTION_STATE_SETTLED,
+		Type:           constants.TRANSACTION_TYPE_OUTGOING,
+		PaymentRequest: tests.MockLNClientTransaction.Invoice,
+		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
+		Preimage:       &mockPreimage,
+		AmountMsat:     123000,
+		CreatedAt:      time.Now(),
+	})
+	svc.DB.Create(&db.Transaction{
+		State:          constants.TRANSACTION_STATE_FAILED,
+		Type:           constants.TRANSACTION_TYPE_OUTGOING,
+		PaymentRequest: tests.MockLNClientTransaction.Invoice,
+		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
+		Preimage:       &mockPreimage,
+		AmountMsat:     123000,
+		CreatedAt:      time.Now().Add(-1 * time.Second),
+	})
+	svc.DB.Create(&db.Transaction{
+		State:          constants.TRANSACTION_STATE_PENDING,
+		Type:           constants.TRANSACTION_TYPE_OUTGOING,
+		PaymentRequest: tests.MockLNClientTransaction.Invoice,
+		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
+		Preimage:       &mockPreimage,
+		AmountMsat:     123000,
+		CreatedAt:      time.Now().Add(-2 * time.Second),
+	})
+	svc.DB.Create(&db.Transaction{
+		State:          constants.TRANSACTION_STATE_FAILED,
+		Type:           constants.TRANSACTION_TYPE_INCOMING,
+		PaymentRequest: tests.MockLNClientTransaction.Invoice,
+		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
+		Preimage:       &mockPreimage,
+		AmountMsat:     123000,
+		CreatedAt:      time.Now().Add(-2 * time.Second),
+	})
+	svc.DB.Create(&db.Transaction{
+		State:          constants.TRANSACTION_STATE_PENDING,
+		Type:           constants.TRANSACTION_TYPE_INCOMING,
+		PaymentRequest: tests.MockLNClientTransaction.Invoice,
+		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
+		Preimage:       &mockPreimage,
+		AmountMsat:     123000,
+		CreatedAt:      time.Now().Add(-2 * time.Second),
+	})
+
+	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
+
+	outgoingTransactions, err := transactionsService.ListTransactions(ctx, 0, 0, 0, 0, true, false, nil, svc.LNClient, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(outgoingTransactions))
+	assert.Equal(t, constants.TRANSACTION_STATE_SETTLED, outgoingTransactions[0].State)
+	assert.Equal(t, constants.TRANSACTION_STATE_FAILED, outgoingTransactions[1].State)
+	assert.Equal(t, constants.TRANSACTION_STATE_PENDING, outgoingTransactions[2].State)
+	for _, transaction := range outgoingTransactions {
+		assert.Equal(t, constants.TRANSACTION_TYPE_OUTGOING, transaction.Type)
+	}
+}
+
+func TestListTransactions_Unpaid(t *testing.T) {
+	ctx := context.TODO()
+
+	defer tests.RemoveTestService()
+	svc, err := tests.CreateTestService()
+	assert.NoError(t, err)
+
+	mockPreimage := tests.MockLNClientTransaction.Preimage
+	svc.DB.Create(&db.Transaction{
+		State:          constants.TRANSACTION_STATE_SETTLED,
+		Type:           constants.TRANSACTION_TYPE_OUTGOING,
+		PaymentRequest: tests.MockLNClientTransaction.Invoice,
+		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
+		Preimage:       &mockPreimage,
+		AmountMsat:     123000,
+		CreatedAt:      time.Now(),
+	})
+	svc.DB.Create(&db.Transaction{
+		State:          constants.TRANSACTION_STATE_FAILED,
+		Type:           constants.TRANSACTION_TYPE_OUTGOING,
+		PaymentRequest: tests.MockLNClientTransaction.Invoice,
+		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
+		Preimage:       &mockPreimage,
+		AmountMsat:     123000,
+		CreatedAt:      time.Now().Add(-1 * time.Second),
+	})
+	svc.DB.Create(&db.Transaction{
+		State:          constants.TRANSACTION_STATE_PENDING,
+		Type:           constants.TRANSACTION_TYPE_OUTGOING,
+		PaymentRequest: tests.MockLNClientTransaction.Invoice,
+		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
+		Preimage:       &mockPreimage,
+		AmountMsat:     123000,
+		CreatedAt:      time.Now().Add(-2 * time.Second),
+	})
+	svc.DB.Create(&db.Transaction{
+		State:          constants.TRANSACTION_STATE_FAILED,
+		Type:           constants.TRANSACTION_TYPE_INCOMING,
+		PaymentRequest: tests.MockLNClientTransaction.Invoice,
+		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
+		Preimage:       &mockPreimage,
+		AmountMsat:     123000,
+		CreatedAt:      time.Now().Add(-2 * time.Second),
+	})
+	svc.DB.Create(&db.Transaction{
+		State:          constants.TRANSACTION_STATE_PENDING,
+		Type:           constants.TRANSACTION_TYPE_INCOMING,
+		PaymentRequest: tests.MockLNClientTransaction.Invoice,
+		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
+		Preimage:       &mockPreimage,
+		AmountMsat:     123000,
+		CreatedAt:      time.Now().Add(-2 * time.Second),
+	})
+
+	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
+
+	outgoingTransactions, err := transactionsService.ListTransactions(ctx, 0, 0, 0, 0, true, true, nil, svc.LNClient, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, len(outgoingTransactions))
 }
 
 func TestListTransactions_Limit(t *testing.T) {
@@ -109,7 +280,7 @@ func TestListTransactions_Limit(t *testing.T) {
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
 
-	incomingTransactions, err := transactionsService.ListTransactions(ctx, 0, 0, 1, 0, false, nil, svc.LNClient, nil)
+	incomingTransactions, err := transactionsService.ListTransactions(ctx, 0, 0, 1, 0, false, false, nil, svc.LNClient, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(incomingTransactions))
 	assert.Equal(t, "first", incomingTransactions[0].Description)
@@ -165,7 +336,7 @@ func TestListTransactions_Offset(t *testing.T) {
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
 
-	incomingTransactions, err := transactionsService.ListTransactions(ctx, 0, 0, 1, 2, false, nil, svc.LNClient, nil)
+	incomingTransactions, err := transactionsService.ListTransactions(ctx, 0, 0, 1, 2, false, false, nil, svc.LNClient, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(incomingTransactions))
 	assert.Equal(t, "third", incomingTransactions[0].Description)
@@ -211,7 +382,7 @@ func TestListTransactions_FromUntil(t *testing.T) {
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
 
-	incomingTransactions, err := transactionsService.ListTransactions(ctx, uint64(time.Now().Add(4*time.Minute).Unix()), uint64(time.Now().Add(6*time.Minute).Unix()), 0, 0, false, nil, svc.LNClient, nil)
+	incomingTransactions, err := transactionsService.ListTransactions(ctx, uint64(time.Now().Add(4*time.Minute).Unix()), uint64(time.Now().Add(6*time.Minute).Unix()), 0, 0, false, false, nil, svc.LNClient, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(incomingTransactions))
 	assert.Equal(t, "second", incomingTransactions[0].Description)

--- a/transactions/list_transactions_test.go
+++ b/transactions/list_transactions_test.go
@@ -70,7 +70,7 @@ func TestListTransactions_UnpaidIncoming(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
-		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_FAILED,
@@ -79,7 +79,7 @@ func TestListTransactions_UnpaidIncoming(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
-		CreatedAt:      time.Now().Add(-1 * time.Second),
+		UpdatedAt:      time.Now().Add(-1 * time.Second),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_PENDING,
@@ -88,7 +88,7 @@ func TestListTransactions_UnpaidIncoming(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
-		CreatedAt:      time.Now().Add(-2 * time.Second),
+		UpdatedAt:      time.Now().Add(-2 * time.Second),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_FAILED,
@@ -97,7 +97,7 @@ func TestListTransactions_UnpaidIncoming(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
-		CreatedAt:      time.Now().Add(-2 * time.Second),
+		UpdatedAt:      time.Now().Add(-2 * time.Second),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_PENDING,
@@ -106,7 +106,7 @@ func TestListTransactions_UnpaidIncoming(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
-		CreatedAt:      time.Now().Add(-2 * time.Second),
+		UpdatedAt:      time.Now().Add(-2 * time.Second),
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
@@ -137,7 +137,7 @@ func TestListTransactions_UnpaidOutgoing(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
-		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_FAILED,
@@ -146,7 +146,7 @@ func TestListTransactions_UnpaidOutgoing(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
-		CreatedAt:      time.Now().Add(-1 * time.Second),
+		UpdatedAt:      time.Now().Add(-1 * time.Second),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_PENDING,
@@ -155,7 +155,7 @@ func TestListTransactions_UnpaidOutgoing(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
-		CreatedAt:      time.Now().Add(-2 * time.Second),
+		UpdatedAt:      time.Now().Add(-2 * time.Second),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_FAILED,
@@ -164,7 +164,7 @@ func TestListTransactions_UnpaidOutgoing(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
-		CreatedAt:      time.Now().Add(-2 * time.Second),
+		UpdatedAt:      time.Now().Add(-2 * time.Second),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_PENDING,
@@ -173,7 +173,7 @@ func TestListTransactions_UnpaidOutgoing(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
-		CreatedAt:      time.Now().Add(-2 * time.Second),
+		UpdatedAt:      time.Now().Add(-2 * time.Second),
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
@@ -204,7 +204,7 @@ func TestListTransactions_Unpaid(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
-		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_FAILED,
@@ -213,7 +213,7 @@ func TestListTransactions_Unpaid(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
-		CreatedAt:      time.Now().Add(-1 * time.Second),
+		UpdatedAt:      time.Now().Add(-1 * time.Second),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_PENDING,
@@ -222,7 +222,7 @@ func TestListTransactions_Unpaid(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
-		CreatedAt:      time.Now().Add(-2 * time.Second),
+		UpdatedAt:      time.Now().Add(-2 * time.Second),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_FAILED,
@@ -231,7 +231,7 @@ func TestListTransactions_Unpaid(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
-		CreatedAt:      time.Now().Add(-2 * time.Second),
+		UpdatedAt:      time.Now().Add(-2 * time.Second),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_PENDING,
@@ -240,7 +240,7 @@ func TestListTransactions_Unpaid(t *testing.T) {
 		PaymentHash:    tests.MockLNClientTransaction.PaymentHash,
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
-		CreatedAt:      time.Now().Add(-2 * time.Second),
+		UpdatedAt:      time.Now().Add(-2 * time.Second),
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
@@ -266,7 +266,7 @@ func TestListTransactions_Limit(t *testing.T) {
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
 		Description:    "first",
-		CreatedAt:      time.Now().Add(1 * time.Minute),
+		UpdatedAt:      time.Now().Add(1 * time.Minute),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_SETTLED,
@@ -302,7 +302,7 @@ func TestListTransactions_Offset(t *testing.T) {
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
 		Description:    "first",
-		CreatedAt:      time.Now().Add(3 * time.Minute),
+		UpdatedAt:      time.Now().Add(3 * time.Minute),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_SETTLED,
@@ -312,7 +312,7 @@ func TestListTransactions_Offset(t *testing.T) {
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
 		Description:    "second",
-		CreatedAt:      time.Now().Add(2 * time.Minute),
+		UpdatedAt:      time.Now().Add(2 * time.Minute),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_SETTLED,
@@ -322,7 +322,7 @@ func TestListTransactions_Offset(t *testing.T) {
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
 		Description:    "third",
-		CreatedAt:      time.Now().Add(1 * time.Minute),
+		UpdatedAt:      time.Now().Add(1 * time.Minute),
 	})
 	svc.DB.Create(&db.Transaction{
 		State:          constants.TRANSACTION_STATE_SETTLED,
@@ -358,6 +358,7 @@ func TestListTransactions_FromUntil(t *testing.T) {
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
 		Description:    "first",
+		UpdatedAt:      time.Now().Add(10 * time.Minute),
 		CreatedAt:      time.Now().Add(10 * time.Minute),
 	})
 	svc.DB.Create(&db.Transaction{
@@ -368,6 +369,7 @@ func TestListTransactions_FromUntil(t *testing.T) {
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
 		Description:    "second",
+		UpdatedAt:      time.Now().Add(5 * time.Minute),
 		CreatedAt:      time.Now().Add(5 * time.Minute),
 	})
 	svc.DB.Create(&db.Transaction{
@@ -378,6 +380,8 @@ func TestListTransactions_FromUntil(t *testing.T) {
 		Preimage:       &mockPreimage,
 		AmountMsat:     123000,
 		Description:    "third",
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)

--- a/transactions/transactions_service.go
+++ b/transactions/transactions_service.go
@@ -35,7 +35,7 @@ type TransactionsService interface {
 	events.EventSubscriber
 	MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error)
 	LookupTransaction(ctx context.Context, paymentHash string, transactionType *string, lnClient lnclient.LNClient, appId *uint) (*Transaction, error)
-	ListTransactions(ctx context.Context, from, until, limit, offset uint64, unpaid bool, transactionType *string, lnClient lnclient.LNClient, appId *uint) (transactions []Transaction, err error)
+	ListTransactions(ctx context.Context, from, until, limit, offset uint64, unpaidOutgoing bool, unpaidIncoming bool, transactionType *string, lnClient lnclient.LNClient, appId *uint) (transactions []Transaction, err error)
 	SendPaymentSync(ctx context.Context, payReq string, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error)
 	SendKeysend(ctx context.Context, amount uint64, destination string, customRecords []lnclient.TLVRecord, preimage string, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error)
 }
@@ -474,16 +474,21 @@ func (svc *transactionsService) LookupTransaction(ctx context.Context, paymentHa
 	return &transaction, nil
 }
 
-func (svc *transactionsService) ListTransactions(ctx context.Context, from, until, limit, offset uint64, unpaid bool, transactionType *string, lnClient lnclient.LNClient, appId *uint) (transactions []Transaction, err error) {
+func (svc *transactionsService) ListTransactions(ctx context.Context, from, until, limit, offset uint64, unpaidOutgoing bool, unpaidIncoming bool, transactionType *string, lnClient lnclient.LNClient, appId *uint) (transactions []Transaction, err error) {
 	svc.checkUnsettledTransactions(ctx, lnClient)
 
-	// TODO: add other filtering and pagination
 	tx := svc.db
 
 	tx = tx.Order("settled_at desc, created_at desc")
 
-	if !unpaid {
+	if !unpaidOutgoing && !unpaidIncoming {
 		tx = tx.Where("state == ?", constants.TRANSACTION_STATE_SETTLED)
+	} else if unpaidOutgoing && !unpaidIncoming {
+		tx = tx.Where("state == ?", constants.TRANSACTION_STATE_SETTLED).
+			Or("type == ?", constants.TRANSACTION_TYPE_OUTGOING)
+	} else if unpaidIncoming && !unpaidOutgoing {
+		tx = tx.Where("state == ?", constants.TRANSACTION_STATE_SETTLED).
+			Or("type == ?", constants.TRANSACTION_TYPE_INCOMING)
 	}
 
 	if transactionType != nil {


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/426

Failed and unsettled outgoing transactions are now shown in the transaction list. Pending transactions have a pulse animation.

I also added an alert on the send page if the user has any pending payments, to avoid the chance they accidentally try pay again.

Note: Listing transactions is now ordered by `updated_at` rather than `settled_at, created_at`

![image](https://github.com/user-attachments/assets/a1c41798-35e3-45d5-9f29-1b324eb4019b)

![image](https://github.com/user-attachments/assets/1e72590c-7662-4da2-8cd5-d02a35c28208)

![image](https://github.com/user-attachments/assets/9c0d019d-884d-4858-8cfc-9dbab6e791a3)

![image](https://github.com/user-attachments/assets/22bc063d-3cf1-4dae-af5e-ddb8f827b233)

![image](https://github.com/user-attachments/assets/8335fd56-e6e0-449c-96b1-d15690c782ab)

![image](https://github.com/user-attachments/assets/b42f1e72-971e-4d26-87bb-c12047b52ffd)

![image](https://github.com/user-attachments/assets/aa477556-ce61-4d42-8c2e-11d1a4c4b7e9)


TODOs:
- [x] fix ordering (settled at is an issue for unpaid payments)
- [ ] should transactions that have expired (unsettled after expiration of the invoice) be updated to failed?
- [ ] support params for NIP-47 so Alby Go can do the same