### PR TITLE
feat: disable public channel checkbox for channel partners that do not support public channels

### DIFF
--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -909,16 +909,6 @@ func (svc *albyOAuthService) GetChannelPeerSuggestions(ctx context.Context) ([]C
 		return nil, err
 	}
 
-	// TODO: remove once alby API is updated
-	for i, suggestion := range suggestions {
-		if suggestion.BrokenLspType != "" {
-			suggestions[i].LspType = suggestion.BrokenLspType
-		}
-		if suggestion.BrokenLspUrl != "" {
-			suggestions[i].LspUrl = suggestion.BrokenLspUrl
-		}
-	}
-
 	logger.Logger.WithFields(logrus.Fields{"channel_suggestions": suggestions}).Debug("Alby channel peer suggestions response")
 	return suggestions, nil
 }

--- a/alby/models.go
+++ b/alby/models.go
@@ -80,18 +80,19 @@ type AlbyBalance struct {
 }
 
 type ChannelPeerSuggestion struct {
-	Network            string `json:"network"`
-	PaymentMethod      string `json:"paymentMethod"`
-	Pubkey             string `json:"pubkey"`
-	Host               string `json:"host"`
-	MinimumChannelSize uint64 `json:"minimumChannelSize"`
-	MaximumChannelSize uint64 `json:"maximumChannelSize"`
-	Name               string `json:"name"`
-	Image              string `json:"image"`
-	BrokenLspUrl       string `json:"lsp_url"`
-	BrokenLspType      string `json:"lsp_type"`
-	LspUrl             string `json:"lspUrl"`
-	LspType            string `json:"lspType"`
+	Network               string `json:"network"`
+	PaymentMethod         string `json:"paymentMethod"`
+	Pubkey                string `json:"pubkey"`
+	Host                  string `json:"host"`
+	MinimumChannelSize    uint64 `json:"minimumChannelSize"`
+	MaximumChannelSize    uint64 `json:"maximumChannelSize"`
+	Name                  string `json:"name"`
+	Image                 string `json:"image"`
+	BrokenLspUrl          string `json:"lsp_url"`
+	BrokenLspType         string `json:"lsp_type"`
+	LspUrl                string `json:"lspUrl"`
+	LspType               string `json:"lspType"`
+	PublicChannelsAllowed bool   `json:"publicChannelsAllowed"`
 }
 
 type ErrorResponse struct {

--- a/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
@@ -337,6 +337,12 @@ function NewChannelInternal({
                   defaultChecked={order.isPublic}
                   onCheckedChange={() => setPublic(!order.isPublic)}
                   className="mr-2"
+                  disabled={selectedPeer && !selectedPeer.publicChannelsAllowed}
+                  title={
+                    selectedPeer && !selectedPeer.publicChannelsAllowed
+                      ? "This channel partner does not support public channels."
+                      : undefined
+                  }
                 />
                 <div className="grid gap-1.5 leading-none">
                   <Label

--- a/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
@@ -79,6 +79,7 @@ function NewChannelInternal({ network }: { network: Network }) {
       pubkey: "",
       host: "",
       image: "",
+      publicChannelsAllowed: true,
     };
     return _channelPeerSuggestions
       ? [
@@ -369,6 +370,12 @@ function NewChannelInternal({ network }: { network: Network }) {
                   defaultChecked={order.isPublic}
                   onCheckedChange={() => setPublic(!order.isPublic)}
                   className="mr-2"
+                  disabled={selectedPeer && !selectedPeer.publicChannelsAllowed}
+                  title={
+                    selectedPeer && !selectedPeer.publicChannelsAllowed
+                      ? "This channel partner does not support public channels."
+                      : undefined
+                  }
                 />
                 <div className="grid gap-1.5 leading-none">
                   <Label

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -306,6 +306,7 @@ export type RecommendedChannelPeer = {
   name: string;
   minimumChannelSize: number;
   maximumChannelSize: number;
+  publicChannelsAllowed: boolean;
 } & (
   | {
       paymentMethod: "onchain";


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/677

The checkbox is disabled, with a message when you hover over it. I think this might be sufficient for now.