### PR TITLE
feat: include LDK channel monitors in static channel backups

### DIFF
--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -706,8 +706,8 @@ func (svc *albyOAuthService) backupChannels(ctx context.Context, event *events.E
 		Data        string `json:"data"`
 	}
 
-	channelsData := bytes.NewBuffer([]byte{})
-	err = json.NewEncoder(channelsData).Encode(bkpEvent.Channels)
+	eventData := bytes.NewBuffer([]byte{})
+	err = json.NewEncoder(eventData).Encode(bkpEvent)
 	if err != nil {
 		return fmt.Errorf("failed to encode channels backup data:  %w", err)
 	}
@@ -718,7 +718,7 @@ func (svc *albyOAuthService) backupChannels(ctx context.Context, event *events.E
 		return fmt.Errorf("failed to fetch encryption key: %w", err)
 	}
 
-	encrypted, err := config.AesGcmEncrypt(channelsData.String(), encryptedMnemonic)
+	encrypted, err := config.AesGcmEncrypt(eventData.String(), encryptedMnemonic)
 	if err != nil {
 		return fmt.Errorf("failed to encrypt channels backup data: %w", err)
 	}

--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -689,7 +689,7 @@ func (svc *albyOAuthService) ConsumeEvent(ctx context.Context, event *events.Eve
 }
 
 func (svc *albyOAuthService) backupChannels(ctx context.Context, event *events.Event) error {
-	bkpEvent, ok := event.Properties.(*events.ChannelBackupEvent)
+	bkpEvent, ok := event.Properties.(*events.StaticChannelsBackupEvent)
 	if !ok {
 		return fmt.Errorf("invalid nwc_backup_channels event properties, could not cast to the expected type: %+v", event.Properties)
 	}

--- a/events/models.go
+++ b/events/models.go
@@ -20,18 +20,18 @@ type Event struct {
 	Properties interface{} `json:"properties,omitempty"`
 }
 
-type ChannelBackupEvent struct {
-	NodeID   string                 `json:"node_id"`
-	Channels []ChannelBackupInfo    `json:"channels"`
-	Monitors []ChannelMonitorBackup `json:"monitors"`
+type StaticChannelsBackupEvent struct {
+	NodeID   string                        `json:"node_id"`
+	Channels []ChannelBackup               `json:"channels"`
+	Monitors []EncodedChannelMonitorBackup `json:"monitors"`
 }
 
-type ChannelMonitorBackup struct {
+type EncodedChannelMonitorBackup struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
 
-type ChannelBackupInfo struct {
+type ChannelBackup struct {
 	ChannelID         string `json:"channel_id"`
 	PeerID            string `json:"peer_id"`
 	PeerSocketAddress string `json:"peer_socket_address"`

--- a/events/models.go
+++ b/events/models.go
@@ -21,6 +21,7 @@ type Event struct {
 }
 
 type ChannelBackupEvent struct {
+	NodeID   string                 `json:"node_id"`
 	Channels []ChannelBackupInfo    `json:"channels"`
 	Monitors []ChannelMonitorBackup `json:"monitors"`
 }
@@ -31,10 +32,10 @@ type ChannelMonitorBackup struct {
 }
 
 type ChannelBackupInfo struct {
-	ChannelID     string `json:"channel_id"`
-	NodeID        string `json:"node_id"`
-	PeerID        string `json:"peer_id"`
-	ChannelSize   uint64 `json:"channel_size"`
-	FundingTxID   string `json:"funding_tx_id"`
-	FundingTxVout uint32 `json:"funding_tx_vout"`
+	ChannelID         string `json:"channel_id"`
+	PeerID            string `json:"peer_id"`
+	PeerSocketAddress string `json:"peer_socket_address"`
+	ChannelSize       uint64 `json:"channel_size"`
+	FundingTxID       string `json:"funding_tx_id"`
+	FundingTxVout     uint32 `json:"funding_tx_vout"`
 }

--- a/events/models.go
+++ b/events/models.go
@@ -21,7 +21,13 @@ type Event struct {
 }
 
 type ChannelBackupEvent struct {
-	Channels []ChannelBackupInfo `json:"channels"`
+	Channels []ChannelBackupInfo    `json:"channels"`
+	Monitors []ChannelMonitorBackup `json:"monitors"`
+}
+
+type ChannelMonitorBackup struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 type ChannelBackupInfo struct {

--- a/frontend/src/components/layouts/SettingsLayout.tsx
+++ b/frontend/src/components/layouts/SettingsLayout.tsx
@@ -101,9 +101,7 @@ export default function SettingsLayout() {
             <MenuItem to="/settings/change-unlock-password">
               Unlock Password
             </MenuItem>
-            {hasMnemonic && (
-              <MenuItem to="/settings/key-backup">Key Backup</MenuItem>
-            )}
+            {hasMnemonic && <MenuItem to="/settings/backup">Backup</MenuItem>}
             {hasNodeBackup && (
               <MenuItem to="/settings/node-backup">Migrate Node</MenuItem>
             )}

--- a/frontend/src/hooks/useOnboardingData.ts
+++ b/frontend/src/hooks/useOnboardingData.ts
@@ -97,7 +97,7 @@ export const useOnboardingData = (): UseOnboardingDataResponse => {
             description:
               "Secure your keys by creating a backup to ensure you don't lose access.",
             checked: hasBackedUp === true,
-            to: "/settings/key-backup",
+            to: "/settings/backup",
           },
         ]
       : []),

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -156,9 +156,9 @@ const routes = [
                 handle: { crumb: () => "Unlock Password" },
               },
               {
-                path: "key-backup",
+                path: "backup",
                 element: <BackupMnemonic />,
-                handle: { crumb: () => "Key Backup" },
+                handle: { crumb: () => "Backup" },
               },
               {
                 path: "node-backup",

--- a/frontend/src/screens/BackupMnemonic.tsx
+++ b/frontend/src/screens/BackupMnemonic.tsx
@@ -137,7 +137,9 @@ export function BackupMnemonic() {
                   <b>
                     Make sure to also backup your data directory as this is
                     required to recover funds on your channels. You can also
-                    connect your Alby Account for automatic backups.
+                    connect your Alby Account for automatic encrypted backups
+                    (you still need your seed and unlock password to decrypt
+                    those).
                   </b>
                 )}
               </span>

--- a/frontend/src/screens/BackupMnemonic.tsx
+++ b/frontend/src/screens/BackupMnemonic.tsx
@@ -26,6 +26,7 @@ export function BackupMnemonic() {
   const [decryptedMnemonic, setDecryptedMnemonic] = React.useState("");
   const [loading, setLoading] = React.useState(false);
   const [backedUp, setIsBackedUp] = useState<boolean>(false);
+  const { data: info } = useInfo();
 
   const onSubmitPassword = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -124,7 +125,21 @@ export function BackupMnemonic() {
               </div>
               <span>
                 Your recovery phrase is a set of 12 words that{" "}
-                <b>backs up your wallet</b>
+                <b>backs up your wallet savings balance</b>.
+                {info?.albyAccountConnected && (
+                  <b>
+                    You also need to make sure you do not forget your unlock
+                    password as this will be used to recover funds from
+                    channels.
+                  </b>
+                )}
+                {!info?.albyAccountConnected && (
+                  <b>
+                    Make sure to also backup your data directory as this is
+                    required to recover funds on your channels. You can also
+                    connect your Alby Account for automatic backups.
+                  </b>
+                )}
               </span>
             </div>
             <div className="flex gap-2 items-center">

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/breez/breez-sdk-go v0.5.2
 	github.com/elnosh/gonuts v0.2.0
 	github.com/getAlby/glalby-go v0.0.0-20240621192717-95673c864d59
-	github.com/getAlby/ldk-node-go v0.0.0-20240815144818-6fa575b0a3f5
+	github.com/getAlby/ldk-node-go v0.0.0-20240924080718-27f0fdd2a75d
 	github.com/go-gormigrate/gormigrate/v2 v2.1.2
 	github.com/labstack/echo/v4 v4.12.0
 	github.com/nbd-wtf/go-nostr v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,8 @@ github.com/getAlby/glalby-go v0.0.0-20240621192717-95673c864d59 h1:fSqdXE9uKhLcO
 github.com/getAlby/glalby-go v0.0.0-20240621192717-95673c864d59/go.mod h1:ViyJvjlvv0GCesTJ7mb3fBo4G+/qsujDAFN90xZ7a9U=
 github.com/getAlby/ldk-node-go v0.0.0-20240815144818-6fa575b0a3f5 h1:FY32CuHXa86wwXfBl+vcscVpwQ8yKhBSaL4ZVhTgfi4=
 github.com/getAlby/ldk-node-go v0.0.0-20240815144818-6fa575b0a3f5/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20240924080718-27f0fdd2a75d h1:scWSwE01B4fKdWmAQClerzSu7Ao691J5HheHdVLI7Tc=
+github.com/getAlby/ldk-node-go v0.0.0-20240924080718-27f0fdd2a75d/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -1441,7 +1441,7 @@ func (ls *LDKService) backupChannels() {
 		})
 	}
 
-	monitors, err := ls.node.GetChannelMonitors()
+	monitors, err := ls.node.GetEncodedChannelMonitors()
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to list channel monitors")
 		return

--- a/lnclient/ldk/ldk_event_broadcaster.go
+++ b/lnclient/ldk/ldk_event_broadcaster.go
@@ -5,8 +5,8 @@ import (
 	"slices"
 	"time"
 
-	//"github.com/getAlby/ldk-node-go/ldk_node"
-	"github.com/getAlby/hub/ldk_node"
+	"github.com/getAlby/ldk-node-go/ldk_node"
+	// "github.com/getAlby/hub/ldk_node"
 	"github.com/getAlby/hub/logger"
 
 	"github.com/sirupsen/logrus"

--- a/lnclient/ldk/ldk_event_broadcaster.go
+++ b/lnclient/ldk/ldk_event_broadcaster.go
@@ -5,8 +5,8 @@ import (
 	"slices"
 	"time"
 
-	"github.com/getAlby/ldk-node-go/ldk_node"
-	// "github.com/getAlby/hub/ldk_node"
+	//"github.com/getAlby/ldk-node-go/ldk_node"
+	"github.com/getAlby/hub/ldk_node"
 	"github.com/getAlby/hub/logger"
 
 	"github.com/sirupsen/logrus"

--- a/service/start.go
+++ b/service/start.go
@@ -179,7 +179,7 @@ func (svc *service) launchLNBackend(ctx context.Context, encryptionKey string) e
 		Mnemonic, _ := svc.cfg.Get("Mnemonic", encryptionKey)
 		LDKWorkdir := path.Join(svc.cfg.GetEnv().Workdir, "ldk")
 
-		lnClient, err = ldk.NewLDKService(ctx, svc.cfg, svc.eventPublisher, Mnemonic, LDKWorkdir, svc.cfg.GetEnv().LDKNetwork)
+		lnClient, err = ldk.NewLDKService(ctx, svc.cfg, svc.eventPublisher, Mnemonic, LDKWorkdir, svc.cfg.GetEnv().LDKNetwork, nil, false)
 	case config.GreenlightBackendType:
 		Mnemonic, _ := svc.cfg.Get("Mnemonic", encryptionKey)
 		GreenlightInviteCode, _ := svc.cfg.Get("GreenlightInviteCode", encryptionKey)


### PR DESCRIPTION
TODO:
- [x] rename "Key Backup" -> "Backup" + tell users to keep the seed safe and also save the data directory (on the cloud this is taken care for you)
- [x] update LDK-node dependency and undo changes to use local LDK-node version
- [ ] add new issue to derive an encryption key from seed instead of using unlock password to recover SCBs
- [ ] add new issue to improve backup pages - one for alby account vs no alby account
- [ ] test decrypting locally the encrypted saved data to getalby.com
- [ ] test LDK-node flow of starting with restored monitors (old channel state)
- [ ] make guide pages on how to do backups