### PR TITLE
chore: hide preimage in failed payment dialog

### DIFF
--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -233,22 +233,24 @@ function TransactionItem({ tx }: Props) {
               {showDetails && (
                 <>
                   {tx.boostagram && <PodcastingInfo boost={tx.boostagram} />}
-                  <div className="mt-6">
-                    <p>Preimage</p>
-                    <div className="flex items-center gap-4">
-                      <p className="text-muted-foreground break-all">
-                        {tx.preimage}
-                      </p>
-                      <CopyIcon
-                        className="cursor-pointer text-muted-foreground w-6 h-6"
-                        onClick={() => {
-                          if (tx.preimage) {
-                            copy(tx.preimage);
-                          }
-                        }}
-                      />
+                  {tx.preimage && (
+                    <div className="mt-6">
+                      <p>Preimage</p>
+                      <div className="flex items-center gap-4">
+                        <p className="text-muted-foreground break-all">
+                          {tx.preimage}
+                        </p>
+                        <CopyIcon
+                          className="cursor-pointer text-muted-foreground w-6 h-6"
+                          onClick={() => {
+                            if (tx.preimage) {
+                              copy(tx.preimage);
+                            }
+                          }}
+                        />
+                      </div>
                     </div>
-                  </div>
+                  )}
                   <div className="mt-6">
                     <p>Hash</p>
                     <div className="flex items-center gap-4">

--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -199,7 +199,7 @@ function TransactionItem({ tx }: Props) {
                   .format("D MMMM YYYY, HH:mm")}
               </p>
             </div>
-            {type == "outgoing" && (
+            {tx.state != "failed" && type == "outgoing" && (
               <div className="mt-6">
                 <p>Fee</p>
                 <p className="text-muted-foreground">


### PR DESCRIPTION
<table>
<tr>
<td>
<h3>Before</h3>
</td>
<td>
<h3>After</h3>
</td>
</tr>
<td>
<img alt="Screenshot 2024-09-25 at 10 22 53 AM" src="https://github.com/user-attachments/assets/001c629d-a39f-46fd-91e6-6c93f6cd2d0a">
</td>
<td>
<img alt="Screenshot 2024-09-25 at 10 23 58 AM" src="https://github.com/user-attachments/assets/cf8ecad9-7137-4f53-8009-dcd3ccdaef66">
</td>
</tr>
</table>