### PR TITLE
fix: version comparision logic

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "canvas-confetti": "^1.9.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "compare-versions": "^6.1.1",
     "date-fns": "^3.6.0",
     "dayjs": "^1.11.10",
     "embla-carousel-react": "^8.0.2",

--- a/frontend/src/components/layouts/AppLayout.tsx
+++ b/frontend/src/components/layouts/AppLayout.tsx
@@ -1,3 +1,4 @@
+import { compare } from "compare-versions";
 import {
   Cable,
   Cloud,
@@ -327,7 +328,7 @@ function AppVersion() {
   const upToDate =
     info.version &&
     info.version.startsWith("v") &&
-    info.version.substring(1) >= albyInfo.hub.latestVersion;
+    compare(info.version.substring(1), albyInfo.hub.latestVersion, ">=");
 
   return (
     <TooltipProvider>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3095,6 +3095,11 @@ compare-func@^2.0.0:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
 
+compare-versions@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.1.tgz#7af3cc1099ba37d244b3145a9af5201b629148a9"
+  integrity sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"


### PR DESCRIPTION
The current Hub won't show 1.10.1 as the new update in the Sidebar because we do a `"1.9.0" >= "1.10.1"` comparsion which results in `true` meaning the current version is wrongly shown as up to date. This fixes the comparision logic by adding the `compareVersions` utils function.

<img width="320" alt="Screenshot 2024-10-03 at 4 12 02 PM" src="https://github.com/user-attachments/assets/ae498eb8-58cb-472d-ab1b-3d731b9a0178">
