### PR TITLE
fix: increase metadata limit

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -34,7 +34,7 @@ const (
 // given a relay limit of 512000 bytes and ideally being able to list 50 transactions,
 // each transaction would have to have a maximum size of 10240
 // accounting for encryption and other metadata in the response, this is set to 2048 characters
-const INVOICE_METADATA_MAX_LENGTH = 2048
+const INVOICE_METADATA_MAX_LENGTH = 4096
 
 // errors used by NIP-47 and the transaction service
 const (

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -31,9 +31,9 @@ const (
 )
 
 // limit encoded metadata length, otherwise relays may have trouble listing multiple transactions
-// given a relay limit of 512000 bytes and ideally being able to list 50 transactions,
-// each transaction would have to have a maximum size of 10240
-// accounting for encryption and other metadata in the response, this is set to 2048 characters
+// given a relay limit of 512000 bytes and ideally being able to list 25 transactions,
+// each transaction would have to have a maximum size of 20480
+// accounting for encryption and other metadata in the response, this is set to 4096 characters
 const INVOICE_METADATA_MAX_LENGTH = 4096
 
 // errors used by NIP-47 and the transaction service

--- a/transactions/make_invoice_test.go
+++ b/transactions/make_invoice_test.go
@@ -3,6 +3,7 @@ package transactions
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -50,7 +51,7 @@ func TestMakeInvoice_MetadataTooLarge(t *testing.T) {
 	transaction, err := transactionsService.MakeInvoice(ctx, 1234, "Hello world", "", 0, metadata, svc.LNClient, nil, nil)
 
 	assert.Error(t, err)
-	assert.Equal(t, "encoded invoice metadata provided is too large. Limit: 2048 Received: 2049", err.Error())
+	assert.Equal(t, fmt.Sprintf("encoded invoice metadata provided is too large. Limit: %d Received: %d", constants.INVOICE_METADATA_MAX_LENGTH, constants.INVOICE_METADATA_MAX_LENGTH+1), err.Error())
 	assert.Nil(t, transaction)
 }
 


### PR DESCRIPTION
Some invoices seem to include quite a lot of metadata. So much, it actually runs into the INVOICE_METADATA_MAX_LENGTH limit. 

We need to find out what metadata clients embed here and why, but in the meantime let's increase the limit to prevent failed payments.