### PR TITLE
fix: add get_info to isolated app permissions

### DIFF
--- a/frontend/src/components/Scopes.tsx
+++ b/frontend/src/components/Scopes.tsx
@@ -79,6 +79,7 @@ const Scopes: React.FC<ScopesProps> = ({
     const isolatedScopes: Scope[] = [
       "pay_invoice",
       "get_balance",
+      "get_info",
       "make_invoice",
       "lookup_invoice",
       "list_transactions",


### PR DESCRIPTION
Adds `get_info` permission to isolated apps, previously created isolated app connections will remain unchanged 