### PR TITLE
fix: remove obsolete mention of pairing secret

### DIFF
--- a/frontend/src/screens/apps/AppCreated.tsx
+++ b/frontend/src/screens/apps/AppCreated.tsx
@@ -184,7 +184,7 @@ export function ConnectAppCard({
         <div>
           <Button onClick={copy} variant="outline">
             <CopyIcon className="w-4 h-4 mr-2" />
-            Copy pairing secret
+            Copy
           </Button>
         </div>
       </CardContent>


### PR DESCRIPTION
New name across NWC apps is "Connection Secret", but since this is obvious on the connect screen anyway I just removed it completely. 