### PR TITLE
fix: do not show duplicated incoming funds from channel closures

### DIFF
--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -318,15 +318,11 @@ export default function Channels() {
                   {new Intl.NumberFormat().format(balances.onchain.spendable)}{" "}
                   sats
                   {balances &&
-                    (balances.onchain.spendable !== balances.onchain.total ||
-                      balances.onchain.pendingBalancesFromChannelClosures >
-                        0) && (
+                    balances.onchain.spendable !== balances.onchain.total && (
                       <p className="text-xs text-muted-foreground animate-pulse">
                         +
                         {new Intl.NumberFormat().format(
-                          balances.onchain.total -
-                            balances.onchain.spendable +
-                            balances.onchain.pendingBalancesFromChannelClosures
+                          balances.onchain.total - balances.onchain.spendable
                         )}{" "}
                         sats incoming
                       </p>
@@ -435,7 +431,9 @@ export default function Channels() {
               balances.onchain.pendingBalancesFromChannelClosures
             )}{" "}
             sats pending from one or more closed channels. Once spendable again
-            these will become available in your savings balance.{" "}
+            these will become available in your savings balance. Funds from
+            channels that were force closed may take up to 2 weeks to become
+            available.{" "}
             <ExternalLink
               to="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/faq-alby-hub/why-was-my-lightning-channel-closed-and-what-to-do-next"
               className="underline"

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -760,6 +760,10 @@ func (svc *LNDService) GetOnchainBalance(ctx context.Context) (*lnclient.Onchain
 		Total:                              int64(balances.TotalBalance),
 		Reserved:                           int64(balances.ReservedBalanceAnchorChan),
 		PendingBalancesFromChannelClosures: pendingBalancesFromChannelClosures,
+		InternalBalances: map[string]interface{}{
+			"balances":         balances,
+			"pending_channels": pendingChannels,
+		},
 	}, nil
 }
 

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -134,10 +134,11 @@ type CloseChannelResponse struct {
 }
 
 type OnchainBalanceResponse struct {
-	Spendable                          int64  `json:"spendable"`
-	Total                              int64  `json:"total"`
-	Reserved                           int64  `json:"reserved"`
-	PendingBalancesFromChannelClosures uint64 `json:"pendingBalancesFromChannelClosures"`
+	Spendable                          int64       `json:"spendable"`
+	Total                              int64       `json:"total"`
+	Reserved                           int64       `json:"reserved"`
+	PendingBalancesFromChannelClosures uint64      `json:"pendingBalancesFromChannelClosures"`
+	InternalBalances                   interface{} `json:"internalBalances"`
 }
 
 type PeerDetails struct {


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/752
Fixes https://github.com/getAlby/hub/issues/612

There is overlap in balance from pending closed channels and total onchain balance.

They will show as incoming in the total onchain balance once the channel becomes sweepable. Therefore, this PR no longer manually includes balances from pending closed channels in the "incoming" amount on the savings balance card.

This PR also adds extra balance info that can be retrieved from debug tools -> get balances which is useful for debugging channels that are stuck (e.g. unconfirmed) or to know if the funds on a channel are still locked, and which counterparty the channel is with.