### PR TITLE
chore: extend startup timeout

### DIFF
--- a/frontend/src/screens/Start.tsx
+++ b/frontend/src/screens/Start.tsx
@@ -71,7 +71,7 @@ export default function Start() {
       setButtonText("Login");
       setUnlockPassword("");
       return;
-    }, 30000); // wait for 30 seconds
+    }, 60000); // wait for 60 seconds
 
     return () => {
       clearInterval(intervalId);


### PR DESCRIPTION
startups can take some time. It should be faster but I think it is worse when a user submits the startup again.