### PR TITLE
feat: auth with alby account before node setup

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 
 	"github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/logger"
@@ -117,19 +116,12 @@ func (cfg *config) init(env *AppConfig) error {
 }
 
 func (cfg *config) SetupCompleted() bool {
-	// TODO: remove AlbyUserIdentifier and hasLdkDir checks after 2025/01/01
-	// to give time for users to update to 1.6.0+
-	albyUserIdentifier, _ := cfg.Get("AlbyUserIdentifier", "")
 	nodeLastStartTime, _ := cfg.Get("NodeLastStartTime", "")
-	ldkDir, err := os.Stat(path.Join(cfg.GetEnv().Workdir, "ldk"))
-	hasLdkDir := err == nil && ldkDir != nil && ldkDir.IsDir()
 
 	logger.Logger.WithFields(logrus.Fields{
-		"has_ldk_dir":              hasLdkDir,
-		"has_alby_user_identifier": albyUserIdentifier != "",
 		"has_node_last_start_time": nodeLastStartTime != "",
 	}).Debug("Checking if setup is completed")
-	return albyUserIdentifier != "" || nodeLastStartTime != "" || hasLdkDir
+	return nodeLastStartTime != ""
 }
 
 func (cfg *config) GetJWTSecret() string {

--- a/frontend/src/components/redirects/HomeRedirect.tsx
+++ b/frontend/src/components/redirects/HomeRedirect.tsx
@@ -13,31 +13,49 @@ export function HomeRedirect() {
     if (!info) {
       return;
     }
+
+    const setupReturnTo = window.localStorage.getItem(
+      localStorageKeys.setupReturnTo
+    );
+
     let to: string | undefined;
-    if (info.setupCompleted && info.running) {
-      if (info.unlocked) {
-        if (info.albyAccountConnected || !info.albyUserIdentifier) {
-          const returnTo = window.localStorage.getItem(
-            localStorageKeys.returnTo
-          );
-          // setTimeout hack needed for React strict mode (in development)
-          // because the effect runs twice before the navigation occurs
-          setTimeout(() => {
-            window.localStorage.removeItem(localStorageKeys.returnTo);
-          }, 100);
-          to = returnTo || "/home";
+    if (!setupReturnTo) {
+      if (info.setupCompleted && info.running) {
+        if (info.unlocked) {
+          if (info.albyAccountConnected || !info.albyUserIdentifier) {
+            const returnTo = window.localStorage.getItem(
+              localStorageKeys.returnTo
+            );
+            // setTimeout hack needed for React strict mode (in development)
+            // because the effect runs twice before the navigation occurs
+            setTimeout(() => {
+              window.localStorage.removeItem(localStorageKeys.returnTo);
+            }, 100);
+            to = returnTo || "/home";
+          } else {
+            to = "/alby/auth";
+          }
         } else {
-          to = "/alby/auth";
+          to = "/unlock";
         }
+      } else if (info.setupCompleted && !info.running) {
+        to = "/start";
+      } else if (info.albyAccountConnected) {
+        to = "/welcome";
       } else {
-        to = "/unlock";
+        to = "/intro";
       }
-    } else if (info.setupCompleted && !info.running) {
-      to = "/start";
     } else {
-      to = "/intro";
+      // setTimeout hack needed for React strict mode (in development)
+      // because the effect runs twice before the navigation occurs
+      setTimeout(() => {
+        window.localStorage.removeItem(localStorageKeys.setupReturnTo);
+      }, 100);
+      to = setupReturnTo;
     }
-    navigate(to);
+    navigate(to, {
+      replace: true,
+    });
   }, [info, location, navigate]);
 
   if (!info) {

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,5 +1,6 @@
 export const localStorageKeys = {
   returnTo: "returnTo",
+  setupReturnTo: "setupReturnTo",
   channelOrder: "channelOrder",
   authToken: "authToken",
 };

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -359,6 +359,14 @@ const routes = [
             element: <Navigate to="password" replace />,
           },
           {
+            path: "alby",
+            element: <ConnectAlbyAccount connectUrl="/setup/auth" />,
+          },
+          {
+            path: "auth",
+            element: <AlbyAuthRedirect />,
+          },
+          {
             path: "password",
             element: <SetupPassword />,
           },
@@ -416,10 +424,6 @@ const routes = [
             element: <SetupFinish />,
           },
         ],
-      },
-      {
-        path: "alby/auth",
-        element: <AlbyAuthRedirect />,
       },
     ],
   },

--- a/frontend/src/screens/ConnectAlbyAccount.tsx
+++ b/frontend/src/screens/ConnectAlbyAccount.tsx
@@ -16,7 +16,11 @@ import {
   CardTitle,
 } from "src/components/ui/card";
 
-export function ConnectAlbyAccount() {
+type ConnectAlbyAccountProps = {
+  connectUrl?: string;
+};
+
+export function ConnectAlbyAccount({ connectUrl }: ConnectAlbyAccountProps) {
   return (
     <div className="w-full h-full flex flex-col items-center justify-center gap-5">
       <Container>
@@ -81,7 +85,7 @@ export function ConnectAlbyAccount() {
           </Card>
         </div>
         <div className="flex flex-col items-center justify-center mt-8 gap-2">
-          <LinkButton to="/alby/auth" size="lg">
+          <LinkButton to={connectUrl || "/alby/auth"} size="lg">
             Connect now
           </LinkButton>
           <LinkButton

--- a/frontend/src/screens/Welcome.tsx
+++ b/frontend/src/screens/Welcome.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import Container from "src/components/Container";
 import { Button } from "src/components/ui/button";
 import {
@@ -11,6 +11,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "src/components/ui/dialog";
+import { localStorageKeys } from "src/constants";
 import { useInfo } from "src/hooks/useInfo";
 
 export function Welcome() {
@@ -23,6 +24,19 @@ export function Welcome() {
     }
     navigate("/");
   }, [info, navigate]);
+
+  function navigateToAuthPage(returnTo: string) {
+    window.localStorage.setItem(localStorageKeys.setupReturnTo, returnTo);
+
+    // by default, allow the user to choose whether or not to connect to alby account
+    let navigateTo = "/setup/alby";
+    if (info?.oauthRedirect) {
+      // if using a custom OAuth client (e.g. Alby Cloud) the user must connect their Alby account
+      // but they are already logged in at getalby.com, so it should be an instant redirect.
+      navigateTo = "/alby/auth";
+    }
+    navigate(navigateTo);
+  }
 
   return (
     <Container>
@@ -37,26 +51,28 @@ export function Welcome() {
           </p>
         </div>
         <div className="grid gap-2">
-          <Link
-            to={
-              info?.backendType
-                ? "/setup/password?node=preset" // node already setup through env variables
-                : "/setup/password?node=ldk"
-            }
+          <Button
             className="w-full"
+            onClick={() =>
+              navigateToAuthPage(
+                info?.backendType
+                  ? "/setup/password?node=preset" // node already setup through env variables
+                  : "/setup/password?node=ldk"
+              )
+            }
           >
-            <Button className="w-full">
-              Get Started
-              {info?.backendType && ` (${info?.backendType})`}
-            </Button>
-          </Link>
+            Get Started
+            {info?.backendType && ` (${info?.backendType})`}
+          </Button>
 
           {info?.enableAdvancedSetup && (
-            <Link to="/setup/advanced" className="w-full">
-              <Button variant="secondary" className="w-full">
-                Advanced Setup
-              </Button>
-            </Link>
+            <Button
+              variant="secondary"
+              className="w-full"
+              onClick={() => navigateToAuthPage("/setup/advanced")}
+            >
+              Advanced Setup
+            </Button>
           )}
         </div>
         <div className="text-sm text-muted-foreground">


### PR DESCRIPTION
Part of https://github.com/getAlby/hub/issues/143

This moves the "Connect Alby Account" step from after the node is launched to being after the user clicks "Get Started" or "Advanced Setup". Once the auth screen is passed, the setup flow returns to normal.

This allows us to know if the user is authenticated before setting up the node, which is required because the node will be launched differently if VSS is used.