### PR TITLE
fix: limit funds transferred from shared wallet to hub node

### DIFF
--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -372,6 +372,9 @@ func (svc *albyOAuthService) DrainSharedWallet(ctx context.Context, lnClient lnc
 	if amountSat < 1 {
 		return errors.New("not enough balance remaining")
 	}
+	// limit the maximum to 1M sats to ensure the funds can easily be migrated
+	// the user can migrate more if they still have sats left over
+	amountSat = min(amountSat, 1_000_000)
 	amount := uint64(amountSat * 1000)
 
 	logger.Logger.WithField("amount", amount).WithError(err).Error("Draining Alby shared wallet funds")

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -278,7 +278,7 @@ export default function Channels() {
                   ])
                 }
               >
-                Migrate
+                Transfer
               </TransferFundsButton>
             </CardFooter>
           </Card>

--- a/frontend/src/screens/channels/first/FirstChannel.tsx
+++ b/frontend/src/screens/channels/first/FirstChannel.tsx
@@ -204,7 +204,7 @@ export function FirstChannel() {
             )}
             <LoadingButton loading={isLoading} onClick={openChannel}>
               Open Channel
-              {canMigrateFunds && <> and Migrate Funds</>}
+              {canMigrateFunds && <> and Transfer Funds</>}
             </LoadingButton>
           </div>
         </>

--- a/frontend/src/screens/wallet/index.tsx
+++ b/frontend/src/screens/wallet/index.tsx
@@ -55,10 +55,10 @@ function Wallet() {
               sats in your Alby shared wallet
             </h3>
             <p className="text-sm text-muted-foreground mb-4">
-              Migrate funds from your Alby hosted balance.
+              Transfer funds from your Alby hosted balance.
             </p>
             {needsChannels ? (
-              <LinkButton to="/channels/first">Migrate Funds</LinkButton>
+              <LinkButton to="/channels/first">Transfer Funds</LinkButton>
             ) : (
               <TransferFundsButton
                 channels={channels}
@@ -71,7 +71,7 @@ function Wallet() {
                   ])
                 }
               >
-                Migrate Funds
+                Transfer Funds
               </TransferFundsButton>
             )}
           </div>


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/781

- renamed "migrate" to "transfer" to match getalby.com/node page 
- when transferring funds on first channel open, will not repeatedly drain funds (except when user only has small amount of funds left over)
- transfer funds endpoint now caps the amount to transfer to 1M sats.