### PR TITLE
fix: change key already exists error to debug log

### DIFF
--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -685,7 +685,7 @@ func (svc *albyOAuthService) ConsumeEvent(ctx context.Context, event *events.Eve
 	for k, v := range globalProperties {
 		_, exists := eventWithGlobalProperties.Properties[k]
 		if exists {
-			logger.Logger.WithField("key", k).Error("Key already exists in event properties, skipping global property")
+			logger.Logger.WithField("key", k).Debug("Key already exists in event properties, skipping global property")
 			continue
 		}
 		eventWithGlobalProperties.Properties[k] = v


### PR DESCRIPTION
fixes https://github.com/getAlby/hub/issues/769

This happens when node_id is included in both the channels backup event and the event publisher global properties.

I have updated the log to debug as the node_id must be part of the event properties. In this case, I think the log just does not need to be error level, as the event properties always take precedence over the global properties.