### PR TITLE
fix: change failed to refresh existing token log from error to warn level

### DIFF
--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -231,7 +231,7 @@ func (svc *albyOAuthService) fetchUserToken(ctx context.Context) (*oauth2.Token,
 
 	newToken, err := svc.oauthConf.TokenSource(ctx, currentToken).Token()
 	if err != nil {
-		logger.Logger.WithError(err).Error("Failed to refresh existing token")
+		logger.Logger.WithError(err).Warn("Failed to refresh existing token")
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/765