### PR TITLE
feat: show transaction metadata in transaction list

### DIFF
--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -9,9 +9,11 @@ import {
   CopyIcon,
   XIcon,
 } from "lucide-react";
+import { nip19 } from "nostr-tools";
 import React from "react";
 import { Link } from "react-router-dom";
 import AppAvatar from "src/components/AppAvatar";
+import ExternalLink from "src/components/ExternalLink";
 import PodcastingInfo from "src/components/PodcastingInfo";
 import {
   Dialog,
@@ -104,6 +106,17 @@ function TransactionItem({ tx }: Props) {
     </div>
   );
 
+  let from;
+
+  if (tx.metadata?.payer_data?.name) {
+    from = "from " + tx.metadata.payer_data.name;
+  } else if (tx.metadata?.nostr) {
+    const npub = nip19.npubEncode(tx.metadata.nostr.pubkey);
+    from = "zap from " + npub.substring(0, 12) + "...";
+  }
+
+  const eventId = tx.metadata?.nostr?.tags.find((t) => t[0] === "e")?.[1];
+
   return (
     <Dialog
       onOpenChange={(open) => {
@@ -122,11 +135,12 @@ function TransactionItem({ tx }: Props) {
           {typeStateIcon}
           <div className="overflow-hidden mr-3 max-w-full text-left flex flex-col items-start justify-center">
             <div>
-              <p className="flex items-center gap-2 truncate">
+              <p className="flex items-end truncate">
                 <span className="md:text-xl font-semibold">
                   {typeStateText}
                 </span>
-                <span className="text-xs md:text-base truncate text-muted-foreground">
+                {from !== undefined && <>&nbsp;{from}</>}
+                <span className="text-xs md:text-base ml-2 truncate text-muted-foreground">
                   {dayjs(tx.settledAt || tx.createdAt).fromNow()}
                 </span>
               </p>
@@ -218,6 +232,23 @@ function TransactionItem({ tx }: Props) {
                 </p>
               </div>
             )}
+            {tx.metadata?.nostr && eventId && (
+              <div className="mt-6">
+                <p>
+                  <ExternalLink
+                    to={`https://njump.me/${nip19.neventEncode({
+                      id: eventId,
+                    })}`}
+                    className="underline"
+                  >
+                    Nostr Zap
+                  </ExternalLink>{" "}
+                  <span className="text-muted-foreground break-all">
+                    from {nip19.npubEncode(tx.metadata.nostr.pubkey)}
+                  </span>
+                </p>
+              </div>
+            )}
             <div className="mt-4 w-full">
               <div
                 className="flex items-center gap-2 cursor-pointer"
@@ -241,7 +272,7 @@ function TransactionItem({ tx }: Props) {
                           {tx.preimage}
                         </p>
                         <CopyIcon
-                          className="cursor-pointer text-muted-foreground w-6 h-6"
+                          className="cursor-pointer text-muted-foreground w-4 h-4 flex-shrink-0"
                           onClick={() => {
                             if (tx.preimage) {
                               copy(tx.preimage);
@@ -258,13 +289,29 @@ function TransactionItem({ tx }: Props) {
                         {tx.paymentHash}
                       </p>
                       <CopyIcon
-                        className="cursor-pointer text-muted-foreground w-6 h-6"
+                        className="cursor-pointer text-muted-foreground w-4 h-4 flex-shrink-0"
                         onClick={() => {
                           copy(tx.paymentHash);
                         }}
                       />
                     </div>
                   </div>
+                  {tx.metadata && (
+                    <div className="mt-6">
+                      <p>Metadata</p>
+                      <div className="flex items-center gap-4">
+                        <p className="text-muted-foreground break-all">
+                          {JSON.stringify(tx.metadata)}
+                        </p>
+                        <CopyIcon
+                          className="cursor-pointer text-muted-foreground w-4 h-4 flex-shrink-0"
+                          onClick={() => {
+                            copy(JSON.stringify(tx.metadata));
+                          }}
+                        />
+                      </div>
+                    </div>
+                  )}
                 </>
               )}
             </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -403,7 +403,18 @@ export type Transaction = {
   feesPaid: number;
   createdAt: string;
   settledAt: string | undefined;
-  metadata?: Record<string, unknown>;
+  metadata?: {
+    comment?: string; // LUD-12
+    payer_data?: {
+      email?: string;
+      name?: string;
+      pubkey?: string;
+    }; // LUD-18
+    nostr?: {
+      pubkey: string;
+      tags: string[][];
+    }; // NIP-57
+  } & Record<string, unknown>;
   boostagram?: Boostagram;
 };
 


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/577

Alternative to https://github.com/getAlby/hub/pull/678

Shows LUD-18 and NIP-57 data for received payments in the transaction list.

This iteration only shows text data. Nostr zap profile name and picture would require a separate service or deeper nostr integration which might not be worthwhile right now.

![image](https://github.com/user-attachments/assets/a6f5722a-1c39-4875-a246-2baaa861f42b)

![image](https://github.com/user-attachments/assets/2646a9a0-4ee6-4c7c-b761-e0687ed3a546)

![image](https://github.com/user-attachments/assets/ca4c1faa-df0f-408f-9fd7-33aebd1c72c9)
