### PR TITLE
fix: remove eos check after connecting to relay

### DIFF
--- a/service/start.go
+++ b/service/start.go
@@ -192,10 +192,6 @@ func (svc *service) StartSubscription(ctx context.Context, sub *nostr.Subscripti
 	svc.nip47Service.StartNotifier(ctx, sub.Relay, svc.lnClient)
 
 	go func() {
-		// block till EOS is received
-		<-sub.EndOfStoredEvents
-		logger.Logger.Debug("Received EOS")
-
 		// loop through incoming events
 		for event := range sub.Events {
 			go svc.nip47Service.HandleEvent(ctx, sub.Relay, event, svc.lnClient)


### PR DESCRIPTION
The eos check is not needed because:
- The request events are ephemeral
- When we update the relay to keep undelivered ephemeral events, only undelivered events will be consumed 

Fixes https://github.com/getAlby/hub/issues/743