### PR TITLE
feat: add budget warning event, rename app events

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,9 @@ Internally Alby Hub uses a basic implementation of the pubsub messaging pattern 
     - `nwc_payment_failed` - failed to make a lightning payment
     - `nwc_payment_sent` - successfully made a lightning payment
     - `nwc_payment_received` - received a lightning payment
+    - `nwc_budget_warning` - successfully made a lightning payment, but budget is nearly exceeded
+    - `nwc_app_created` - a new app connection was created
+    - `nwc_app_deleted` - a new app connection was deleted
     - `nwc_lnclient_*` - underlying LNClient events, consumed only by the transactions service.
 
 ### NIP-47 Handlers

--- a/apps/apps_service.go
+++ b/apps/apps_service.go
@@ -117,7 +117,7 @@ func (svc *appsService) CreateApp(name string, pubkey string, maxAmountSat uint6
 	}
 
 	svc.eventPublisher.Publish(&events.Event{
-		Event: "app_created",
+		Event: "nwc_app_created",
 		Properties: map[string]interface{}{
 			"name": name,
 			"id":   app.ID,
@@ -134,7 +134,7 @@ func (svc *appsService) DeleteApp(app *db.App) error {
 		return err
 	}
 	svc.eventPublisher.Publish(&events.Event{
-		Event: "app_deleted",
+		Event: "nwc_app_deleted",
 		Properties: map[string]interface{}{
 			"name": app.Name,
 			"id":   app.ID,

--- a/service/create_app_consumer.go
+++ b/service/create_app_consumer.go
@@ -17,7 +17,7 @@ type createAppConsumer struct {
 
 // When a new app is created, subscribe to it on the relay
 func (s *createAppConsumer) ConsumeEvent(ctx context.Context, event *events.Event, globalProperties map[string]interface{}) {
-	if event.Event != "app_created" {
+	if event.Event != "nwc_app_created" {
 		return
 	}
 

--- a/service/delete_app_consumer.go
+++ b/service/delete_app_consumer.go
@@ -19,7 +19,7 @@ type deleteAppConsumer struct {
 // When an app is deleted, unsubscribe from events for that app on the relay
 // and publish a deletion event for that app's info event
 func (s *deleteAppConsumer) ConsumeEvent(ctx context.Context, event *events.Event, globalProperties map[string]interface{}) {
-	if event.Event != "app_deleted" {
+	if event.Event != "nwc_app_deleted" {
 		return
 	}
 	properties, ok := event.Properties.(map[string]interface{})

--- a/service/start.go
+++ b/service/start.go
@@ -90,7 +90,7 @@ func (svc *service) startNostr(ctx context.Context) error {
 			}).Info("Connected to the relay")
 			waitToReconnectSeconds = 0
 
-			// register a subscriber for events of "app_created" which handles creation of nostr subscription for new app
+			// register a subscriber for events of "nwc_app_created" which handles creation of nostr subscription for new app
 			if createAppEventListener != nil {
 				svc.eventPublisher.RemoveSubscriber(createAppEventListener)
 			}
@@ -175,7 +175,7 @@ func (svc *service) startAppWalletSubscription(ctx context.Context, relay *nostr
 		return err
 	}
 
-	// register a subscriber for "app_deleted" events, which handles nostr subscription cancel and nip47 info event deletion
+	// register a subscriber for "nwc_app_deleted" events, which handles nostr subscription cancel and nip47 info event deletion
 	deleteEventSubscriber := deleteAppConsumer{nostrSubscription: sub, walletPubkey: appWalletPubKey, svc: svc, relay: relay}
 	svc.eventPublisher.RegisterSubscriber(&deleteEventSubscriber)
 

--- a/tests/create_app.go
+++ b/tests/create_app.go
@@ -1,12 +1,13 @@
 package tests
 
 import (
+	"time"
+
 	db "github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/events"
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/nbd-wtf/go-nostr/nip04"
 	"gorm.io/gorm"
-	"time"
 )
 
 func CreateApp(svc *TestService) (app *db.App, ss []byte, err error) {
@@ -57,7 +58,7 @@ func CreateLegacyApp(svc *TestService, senderPrivkey string) (app *db.App, ss []
 	}
 
 	svc.EventPublisher.Publish(&events.Event{
-		Event: "app_created",
+		Event: "nwc_app_created",
 		Properties: map[string]interface{}{
 			"name": "test",
 			"id":   app.ID,


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/319

Also renames app events which did not have the `nwc_` prefix (all other events have it)