### PR TITLE
feat: app-wide received payment notifications

### DIFF
--- a/frontend/src/components/layouts/AppLayout.tsx
+++ b/frontend/src/components/layouts/AppLayout.tsx
@@ -50,6 +50,7 @@ import { useAlbyMe } from "src/hooks/useAlbyMe";
 
 import { useAlbyInfo } from "src/hooks/useAlbyInfo";
 import { useInfo } from "src/hooks/useInfo";
+import { useNotifyReceivedPayments } from "src/hooks/useNotifyReceivedPayments";
 import { useRemoveSuccessfulChannelOrder } from "src/hooks/useRemoveSuccessfulChannelOrder";
 import { deleteAuthToken } from "src/lib/auth";
 import { cn } from "src/lib/utils";
@@ -65,6 +66,7 @@ export default function AppLayout() {
   const location = useLocation();
   const navigate = useNavigate();
   useRemoveSuccessfulChannelOrder();
+  useNotifyReceivedPayments();
 
   const _isHttpMode = isHttpMode();
 

--- a/frontend/src/hooks/useNotifyReceivedPayments.ts
+++ b/frontend/src/hooks/useNotifyReceivedPayments.ts
@@ -1,0 +1,22 @@
+import React from "react";
+import { useToast } from "src/components/ui/use-toast";
+import { useTransactions } from "src/hooks/useTransactions";
+import { Transaction } from "src/types";
+
+export function useNotifyReceivedPayments() {
+  const { data: transactions } = useTransactions(true, 1);
+  const [prevTransaction, setPrevTransaction] = React.useState<Transaction>();
+  const { toast } = useToast();
+
+  React.useEffect(() => {
+    if (transactions && prevTransaction !== transactions[0]) {
+      if (prevTransaction && transactions[0].type === "incoming") {
+        toast({
+          title: "Payment received",
+          description: `${new Intl.NumberFormat().format(Math.floor(transactions[0].amount / 1000))} sats`,
+        });
+      }
+      setPrevTransaction(transactions[0]);
+    }
+  }, [prevTransaction, toast, transactions]);
+}

--- a/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
@@ -47,9 +47,6 @@ export default function ReceiveInvoice() {
   React.useEffect(() => {
     if (invoiceData?.settledAt) {
       setPaymentDone(true);
-      toast({
-        title: "Payment received!",
-      });
     }
   }, [invoiceData, toast]);
 


### PR DESCRIPTION
Followup of https://github.com/getAlby/hub/pull/815 that will show a notification if you receive payments via lightning address.

I am not sure it's really needed though, or should just go on the receive page so that the rest of the app does not necessarily poll to get the latest transaction