### PR TITLE
fix: re-add pending balance for LightningBalanceClaimableAwaitingConfirmations

### DIFF
--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -1077,8 +1077,7 @@ func (ls *LDKService) GetOnchainBalance(ctx context.Context) (*lnclient.OnchainB
 		case ldk_node.LightningBalanceClaimableOnChannelClose:
 			increasePendingBalance(balanceType.ChannelId, balanceType.AmountSatoshis)
 		case ldk_node.LightningBalanceClaimableAwaitingConfirmations:
-			// this will show in the total balance (as incoming).
-			// increasePendingBalance(balanceType.ChannelId, balanceType.AmountSatoshis)
+			increasePendingBalance(balanceType.ChannelId, balanceType.AmountSatoshis)
 		case ldk_node.LightningBalanceContentiousClaimable:
 			increasePendingBalance(balanceType.ChannelId, balanceType.AmountSatoshis)
 		case ldk_node.LightningBalanceMaybeTimeoutClaimableHtlc:


### PR DESCRIPTION
(if the user force closes from their side this will show as pending funds from closed channels until the timelock ends)