### PR TITLE
feat: simplify node page and manual open channel flows

### DIFF
--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -24,7 +24,7 @@ function AppHeader({
             {description}
           </p>
         </div>
-        <div className="flex gap-3">{contentRight}</div>
+        <div className="flex gap-3 h-full">{contentRight}</div>
       </div>
     </>
   );

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -146,7 +146,7 @@ const routes = [
           {
             path: "withdraw",
             element: <WithdrawOnchainFunds />,
-            handle: { crumb: () => "Withdraw Savings Balance" },
+            handle: { crumb: () => "Withdraw On-Chain Balance" },
           },
         ],
       },
@@ -295,12 +295,12 @@ const routes = [
           {
             path: "outgoing",
             element: <IncreaseOutgoingCapacity />,
-            handle: { crumb: () => "Increase Spending Balance" },
+            handle: { crumb: () => "Open Channel with On-Chain" },
           },
           {
             path: "incoming",
             element: <IncreaseIncomingCapacity />,
-            handle: { crumb: () => "Increase Receiving Capacity" },
+            handle: { crumb: () => "Open Channel with Lightning" },
           },
           {
             path: "order",

--- a/frontend/src/screens/BackupMnemonic.tsx
+++ b/frontend/src/screens/BackupMnemonic.tsx
@@ -132,7 +132,7 @@ export function BackupMnemonic() {
               </div>
               <span>
                 Your recovery phrase is a set of 12 words that{" "}
-                <b>backs up your wallet savings balance</b>.&nbsp;
+                <b>backs up your wallet on-chain balance</b>.&nbsp;
                 {info?.albyAccountConnected && (
                   <>
                     Channel backups are saved automatically to your Alby

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -1,7 +1,5 @@
 import {
   AlertTriangle,
-  ArrowDown,
-  ArrowUp,
   Bitcoin,
   ChevronDown,
   CopyIcon,
@@ -11,6 +9,7 @@ import {
   InfoIcon,
   Settings2,
   Unplug,
+  ZapIcon,
 } from "lucide-react";
 import React from "react";
 import { Link, useNavigate } from "react-router-dom";
@@ -153,8 +152,9 @@ export default function Channels() {
                     </div>
                   </DropdownMenuItem>
                 </DropdownMenuGroup>
+                <DropdownMenuSeparator />
                 <DropdownMenuGroup>
-                  <DropdownMenuSeparator />
+                  <DropdownMenuLabel>On-Chain</DropdownMenuLabel>
                   <DropdownMenuItem>
                     <Link
                       to="/channels/onchain/deposit-bitcoin"
@@ -163,12 +163,17 @@ export default function Channels() {
                       Deposit Bitcoin
                     </Link>
                   </DropdownMenuItem>
+                  <DropdownMenuItem>
+                    <Link to="onchain/buy-bitcoin" className="w-full">
+                      Buy Bitcoin
+                    </Link>
+                  </DropdownMenuItem>
                   {(balances?.onchain.spendable || 0) > ONCHAIN_DUST_SATS && (
                     <DropdownMenuItem
                       onClick={() => navigate("/wallet/withdraw")}
                       className="w-full cursor-pointer"
                     >
-                      Withdraw Savings Balance
+                      Withdraw On-Chain Balance
                     </DropdownMenuItem>
                   )}
                 </DropdownMenuGroup>
@@ -188,7 +193,7 @@ export default function Channels() {
                 </DropdownMenuGroup>
               </DropdownMenuContent>
             </DropdownMenu>
-            <Link to="/channels/outgoing">
+            <Link to="/channels/incoming">
               <Button>Open Channel</Button>
             </Link>
             <ExternalLink to="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/liquidity/node-health">
@@ -247,10 +252,7 @@ export default function Channels() {
       )}
 
       <div
-        className={cn(
-          "grid grid-cols-1 gap-3 slashed-zero",
-          showHostedBalance ? "xl:grid-cols-4" : "lg:grid-cols-3"
-        )}
+        className={cn("flex flex-col sm:flex-row flex-wrap gap-3 slashed-zero")}
       >
         {showHostedBalance && (
           <Card className="flex flex-col">
@@ -283,28 +285,110 @@ export default function Channels() {
             </CardFooter>
           </Card>
         )}
-        <Card className="flex flex-col">
+
+        <Card className="flex flex-1 sm:flex-[2] flex-col">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger>
-                    <div className="flex flex-row gap-2 items-center">
-                      Savings Balance
-                      <InfoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <CardTitle className="font-semibold">Lightning</CardTitle>
+            <ZapIcon className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+
+          <CardContent className="flex pl-0 flex-wrap">
+            <div className="flex flex-col flex-1">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 pr-0">
+                <CardTitle className="text-sm font-medium">
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <div className="flex flex-row gap-2 items-center justify-start text-sm">
+                          Spending Balance
+                          <InfoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent className="w-[300px]">
+                        Your spending balance is the funds on your side of your
+                        channels, which you can use to make lightning payments.
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="flex-grow pb-0">
+                {!balances && (
+                  <div>
+                    <div className="animate-pulse d-inline ">
+                      <div className="h-2.5 bg-primary rounded-full w-12 my-2"></div>
                     </div>
-                  </TooltipTrigger>
-                  <TooltipContent className="w-[300px]">
-                    Your savings balance (on-chain balance) can be used to open
-                    new lightning channels. When channels are closed, funds from
-                    your channel will be returned to your savings balance.
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </CardTitle>
+                  </div>
+                )}
+                {balances && (
+                  <div className="text-2xl font-bold balance sensitive">
+                    {new Intl.NumberFormat().format(
+                      Math.floor(balances.lightning.totalSpendable / 1000)
+                    )}{" "}
+                    sats
+                  </div>
+                )}
+              </CardContent>
+            </div>
+            <div className="flex flex-col flex-1">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 pr-0">
+                <CardTitle className="text-sm font-medium">
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <div className="flex flex-row gap-2 items-center justify-start text-sm">
+                          Receiving Capacity
+                          <InfoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent className="w-[300px]">
+                        Your receiving capacity is the funds owned by your
+                        channel partner, which will be moved to your side when
+                        you receive lightning payments.
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="flex-grow pb-0">
+                <div className="text-2xl font-bold balance sensitive">
+                  {balances &&
+                    new Intl.NumberFormat().format(
+                      Math.floor(balances.lightning.totalReceivable / 1000)
+                    )}{" "}
+                  sats
+                </div>
+              </CardContent>
+            </div>
+          </CardContent>
+        </Card>
+        <Card className="flex flex-1 flex-col">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="font-semibold">On-Chain</CardTitle>
+
             <Bitcoin className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
-          <CardContent className="flex-grow">
+          <CardContent className="flex-grow pb-0">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 pl-0">
+              <CardTitle className="text-sm font-medium">
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <div className="flex flex-row gap-2 items-center text-sm">
+                        Balance
+                        <InfoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent className="w-[300px]">
+                      Your on-chain balance can be used to open new outgoing
+                      lightning channels. When channels are closed, funds on
+                      your side of your channel will be returned to your savings
+                      balance.
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </CardTitle>
+            </CardHeader>
             {!balances && (
               <div>
                 <div className="animate-pulse d-inline ">
@@ -331,98 +415,6 @@ export default function Channels() {
               )}
             </div>
           </CardContent>
-          <CardFooter className="flex justify-end space-x-1">
-            <Link to="onchain/buy-bitcoin">
-              <Button variant="outline">Buy</Button>
-            </Link>
-            <Link to="onchain/deposit-bitcoin">
-              <Button variant="outline">Deposit</Button>
-            </Link>
-            {(balances?.onchain.spendable || 0) > ONCHAIN_DUST_SATS && (
-              <Link to="/wallet/withdraw">
-                <Button variant="outline">Withdraw</Button>
-              </Link>
-            )}
-          </CardFooter>
-        </Card>
-        <Card className="flex flex-col">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger>
-                    <div className="flex flex-row gap-2 items-center">
-                      Spending Balance
-                      <InfoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent className="w-[300px]">
-                    Your spending balance is the funds on your side of your
-                    channels, which you can use to make lightning payments.
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </CardTitle>
-            <ArrowUp className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent className="flex-grow">
-            {!balances && (
-              <div>
-                <div className="animate-pulse d-inline ">
-                  <div className="h-2.5 bg-primary rounded-full w-12 my-2"></div>
-                </div>
-              </div>
-            )}
-            {balances && (
-              <div className="text-2xl font-bold balance sensitive">
-                {new Intl.NumberFormat().format(
-                  Math.floor(balances.lightning.totalSpendable / 1000)
-                )}{" "}
-                sats
-              </div>
-            )}
-          </CardContent>
-          <CardFooter className="flex justify-end">
-            <Link to="/channels/outgoing">
-              <Button variant="outline">Top Up</Button>
-            </Link>
-          </CardFooter>
-        </Card>
-        <Card className="flex flex-col">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger>
-                    <div className="flex flex-row gap-2 items-center">
-                      Receiving Capacity
-                      <InfoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent className="w-[300px]">
-                    Your receiving capacity is the funds owned by your channel
-                    partner, which will be moved to your side when you receive
-                    lightning payments.
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </CardTitle>
-            <ArrowDown className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent className="flex-grow">
-            <div className="text-2xl font-bold balance sensitive">
-              {balances &&
-                new Intl.NumberFormat().format(
-                  Math.floor(balances.lightning.totalReceivable / 1000)
-                )}{" "}
-              sats
-            </div>
-          </CardContent>
-          <CardFooter className="flex justify-end">
-            <Link to="/channels/incoming">
-              <Button variant="outline">Increase</Button>
-            </Link>
-          </CardFooter>
         </Card>
       </div>
 
@@ -436,7 +428,7 @@ export default function Channels() {
               balances.onchain.pendingBalancesFromChannelClosures
             )}{" "}
             sats pending from one or more closed channels. Once spendable again
-            these will become available in your savings balance. Funds from
+            these will become available in your on-chain balance. Funds from
             channels that were force closed may take up to 2 weeks to become
             available.{" "}
             <ExternalLink
@@ -455,7 +447,7 @@ export default function Channels() {
           title="No Channels Available"
           description="Connect to the Lightning Network by establishing your first channel and start transacting."
           buttonText="Open Channel"
-          buttonLink="/channels/outgoing"
+          buttonLink="/channels/incoming"
         />
       )}
 

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -292,7 +292,7 @@ export default function Channels() {
             <ZapIcon className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
 
-          <CardContent className="flex pl-0 flex-wrap">
+          <CardContent className="flex flex-col sm:flex-row pl-0 flex-wrap">
             <div className="flex flex-col flex-1">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 pr-0">
                 <CardTitle className="text-sm font-medium">

--- a/frontend/src/screens/channels/CurrentChannelOrder.tsx
+++ b/frontend/src/screens/channels/CurrentChannelOrder.tsx
@@ -804,7 +804,7 @@ function PayLightningChannelOrder({ order }: { order: NewChannelOrder }) {
                 </p>
                 <Link to="/channels/outgoing" className="w-full">
                   <Button className="w-full" variant="secondary">
-                    Increase spending balance
+                    Increase Spending Balance
                   </Button>
                 </Link>
                 <ExternalLink

--- a/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, InfoIcon } from "lucide-react";
 import React, { FormEvent } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import AppHeader from "src/components/AppHeader";
@@ -20,6 +20,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "src/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "src/components/ui/tooltip";
 import { useToast } from "src/components/ui/use-toast";
 import { useChannelPeerSuggestions } from "src/hooks/useChannelPeerSuggestions";
 import { useChannels } from "src/hooks/useChannels";
@@ -192,14 +198,15 @@ function NewChannelInternal({
   return (
     <>
       <AppHeader
-        title="Increase Receiving Capacity"
-        description="Purchase a channel with incoming capacity to receive payments"
+        title="Open Channel with Lightning"
+        description="Purchase a channel that allows you to receive payments"
         contentRight={
           <div className="flex items-end">
-            <Link to="/channels/outgoing">
-              <Button className="w-full" variant="secondary">
-                Need spending balance?
-              </Button>
+            <Link
+              to="/channels/outgoing"
+              className="underline break-words text-sm"
+            >
+              Open Channel with On-Chain
             </Link>
           </div>
         }
@@ -216,7 +223,24 @@ function NewChannelInternal({
         />
         <form onSubmit={onSubmit} className="flex flex-col gap-5 flex-1">
           <div className="grid gap-1.5">
-            <Label htmlFor="amount">Channel size (sats)</Label>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger type="button">
+                  <div className="flex flex-row gap-2 items-center justify-start text-sm">
+                    <Label htmlFor="amount">
+                      Increase receiving capacity (sats)
+                    </Label>
+                    <InfoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent className="w-[300px]">
+                  Configure the amount of receiving capacity you need. You will
+                  only pay for the liquidity fee which will be shown in the next
+                  step.
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+
             {order.amount && +order.amount < 200_000 && (
               <p className="text-muted-foreground text-xs">
                 For a smooth experience consider a opening a channel of 200k
@@ -386,7 +410,7 @@ function NewChannelInternal({
             className="w-full"
             variant="secondary"
           >
-            Increase spending balance
+            Increase Spending Balance
           </LinkButton>
           <ExternalLinkButton
             to="https://www.getalby.com/topup"

--- a/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
@@ -221,6 +221,17 @@ function NewChannelInternal({
           src="/images/illustrations/lightning-network-light.svg"
           className="w-full dark:hidden"
         />
+        <p className="text-muted-foreground">
+          Alby Hub works with selected service providers (LSPs) which provide
+          the best network connectivity and liquidity to receive payments. The
+          channel typically stays open as long as there is usage.{" "}
+          <ExternalLink
+            className="underline"
+            to="https://guides.getalby.com/user-guide/alby-account-and-browser-extension/alby-hub/faq-alby-hub/how-to-open-a-channel"
+          >
+            Learn more
+          </ExternalLink>
+        </p>
         <form onSubmit={onSubmit} className="flex flex-col gap-5 flex-1">
           <div className="grid gap-1.5">
             <TooltipProvider>

--- a/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, InfoIcon } from "lucide-react";
 import React, { FormEvent } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import AppHeader from "src/components/AppHeader";
@@ -20,6 +20,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "src/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "src/components/ui/tooltip";
 import { useToast } from "src/components/ui/use-toast";
 import { useBalances } from "src/hooks/useBalances";
 import { useChannelPeerSuggestions } from "src/hooks/useChannelPeerSuggestions";
@@ -216,14 +222,12 @@ function NewChannelInternal({ network }: { network: Network }) {
   return (
     <>
       <AppHeader
-        title="Increase Spending Balance"
+        title="Open Channel with On-Chain"
         description="Funds used to open a channel minus fees will be added to your spending balance"
         contentRight={
           <div className="flex items-end">
-            <Link to="/channels/incoming">
-              <Button className="w-full" variant="secondary">
-                Need receiving capacity?
-              </Button>
+            <Link to="/channels/incoming" className="underline text-sm">
+              Open Channel with Lightning
             </Link>
           </div>
         }
@@ -243,7 +247,24 @@ function NewChannelInternal({ network }: { network: Network }) {
           className="md:max-w-md max-w-full flex flex-col gap-5 flex-1"
         >
           <div className="grid gap-1.5">
-            <Label htmlFor="amount">Channel size (sats)</Label>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger type="button">
+                  <div className="flex flex-row gap-2 items-center justify-start text-sm">
+                    <Label htmlFor="amount">
+                      Increase spending balance (sats)
+                    </Label>
+                    <InfoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent className="w-[300px]">
+                  Configure the amount of spending capacity you need. You will
+                  need to deposit on-chain bitcoin to cover the entire channel
+                  size, plus on-chain fees.
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+
             {order.amount && +order.amount < 200_000 && (
               <p className="text-muted-foreground text-xs">
                 For a smooth experience consider a opening a channel of 200k
@@ -271,7 +292,7 @@ function NewChannelInternal({ network }: { network: Network }) {
               }}
             />
             <div className="text-muted-foreground text-sm sensitive slashed-zero">
-              Current savings balance:{" "}
+              Current on-chain balance:{" "}
               {new Intl.NumberFormat().format(balances.onchain.spendable)} sats
             </div>
             <div className="grid grid-cols-3 gap-1.5 text-muted-foreground text-xs">
@@ -419,7 +440,7 @@ function NewChannelInternal({ network }: { network: Network }) {
             className="w-full"
             variant="secondary"
           >
-            Increase receiving capacity
+            Increase Receiving Capacity
           </LinkButton>
           <ExternalLinkButton
             to="https://www.getalby.com/topup"

--- a/frontend/src/screens/onchain/BuyBitcoin.tsx
+++ b/frontend/src/screens/onchain/BuyBitcoin.tsx
@@ -171,7 +171,7 @@ export default function BuyBitcoin() {
     <div className="grid gap-5">
       <AppHeader
         title="Buy Bitcoin"
-        description="Use one of our partner providers to buy bitcoin and deposit it to your savings balance."
+        description="Use one of our partner providers to buy bitcoin and deposit it to your on-chain balance."
       />
       <MempoolAlert />
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-1 lg:gap-10">

--- a/frontend/src/screens/onchain/DepositBitcoin.tsx
+++ b/frontend/src/screens/onchain/DepositBitcoin.tsx
@@ -30,7 +30,7 @@ export default function DepositBitcoin() {
   return (
     <div className="grid gap-5">
       <AppHeader
-        title="Deposit Bitcoin to Savings Balance"
+        title="Deposit Bitcoin to On-Chain Balance"
         description="Deposit bitcoin to your on-chain address which then can be used to open new lightning channels."
         contentRight={
           <Link to="/channels/onchain/buy-bitcoin">

--- a/frontend/src/screens/setup/ImportMnemonic.tsx
+++ b/frontend/src/screens/setup/ImportMnemonic.tsx
@@ -87,7 +87,7 @@ export function ImportMnemonic() {
               </div>
               <span className="text-muted-foreground">
                 Your recovery phrase is a set of 12 words used to restore your
-                savings balance from a backup.
+                on-chain balance from a backup.
               </span>
             </div>
             <div className="flex gap-2 items-center">

--- a/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
+++ b/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
@@ -115,7 +115,7 @@ export default function WithdrawOnchainFunds() {
           View on Mempool
           <ExternalLinkIcon className="w-4 h-4 ml-2" />
         </ExternalLink>
-        <p>Your savings balance in Alby Hub may take some time to update.</p>
+        <p>Your on-chain balance in Alby Hub may take some time to update.</p>
       </div>
     );
   }
@@ -135,13 +135,13 @@ export default function WithdrawOnchainFunds() {
   return (
     <div className="grid gap-5">
       <AppHeader
-        title="Withdraw Savings Balance"
+        title="Withdraw On-Chain Balance"
         description="Withdraw your onchain funds to another bitcoin wallet"
       />
 
       <div className="max-w-lg">
         <p>
-          Your savings balance will be withdrawn to the onchain bitcoin wallet
+          Your on-chain balance will be withdrawn to the onchain bitcoin wallet
           address you specify below.
         </p>
         <form
@@ -204,7 +204,7 @@ export default function WithdrawOnchainFunds() {
                       You have channels open and this withdrawal will deplete
                       your anchor reserves, which may make it harder to close
                       channels without depositing additional onchain funds to
-                      your savings balance.
+                      your on-chain balance.
                     </>
                   )}
                 </AlertDescription>
@@ -266,7 +266,7 @@ export default function WithdrawOnchainFunds() {
                       Amount:{" "}
                       <span className="font-bold slashed-zero">
                         {sendAll ? (
-                          "entire savings balance"
+                          "entire on-chain balance"
                         ) : (
                           <>{new Intl.NumberFormat().format(+amount)} sats</>
                         )}


### PR DESCRIPTION
Partially addresses https://github.com/getAlby/hub/issues/675

- remove extra buttons from node page
- change default channel flow to increase receiving capacity
- update copy on node page and manual open channel flows
- add tooltips on new channel amounts

![image](https://github.com/user-attachments/assets/77859e66-c453-4487-8e65-e96fa08fc79e)

![image](https://github.com/user-attachments/assets/c3a0f7e5-c66d-4b30-b807-ea963d2c7073)

![image](https://github.com/user-attachments/assets/233d3a76-d5d8-449f-89a6-56de7a28423a)

![image](https://github.com/user-attachments/assets/4d4875fa-b46a-40ab-ae7b-4c74bad1bb98)

