### PR TITLE
fix: unmet fee reserve check on wallet page

### DIFF
--- a/frontend/src/screens/wallet/index.tsx
+++ b/frontend/src/screens/wallet/index.tsx
@@ -81,7 +81,7 @@ function Wallet() {
         !!channels?.length &&
         channels?.every(
           (channel) =>
-            channel.localBalance < channel.unspendablePunishmentReserve
+            channel.localBalance < channel.unspendablePunishmentReserve * 1000
         ) &&
         !showMigrateCard && (
           <Alert>


### PR DESCRIPTION
For some reason I missed this value is in sats, not millisats.