### PR TITLE
fix: allow self-signed certificates and to skip during setup

### DIFF
--- a/frontend/src/screens/setup/node/LNDForm.tsx
+++ b/frontend/src/screens/setup/node/LNDForm.tsx
@@ -1,3 +1,4 @@
+import { InfoIcon } from "lucide-react";
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import Container from "src/components/Container";
@@ -5,11 +6,9 @@ import TwoColumnLayoutHeader from "src/components/TwoColumnLayoutHeader";
 import { Button } from "src/components/ui/button";
 import { Input } from "src/components/ui/input";
 import { Label } from "src/components/ui/label";
-import { useToast } from "src/components/ui/use-toast";
 import useSetupStore from "src/state/SetupStore";
 
 export function LNDForm() {
-  const { toast } = useToast();
   const navigate = useNavigate();
   const setupStore = useSetupStore();
   const [lndAddress, setLndAddress] = React.useState<string>(
@@ -25,13 +24,6 @@ export function LNDForm() {
   // TODO: proper onboarding
   function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!lndAddress || !lndCertHex || !lndMacaroonHex) {
-      toast({
-        title: "Please fill out all fields",
-        variant: "destructive",
-      });
-      return;
-    }
     handleSubmit({
       lndAddress,
       lndCertHex,
@@ -57,6 +49,7 @@ export function LNDForm() {
         <div className="grid gap-1.5">
           <Label htmlFor="lnd-address">LND Address (GRPC)</Label>
           <Input
+            required
             name="lnd-address"
             onChange={(e) => setLndAddress(e.target.value)}
             value={lndAddress}
@@ -64,7 +57,18 @@ export function LNDForm() {
           />
         </div>
         <div className="grid gap-1.5">
-          <Label htmlFor="lnd-cert-hex">TLS Certificate (Hex)</Label>
+          <Label htmlFor="lnd-macaroon-hex">Admin Macaroon (Hex)</Label>
+          <Input
+            required
+            name="lnd-macaroon-hex"
+            onChange={(e) => setLndMacaroonHex(e.target.value)}
+            value={lndMacaroonHex}
+            type="text"
+            id="lnd-macaroon-hex"
+          />
+        </div>
+        <div className="grid gap-1.5">
+          <Label htmlFor="lnd-cert-hex">TLS Certificate (Hex) (optional)</Label>
           <Input
             name="lnd-cert-hex"
             onChange={(e) => setLndCertHex(e.target.value)}
@@ -72,16 +76,13 @@ export function LNDForm() {
             type="text"
             id="lnd-cert-hex"
           />
-        </div>
-        <div className="grid gap-1.5">
-          <Label htmlFor="lnd-macaroon-hex">Admin Macaroon (Hex)</Label>
-          <Input
-            name="lnd-macaroon-hex"
-            onChange={(e) => setLndMacaroonHex(e.target.value)}
-            value={lndMacaroonHex}
-            type="text"
-            id="lnd-macaroon-hex"
-          />
+          {!lndCertHex && (
+            <div className="flex flex-row gap-2 items-center justify-start text-sm text-muted-foreground mt-2">
+              <InfoIcon className="h-4 w-4 shrink-0" />
+              Skipping TLS certificate is not recommended as it may expose your
+              connection to security risks
+            </div>
+          )}
         </div>
         <Button>Next</Button>
       </form>

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -422,7 +422,7 @@ func (svc *LNDService) SendKeysend(ctx context.Context, amount uint64, destinati
 }
 
 func NewLNDService(ctx context.Context, eventPublisher events.EventPublisher, lndAddress, lndCertHex, lndMacaroonHex string) (result lnclient.LNClient, err error) {
-	if lndAddress == "" || lndCertHex == "" || lndMacaroonHex == "" {
+	if lndAddress == "" || lndMacaroonHex == "" {
 		return nil, errors.New("one or more required LND configuration are missing")
 	}
 

--- a/lnclient/lnd/wrapper/lnd.go
+++ b/lnclient/lnd/wrapper/lnd.go
@@ -49,10 +49,7 @@ func NewLNDclient(lndOptions LNDoptions) (result *LNDWrapper, err error) {
 		if !cp.AppendCertsFromPEM(cert) {
 			return nil, errors.New("failed to append certificate")
 		}
-		creds = credentials.NewTLS(&tls.Config{
-			ClientCAs:          cp,
-			InsecureSkipVerify: true,
-		})
+		creds = credentials.NewClientTLSFromCert(cp, "")
 		// if a path to a cert file is provided
 	} else {
 		creds = credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})


### PR DESCRIPTION
Fixes #405

## Description

EDIT: We decided that it's good to always verify if a certificate is passed by the user. If users raise concerns about using their own self-signed certificate (as it fails the verification), we'll think of adding a checkbox saying "I'm using a self signed certificate" which when checked can skip the cert verification process.

As we anyways ask the user to provide the certificate, it doesn't make any sense to verify the server certificate and host name, the same is also true for the case when the TLS certificate is not provided (as the user agrees to the risk it poses). So this adds `InsecureSkipVerify: true` in both cases while generating transport credentials.

(And yes, this PR also adds the possibility to continue without adding a TLS certificate)

## Screenshot
<table>
<tr>
<td><img src="https://github.com/user-attachments/assets/52d70d6c-c019-4c51-ba7e-d2f1dbe08013"/></td>
<td><img src="https://github.com/user-attachments/assets/9e512cb5-c1fc-4f82-bb7b-f393d0dff8a0"/></td>
</tr>
</table>
