### PR TITLE
fix: only show vss info in alby account settings if vss is supported

### DIFF
--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -794,6 +794,7 @@ func (svc *albyOAuthService) ConsumeEvent(ctx context.Context, event *events.Eve
 type channelsBackup struct {
 	Description string `json:"description"`
 	Data        string `json:"data"`
+	NodePubkey  string `json:"node_pubkey"`
 }
 
 func (svc *albyOAuthService) createEncryptedChannelBackup(event *events.StaticChannelsBackupEvent) (*channelsBackup, error) {
@@ -818,6 +819,7 @@ func (svc *albyOAuthService) createEncryptedChannelBackup(event *events.StaticCh
 	backup := &channelsBackup{
 		Description: "channels_v2",
 		Data:        encrypted,
+		NodePubkey:  event.NodeID,
 	}
 	return backup, nil
 }

--- a/api/api.go
+++ b/api/api.go
@@ -691,6 +691,7 @@ func (api *api) GetInfo(ctx context.Context) (*InfoResponse, error) {
 	info.Version = version.Tag
 	info.EnableAdvancedSetup = api.cfg.GetEnv().EnableAdvancedSetup
 	info.LdkVssEnabled = ldkVssEnabled == "true"
+	info.VssSupported = backendType == config.LDKBackendType && api.cfg.GetEnv().LDKVssUrl != ""
 	albyUserIdentifier, err := api.albyOAuthSvc.GetUserIdentifier()
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to get alby user identifier")
@@ -919,6 +920,10 @@ func (api *api) MigrateNodeStorage(ctx context.Context, to string) error {
 
 	if ldkVssEnabled == "true" {
 		return errors.New("VSS already enabled")
+	}
+
+	if api.cfg.GetEnv().LDKVssUrl == "" {
+		return errors.New("No VSS URL set")
 	}
 
 	api.cfg.SetUpdate("LdkVssEnabled", "true", "")

--- a/api/models.go
+++ b/api/models.go
@@ -172,6 +172,7 @@ type InfoResponse struct {
 	Network              string    `json:"network"`
 	EnableAdvancedSetup  bool      `json:"enableAdvancedSetup"`
 	LdkVssEnabled        bool      `json:"ldkVssEnabled"`
+	VssSupported         bool      `json:"vssSupported"`
 	StartupError         string    `json:"startupError"`
 	StartupErrorTime     time.Time `json:"startupErrorTime"`
 }

--- a/frontend/src/screens/settings/AlbyAccount.tsx
+++ b/frontend/src/screens/settings/AlbyAccount.tsx
@@ -81,19 +81,19 @@ export function AlbyAccount() {
           </CardHeader>
         </Card>
       </UnlinkAlbyAccount>
-      <div /* spacing */ />
-      <SettingsHeader title="VSS" description="Versioned Storage Service" />
-      <p>
-        Versioned Storage Service (VSS) provides a secure, encrypted server-side
-        storage of essential lightning and onchain data.
-      </p>
-      <p>
-        This service is enabled by your Alby account and provides additional
-        backup security which allows you to recover your lightning data with
-        your recovery phrase alone, without having to close your channels.
-      </p>
-      {info && (
+      {info?.vssSupported && (
         <>
+          <div /* spacing */ />
+          <SettingsHeader title="VSS" description="Versioned Storage Service" />
+          <p>
+            Versioned Storage Service (VSS) provides a secure, encrypted
+            server-side storage of essential lightning and onchain data.
+          </p>
+          <p>
+            This service is enabled by your Alby account and provides additional
+            backup security which allows you to recover your lightning data with
+            your recovery phrase alone, without having to close your channels.
+          </p>
           {info.ldkVssEnabled && (
             <p>
               ✅ VSS <b>enabled</b>.{" "}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -142,6 +142,7 @@ export interface InfoResponse {
   oauthRedirect: boolean;
   albyAccountConnected: boolean;
   ldkVssEnabled: boolean;
+  vssSupported: boolean;
   running: boolean;
   albyAuthUrl: string;
   nextBackupReminder: string;


### PR DESCRIPTION
e.g. we do not want a user to try to migrate if they actually cannot.