### PR TITLE
chore: add tests for calculateFeeReserve

### DIFF
--- a/transactions/isolated_app_payments_test.go
+++ b/transactions/isolated_app_payments_test.go
@@ -321,3 +321,16 @@ func TestSendPaymentSync_IsolatedApp_BalanceSufficient_FailedPayment(t *testing.
 	assert.Equal(t, app.ID, *transaction.AppId)
 	assert.Equal(t, dbRequestEvent.ID, *transaction.RequestEventId)
 }
+
+func TestCalculateFeeReserve(t *testing.T) {
+	defer tests.RemoveTestService()
+	svc, err := tests.CreateTestService()
+	require.NoError(t, err)
+	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
+
+	assert.Equal(t, uint64(10_000), transactionsService.calculateFeeReserveMsat(0))
+	assert.Equal(t, uint64(10_000), transactionsService.calculateFeeReserveMsat(10_000))
+	assert.Equal(t, uint64(10_000), transactionsService.calculateFeeReserveMsat(100_000))
+	assert.Equal(t, uint64(10_000), transactionsService.calculateFeeReserveMsat(1000_000))
+	assert.Equal(t, uint64(20_000), transactionsService.calculateFeeReserveMsat(2000_000))
+}


### PR DESCRIPTION
already tests in the same file for sufficient/insufficient budget based on the fee reserve, but not the fee reserve calculation function. I am just paranoid :grin: 