### PR TITLE
feat: nwc create_connection command (WIP)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -883,6 +883,8 @@ func (api *api) GetWalletCapabilities(ctx context.Context) (*WalletCapabilitiesR
 	if len(notificationTypes) > 0 {
 		scopes = append(scopes, constants.NOTIFICATIONS_SCOPE)
 	}
+	// add always-supported capabilities
+	scopes = append(scopes, constants.SUPERUSER_SCOPE)
 
 	return &WalletCapabilitiesResponse{
 		Methods:           methods,

--- a/apps/apps_service.go
+++ b/apps/apps_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/getAlby/hub/constants"
@@ -44,9 +45,13 @@ func (svc *appsService) CreateApp(name string, pubkey string, maxAmountSat uint6
 		return nil, "", errors.New("isolated app cannot have sign_message scope")
 	}
 
-	// TODO: ensure there is at least one scope
+	if budgetRenewal == "" {
+		budgetRenewal = constants.BUDGET_RENEWAL_NEVER
+	}
 
-	// TODO: validate budget renewal
+	if !slices.Contains(constants.GetBudgetRenewals(), budgetRenewal) {
+		return nil, "", fmt.Errorf("invalid budget renewal. Must be one of %s", strings.Join(constants.GetBudgetRenewals(), ","))
+	}
 
 	var pairingPublicKey string
 	var pairingSecretKey string

--- a/apps/apps_service.go
+++ b/apps/apps_service.go
@@ -44,6 +44,10 @@ func (svc *appsService) CreateApp(name string, pubkey string, maxAmountSat uint6
 		return nil, "", errors.New("isolated app cannot have sign_message scope")
 	}
 
+	// TODO: ensure there is at least one scope
+
+	// TODO: validate budget renewal
+
 	var pairingPublicKey string
 	var pairingSecretKey string
 	if pubkey == "" {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -19,6 +19,16 @@ const (
 	BUDGET_RENEWAL_NEVER   = "never"
 )
 
+func GetBudgetRenewals() []string {
+	return []string{
+		BUDGET_RENEWAL_DAILY,
+		BUDGET_RENEWAL_WEEKLY,
+		BUDGET_RENEWAL_MONTHLY,
+		BUDGET_RENEWAL_YEARLY,
+		BUDGET_RENEWAL_NEVER,
+	}
+}
+
 const (
 	PAY_INVOICE_SCOPE       = "pay_invoice" // also covers pay_keysend and multi_* payment methods
 	GET_BALANCE_SCOPE       = "get_balance"

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -28,6 +28,7 @@ const (
 	LIST_TRANSACTIONS_SCOPE = "list_transactions"
 	SIGN_MESSAGE_SCOPE      = "sign_message"
 	NOTIFICATIONS_SCOPE     = "notifications" // covers all notification types
+	SUPERUSER_SCOPE         = "superuser"
 )
 
 // limit encoded metadata length, otherwise relays may have trouble listing multiple transactions

--- a/frontend/src/components/Permissions.tsx
+++ b/frontend/src/components/Permissions.tsx
@@ -1,4 +1,4 @@
-import { BrickWall, PlusCircle } from "lucide-react";
+import { AlertTriangleIcon, BrickWall, PlusCircle } from "lucide-react";
 import React from "react";
 import BudgetAmountSelect from "src/components/BudgetAmountSelect";
 import BudgetRenewalSelect from "src/components/BudgetRenewalSelect";
@@ -128,6 +128,20 @@ const Permissions: React.FC<PermissionsProps> = ({
             will have an isolated balance and only has access to its own
             transaction history. It will not be able to sign messages on your
             node's behalf.
+          </p>
+        </>
+      )}
+
+      {permissions.scopes.includes("superuser") && (
+        <>
+          <div className="flex items-center gap-2 mb-2">
+            <AlertTriangleIcon className="w-4 h-4" />
+            <p className="text-sm font-medium">Superuser Access</p>
+          </div>
+
+          <p className="mb-4">
+            This app can create other app connections. Please make sure you
+            trust this app.
           </p>
         </>
       )}

--- a/frontend/src/components/Scopes.tsx
+++ b/frontend/src/components/Scopes.tsx
@@ -52,7 +52,7 @@ const Scopes: React.FC<ScopesProps> = ({
   onScopesChanged,
 }) => {
   const fullAccessScopes: Scope[] = React.useMemo(() => {
-    return [...capabilities.scopes];
+    return capabilities.scopes.filter((scope) => scope !== "superuser");
   }, [capabilities.scopes]);
 
   const readOnlyScopes: Scope[] = React.useMemo(() => {
@@ -87,10 +87,17 @@ const Scopes: React.FC<ScopesProps> = ({
   }, [capabilities.scopes]);
 
   const [scopeGroup, setScopeGroup] = React.useState<ScopeGroup>(() => {
-    if (isolated && scopes.length === capabilities.scopes.length) {
+    if (
+      isolated &&
+      scopes.length === fullAccessScopes.length &&
+      scopes.every((scope) => fullAccessScopes.includes(scope))
+    ) {
       return "isolated";
     }
-    if (scopes.length === capabilities.scopes.length) {
+    if (
+      scopes.length === fullAccessScopes.length &&
+      scopes.every((scope) => fullAccessScopes.includes(scope))
+    ) {
       return "full_access";
     }
     if (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,6 +1,7 @@
 import {
   Bell,
   CirclePlus,
+  Crown,
   HandCoins,
   Info,
   LucideIcon,
@@ -47,7 +48,8 @@ export type Scope =
   | "lookup_invoice"
   | "list_transactions"
   | "sign_message"
-  | "notifications"; // covers all notification types
+  | "notifications" // covers all notification types
+  | "superuser";
 
 export type Nip47NotificationType = "payment_received" | "payment_sent";
 
@@ -64,6 +66,7 @@ export const scopeIconMap: ScopeIconMap = {
   pay_invoice: HandCoins,
   sign_message: PenLine,
   notifications: Bell,
+  superuser: Crown,
 };
 
 export type WalletCapabilities = {
@@ -89,6 +92,7 @@ export const scopeDescriptions: Record<Scope, string> = {
   pay_invoice: "Send payments",
   sign_message: "Sign messages",
   notifications: "Receive wallet notifications",
+  superuser: "Create other app connections",
 };
 
 export const expiryOptions: Record<string, number> = {

--- a/nip47/controllers/create_connection_controller.go
+++ b/nip47/controllers/create_connection_controller.go
@@ -1,0 +1,77 @@
+package controllers
+
+import (
+	"context"
+	"time"
+
+	"github.com/getAlby/hub/constants"
+	"github.com/getAlby/hub/logger"
+	"github.com/getAlby/hub/nip47/models"
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/sirupsen/logrus"
+)
+
+type createConnectionBudgetParams struct {
+	Budget        uint64 `json:"budget"`
+	RenewalPeriod string `json:"renewal_period"`
+}
+
+type createConnectionParams struct {
+	Pubkey    string                       `json:"pubkey"` // pubkey of the app connection
+	Name      string                       `json:"name"`
+	Scopes    []string                     `json:"scopes"`
+	Budget    createConnectionBudgetParams `json:"budget"`
+	ExpiresAt *uint64                      `json:"expires_at"` // unix timestamp
+	Isolated  bool                         `json:"isolated"`
+	Metadata  map[string]interface{}       `json:"metadata,omitempty"`
+}
+
+type createConnectionResponse struct {
+	// pubkey is given, user requesting already knows relay.
+	WalletPubkey string `json:"wallet_pubkey"`
+}
+
+func (controller *nip47Controller) HandleCreateConnectionEvent(ctx context.Context, nip47Request *models.Request, requestEventId uint, publishResponse publishFunc) {
+	params := &createConnectionParams{}
+	resp := decodeRequest(nip47Request, params)
+	if resp != nil {
+		publishResponse(resp, nostr.Tags{})
+		return
+	}
+
+	logger.Logger.WithFields(logrus.Fields{
+		"request_event_id": requestEventId,
+		"params":           params,
+	}).Info("creating app")
+
+	var expiresAt *time.Time
+	if params.ExpiresAt != nil {
+		expiresAtUnsigned := *params.ExpiresAt
+		expiresAtValue := time.Unix(int64(expiresAtUnsigned), 0)
+		expiresAt = &expiresAtValue
+	}
+
+	app, _, err := controller.appsService.CreateApp(params.Name, params.Pubkey, params.Budget.Budget, params.Budget.RenewalPeriod, expiresAt, params.Scopes, params.Isolated, params.Metadata)
+	if err != nil {
+		logger.Logger.WithFields(logrus.Fields{
+			"request_event_id": requestEventId,
+		}).WithError(err).Error("Failed to create app")
+		publishResponse(&models.Response{
+			ResultType: nip47Request.Method,
+			Error: &models.Error{
+				Code:    constants.ERROR_INTERNAL,
+				Message: err.Error(),
+			},
+		}, nostr.Tags{})
+		return
+	}
+
+	responsePayload := createConnectionResponse{
+		WalletPubkey: *app.WalletPubkey,
+	}
+
+	publishResponse(&models.Response{
+		ResultType: nip47Request.Method,
+		Result:     responsePayload,
+	}, nostr.Tags{})
+}

--- a/nip47/controllers/create_connection_controller.go
+++ b/nip47/controllers/create_connection_controller.go
@@ -69,6 +69,18 @@ func (controller *nip47Controller) HandleCreateConnectionEvent(ctx context.Conte
 	}
 	scopes, err := permissions.RequestMethodsToScopes(params.Methods)
 
+	// ensure there is at least one scope
+	if len(scopes) == 0 {
+		publishResponse(&models.Response{
+			ResultType: nip47Request.Method,
+			Error: &models.Error{
+				Code:    constants.ERROR_INTERNAL,
+				Message: "No methods provided",
+			},
+		}, nostr.Tags{})
+		return
+	}
+
 	app, _, err := controller.appsService.CreateApp(params.Name, params.Pubkey, params.Budget.Budget, params.Budget.RenewalPeriod, expiresAt, scopes, params.Isolated, params.Metadata)
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{

--- a/nip47/controllers/create_connection_controller_test.go
+++ b/nip47/controllers/create_connection_controller_test.go
@@ -34,7 +34,7 @@ func TestHandleCreateConnectionEvent(t *testing.T) {
 	"params": {
 		"pubkey": "%s",
 		"name": "Test 123",
-		"scopes": ["get_info"]
+		"methods": ["get_info"]
 	}
 }
 `, pairingPublicKey)
@@ -78,4 +78,4 @@ func TestHandleCreateConnectionEvent(t *testing.T) {
 
 // TODO: app already exists test
 // TODO: validation - no pubkey, no scopes, wrong budget etc,
-// TODO: review scopes
+// TODO: ensure lnclient supports the methods

--- a/nip47/controllers/get_balance_controller_test.go
+++ b/nip47/controllers/get_balance_controller_test.go
@@ -48,7 +48,7 @@ func TestHandleGetBalanceEvent(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleGetBalanceEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
 	assert.Equal(t, uint64(21000), publishedResponse.Result.(*getBalanceResponse).Balance)
@@ -82,7 +82,7 @@ func TestHandleGetBalanceEvent_IsolatedApp_NoTransactions(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleGetBalanceEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
 	assert.Equal(t, uint64(0), publishedResponse.Result.(*getBalanceResponse).Balance)
@@ -129,7 +129,7 @@ func TestHandleGetBalanceEvent_IsolatedApp_Transactions(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleGetBalanceEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
 	assert.Equal(t, uint64(1000), publishedResponse.Result.(*getBalanceResponse).Balance)

--- a/nip47/controllers/get_budget_controller_test.go
+++ b/nip47/controllers/get_budget_controller_test.go
@@ -59,7 +59,7 @@ func TestHandleGetBudgetEvent_NoRenewal(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleGetBudgetEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
 	assert.Equal(t, uint64(400000), publishedResponse.Result.(*getBudgetResponse).TotalBudget)
@@ -105,7 +105,7 @@ func TestHandleGetBudgetEvent_NoneUsed(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleGetBudgetEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
 	assert.Equal(t, uint64(400000), publishedResponse.Result.(*getBudgetResponse).TotalBudget)
@@ -159,7 +159,7 @@ func TestHandleGetBudgetEvent_HalfUsed(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleGetBudgetEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
 	assert.Equal(t, uint64(400000), publishedResponse.Result.(*getBudgetResponse).TotalBudget)
@@ -210,7 +210,7 @@ func TestHandleGetBudgetEvent_NoBudget(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleGetBudgetEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
 	assert.Equal(t, struct{}{}, publishedResponse.Result)
@@ -242,7 +242,7 @@ func TestHandleGetBudgetEvent_NoPayInvoicePermission(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleGetBudgetEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
 	assert.Equal(t, struct{}{}, publishedResponse.Result)

--- a/nip47/controllers/get_info_controller_test.go
+++ b/nip47/controllers/get_info_controller_test.go
@@ -56,7 +56,7 @@ func TestHandleGetInfoEvent_NoPermission(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleGetInfoEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
 	assert.Nil(t, publishedResponse.Error)
@@ -105,7 +105,7 @@ func TestHandleGetInfoEvent_WithPermission(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleGetInfoEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
 	assert.Nil(t, publishedResponse.Error)
@@ -161,7 +161,7 @@ func TestHandleGetInfoEvent_WithNotifications(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleGetInfoEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
 	assert.Nil(t, publishedResponse.Error)

--- a/nip47/controllers/list_transactions_controller_test.go
+++ b/nip47/controllers/list_transactions_controller_test.go
@@ -77,7 +77,7 @@ func TestHandleListTransactionsEvent(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleListTransactionsEvent(ctx, nip47Request, dbRequestEvent.ID, *dbRequestEvent.AppId, publishResponse)
 
 	assert.Nil(t, publishedResponse.Error)
@@ -148,7 +148,7 @@ func TestHandleListTransactionsEvent_UnpaidOutgoingOnly(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleListTransactionsEvent(ctx, nip47Request, dbRequestEvent.ID, *dbRequestEvent.AppId, publishResponse)
 
 	assert.Nil(t, publishedResponse.Error)
@@ -210,7 +210,7 @@ func TestHandleListTransactionsEvent_UnpaidIncomingOnly(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleListTransactionsEvent(ctx, nip47Request, dbRequestEvent.ID, *dbRequestEvent.AppId, publishResponse)
 
 	assert.Nil(t, publishedResponse.Error)
@@ -272,7 +272,7 @@ func TestHandleListTransactionsEvent_Unpaid(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleListTransactionsEvent(ctx, nip47Request, dbRequestEvent.ID, *dbRequestEvent.AppId, publishResponse)
 
 	assert.Nil(t, publishedResponse.Error)
@@ -340,7 +340,7 @@ func TestHandleListTransactionsEvent_Paid(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleListTransactionsEvent(ctx, nip47Request, dbRequestEvent.ID, *dbRequestEvent.AppId, publishResponse)
 
 	assert.Nil(t, publishedResponse.Error)

--- a/nip47/controllers/lookup_invoice_controller_test.go
+++ b/nip47/controllers/lookup_invoice_controller_test.go
@@ -68,7 +68,7 @@ func TestHandleLookupInvoiceEvent(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleLookupInvoiceEvent(ctx, nip47Request, dbRequestEvent.ID, *dbRequestEvent.AppId, publishResponse)
 
 	assert.Nil(t, publishedResponse.Error)

--- a/nip47/controllers/make_invoice_controller_test.go
+++ b/nip47/controllers/make_invoice_controller_test.go
@@ -66,7 +66,7 @@ func TestHandleMakeInvoiceEvent(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleMakeInvoiceEvent(ctx, nip47Request, dbRequestEvent.ID, *dbRequestEvent.AppId, publishResponse)
 
 	expectedMetadata := map[string]interface{}{

--- a/nip47/controllers/multi_pay_invoice_controller_test.go
+++ b/nip47/controllers/multi_pay_invoice_controller_test.go
@@ -102,7 +102,7 @@ func TestHandleMultiPayInvoiceEvent_Success(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleMultiPayInvoiceEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
 	var paymentHashes = []string{
@@ -170,7 +170,7 @@ func TestHandleMultiPayInvoiceEvent_OneMalformedInvoice(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleMultiPayInvoiceEvent(ctx, nip47Request, requestEvent.ID, app, publishResponse)
 
 	assert.Equal(t, 2, len(responses))
@@ -243,7 +243,7 @@ func TestHandleMultiPayInvoiceEvent_IsolatedApp_OneBudgetExceeded(t *testing.T) 
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleMultiPayInvoiceEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
 	assert.Equal(t, 2, len(responses))
@@ -323,7 +323,7 @@ func TestHandleMultiPayInvoiceEvent_LNClient_OnePaymentFailed(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleMultiPayInvoiceEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
 	assert.Equal(t, 2, len(responses))

--- a/nip47/controllers/multi_pay_keysend_controller_test.go
+++ b/nip47/controllers/multi_pay_keysend_controller_test.go
@@ -108,7 +108,7 @@ func TestHandleMultiPayKeysendEvent_Success(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleMultiPayKeysendEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
 	assert.Equal(t, 2, len(responses))
@@ -160,7 +160,7 @@ func TestHandleMultiPayKeysendEvent_OneBudgetExceeded(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandleMultiPayKeysendEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
 	// we can't guarantee which request was processed first

--- a/nip47/controllers/nip47_controller.go
+++ b/nip47/controllers/nip47_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"github.com/getAlby/hub/apps"
 	"github.com/getAlby/hub/events"
 	"github.com/getAlby/hub/lnclient"
 	"github.com/getAlby/hub/nip47/permissions"
@@ -14,14 +15,22 @@ type nip47Controller struct {
 	eventPublisher      events.EventPublisher
 	permissionsService  permissions.PermissionsService
 	transactionsService transactions.TransactionsService
+	appsService         apps.AppsService
 }
 
-func NewNip47Controller(lnClient lnclient.LNClient, db *gorm.DB, eventPublisher events.EventPublisher, permissionsService permissions.PermissionsService, transactionsService transactions.TransactionsService) *nip47Controller {
+func NewNip47Controller(
+	lnClient lnclient.LNClient,
+	db *gorm.DB,
+	eventPublisher events.EventPublisher,
+	permissionsService permissions.PermissionsService,
+	transactionsService transactions.TransactionsService,
+	appsService apps.AppsService) *nip47Controller {
 	return &nip47Controller{
 		lnClient:            lnClient,
 		db:                  db,
 		eventPublisher:      eventPublisher,
 		permissionsService:  permissionsService,
 		transactionsService: transactionsService,
+		appsService:         appsService,
 	}
 }

--- a/nip47/controllers/pay_invoice_controller_test.go
+++ b/nip47/controllers/pay_invoice_controller_test.go
@@ -78,7 +78,7 @@ func TestHandlePayInvoiceEvent(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandlePayInvoiceEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse, nostr.Tags{})
 
 	assert.Equal(t, "123preimage", publishedResponse.Result.(payResponse).Preimage)
@@ -129,7 +129,7 @@ func TestHandlePayInvoiceEvent_0Amount(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandlePayInvoiceEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse, nostr.Tags{})
 
 	assert.Equal(t, "123preimage", publishedResponse.Result.(payResponse).Preimage)
@@ -174,7 +174,7 @@ func TestHandlePayInvoiceEvent_MalformedInvoice(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandlePayInvoiceEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse, nostr.Tags{})
 
 	assert.Nil(t, publishedResponse.Result)

--- a/nip47/controllers/pay_keysend_controller_test.go
+++ b/nip47/controllers/pay_keysend_controller_test.go
@@ -80,7 +80,7 @@ func TestHandlePayKeysendEvent(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandlePayKeysendEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse, nostr.Tags{})
 
 	assert.Nil(t, publishedResponse.Error)
@@ -121,7 +121,7 @@ func TestHandlePayKeysendEvent_WithPreimage(t *testing.T) {
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
 	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
-	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc, svc.AppsService).
 		HandlePayKeysendEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse, nostr.Tags{})
 
 	assert.Nil(t, publishedResponse.Error)

--- a/nip47/event_handler.go
+++ b/nip47/event_handler.go
@@ -293,7 +293,7 @@ func (svc *nip47Service) HandleEvent(ctx context.Context, relay nostrmodels.Rela
 		}
 	}
 
-	controller := controllers.NewNip47Controller(lnClient, svc.db, svc.eventPublisher, svc.permissionsService, svc.transactionsService)
+	controller := controllers.NewNip47Controller(lnClient, svc.db, svc.eventPublisher, svc.permissionsService, svc.transactionsService, svc.appsService)
 
 	switch nip47Request.Method {
 	case models.MULTI_PAY_INVOICE_METHOD:
@@ -329,6 +329,9 @@ func (svc *nip47Service) HandleEvent(ctx context.Context, relay nostrmodels.Rela
 	case models.SIGN_MESSAGE_METHOD:
 		controller.
 			HandleSignMessageEvent(ctx, nip47Request, requestEvent.ID, publishResponse)
+	case models.CREATE_CONNECTION_METHOD:
+		controller.
+			HandleCreateConnectionEvent(ctx, nip47Request, requestEvent.ID, publishResponse)
 	default:
 		publishResponse(&models.Response{
 			ResultType: nip47Request.Method,

--- a/nip47/event_handler_test.go
+++ b/nip47/event_handler_test.go
@@ -141,7 +141,7 @@ func TestHandleResponse_WithPermission(t *testing.T) {
 	assert.Nil(t, unmarshalledResponse.Error)
 	assert.Equal(t, models.GET_INFO_METHOD, unmarshalledResponse.ResultType)
 	expectedMethods := slices.Concat([]string{constants.GET_BALANCE_SCOPE}, permissions.GetAlwaysGrantedMethods())
-	assert.Equal(t, expectedMethods, unmarshalledResponse.Result.Methods)
+	assert.ElementsMatch(t, expectedMethods, unmarshalledResponse.Result.Methods)
 }
 
 func TestHandleResponse_DuplicateRequest(t *testing.T) {

--- a/nip47/models/models.go
+++ b/nip47/models/models.go
@@ -22,6 +22,7 @@ const (
 	MULTI_PAY_INVOICE_METHOD = "multi_pay_invoice"
 	MULTI_PAY_KEYSEND_METHOD = "multi_pay_keysend"
 	SIGN_MESSAGE_METHOD      = "sign_message"
+	CREATE_CONNECTION_METHOD = "create_connection"
 )
 
 type Transaction struct {

--- a/nip47/nip47_service.go
+++ b/nip47/nip47_service.go
@@ -2,6 +2,8 @@ package nip47
 
 import (
 	"context"
+
+	"github.com/getAlby/hub/apps"
 	"github.com/getAlby/hub/config"
 	"github.com/getAlby/hub/events"
 	"github.com/getAlby/hub/lnclient"
@@ -17,6 +19,7 @@ import (
 type nip47Service struct {
 	permissionsService     permissions.PermissionsService
 	transactionsService    transactions.TransactionsService
+	appsService            apps.AppsService
 	nip47NotificationQueue notifications.Nip47NotificationQueue
 	cfg                    config.Config
 	keys                   keys.Keys
@@ -41,6 +44,7 @@ func NewNip47Service(db *gorm.DB, cfg config.Config, keys keys.Keys, eventPublis
 		db:                     db,
 		permissionsService:     permissions.NewPermissionsService(db, eventPublisher),
 		transactionsService:    transactions.NewTransactionsService(db, eventPublisher),
+		appsService:            apps.NewAppsService(db, eventPublisher, keys),
 		eventPublisher:         eventPublisher,
 		keys:                   keys,
 	}

--- a/nip47/permissions/permissions.go
+++ b/nip47/permissions/permissions.go
@@ -121,6 +121,8 @@ func scopeToRequestMethods(scope string) []string {
 		return []string{models.LIST_TRANSACTIONS_METHOD}
 	case constants.SIGN_MESSAGE_SCOPE:
 		return []string{models.SIGN_MESSAGE_METHOD}
+	case constants.SUPERUSER_SCOPE:
+		return []string{models.CREATE_CONNECTION_METHOD}
 	}
 	return []string{}
 }
@@ -158,6 +160,8 @@ func RequestMethodToScope(requestMethod string) (string, error) {
 		return constants.LIST_TRANSACTIONS_SCOPE, nil
 	case models.SIGN_MESSAGE_METHOD:
 		return constants.SIGN_MESSAGE_SCOPE, nil
+	case models.CREATE_CONNECTION_METHOD:
+		return constants.SUPERUSER_SCOPE, nil
 	}
 	logger.Logger.WithField("request_method", requestMethod).Error("Unsupported request method")
 	return "", fmt.Errorf("unsupported request method: %s", requestMethod)
@@ -173,6 +177,7 @@ func AllScopes() []string {
 		constants.LIST_TRANSACTIONS_SCOPE,
 		constants.SIGN_MESSAGE_SCOPE,
 		constants.NOTIFICATIONS_SCOPE,
+		constants.SUPERUSER_SCOPE,
 	}
 }
 

--- a/nip47/permissions/permissions_test.go
+++ b/nip47/permissions/permissions_test.go
@@ -55,35 +55,6 @@ func TestHasPermission_Expired(t *testing.T) {
 	assert.Equal(t, "This app has expired", message)
 }
 
-// TODO: move to transactions service
-/*func TestHasPermission_Exceeded(t *testing.T) {
-	defer tests.RemoveTestService()
-	svc, err := tests.CreateTestService()
-	require.NoError(t, err)
-
-	app, _, err := tests.CreateApp(svc)
-	assert.NoError(t, err)
-
-	budgetRenewal := "never"
-	expiresAt := time.Now().Add(24 * time.Hour)
-	appPermission := &db.AppPermission{
-		AppId:         app.ID,
-		App:           *app,
-		Scope:         constants.PAY_INVOICE_SCOPE,
-		MaxAmountSat:  10,
-		BudgetRenewal: budgetRenewal,
-		ExpiresAt:     &expiresAt,
-	}
-	err = svc.DB.Create(appPermission).Error
-	assert.NoError(t, err)
-
-	permissionsSvc := NewPermissionsService(svc.DB, svc.EventPublisher)
-	result, code, message := permissionsSvc.HasPermission(app, PAY_INVOICE_SCOPE, 100*1000)
-	assert.False(t, result)
-	assert.Equal(t, constants.ERROR_QUOTA_EXCEEDED, code)
-	assert.Equal(t, "Insufficient budget remaining to make payment", message)
-}*/
-
 func TestHasPermission_OK(t *testing.T) {
 	defer tests.RemoveTestService()
 	svc, err := tests.CreateTestService()
@@ -142,6 +113,16 @@ func TestRequestMethodsToScopes_GetInfo(t *testing.T) {
 	scopes, err := RequestMethodsToScopes([]string{models.GET_INFO_METHOD})
 	assert.NoError(t, err)
 	assert.Equal(t, []string{constants.GET_INFO_SCOPE}, scopes)
+}
+
+func TestRequestMethodToScope_CreateConnection(t *testing.T) {
+	scope, err := RequestMethodToScope(models.CREATE_CONNECTION_METHOD)
+	assert.NoError(t, err)
+	assert.Equal(t, constants.SUPERUSER_SCOPE, scope)
+}
+func TestScopeToRequestMethods_Superuser(t *testing.T) {
+	methods := scopeToRequestMethods(constants.SUPERUSER_SCOPE)
+	assert.Equal(t, []string{models.CREATE_CONNECTION_METHOD}, methods)
 }
 
 func TestGetPermittedMethods_AlwaysGranted(t *testing.T) {


### PR DESCRIPTION
This is a bit of an exploration on how new app connections could be created via nwc (e.g. for NWA). e.g. in Alby Go.

Things I noticed:
- initial implementation is quite minor, most of the code is already written.
- [x] use methods instead of scopes since scopes do not exist in the NIP-47 spec.
- [x] UI change required to have the new superuser scope
- [ ] budgets and other restrictions do not make sense if this scope exists, since the superuser scope can create new connections without restrictions
- [ ] Alby Go would need a custom detail page to enable the superuser scope
- [ ] Does there need to be a way in the hub to explicitly confirm a superuser scope to create an app (e.g. re-entering unlock password?)
- [x] add missing tests
- [x] implement in JS SDK
- [ ] implement "NWA" in bitcoin connect
- [ ] implement "NWA" in Alby Go