### PR TITLE
feat: add env variable to enable ldk transient network graph

### DIFF
--- a/config/models.go
+++ b/config/models.go
@@ -14,37 +14,38 @@ const (
 )
 
 type AppConfig struct {
-	Relay                 string `envconfig:"RELAY" default:"wss://relay.getalby.com/v1"`
-	LNBackendType         string `envconfig:"LN_BACKEND_TYPE"`
-	LNDAddress            string `envconfig:"LND_ADDRESS"`
-	LNDCertFile           string `envconfig:"LND_CERT_FILE"`
-	LNDMacaroonFile       string `envconfig:"LND_MACAROON_FILE"`
-	Workdir               string `envconfig:"WORK_DIR"`
-	Port                  string `envconfig:"PORT" default:"8080"`
-	DatabaseUri           string `envconfig:"DATABASE_URI" default:"nwc.db"`
-	JWTSecret             string `envconfig:"JWT_SECRET"`
-	LogLevel              string `envconfig:"LOG_LEVEL" default:"4"`
-	LogToFile             bool   `envconfig:"LOG_TO_FILE" default:"true"`
-	LDKNetwork            string `envconfig:"LDK_NETWORK" default:"bitcoin"`
-	LDKEsploraServer      string `envconfig:"LDK_ESPLORA_SERVER" default:"https://electrs.getalbypro.com"` // TODO: remove LDK prefix
-	LDKGossipSource       string `envconfig:"LDK_GOSSIP_SOURCE"`
-	LDKLogLevel           string `envconfig:"LDK_LOG_LEVEL" default:"3"`
-	LDKVssUrl             string `envconfig:"LDK_VSS_URL"`
-	LDKListeningAddresses string `envconfig:"LDK_LISTENING_ADDRESSES" default:"0.0.0.0:9735,[::]:9735"`
-	MempoolApi            string `envconfig:"MEMPOOL_API" default:"https://mempool.space/api"`
-	AlbyClientId          string `envconfig:"ALBY_OAUTH_CLIENT_ID" default:"J2PbXS1yOf"`
-	AlbyClientSecret      string `envconfig:"ALBY_OAUTH_CLIENT_SECRET" default:"rABK2n16IWjLTZ9M1uKU"`
-	BaseUrl               string `envconfig:"BASE_URL"`
-	FrontendUrl           string `envconfig:"FRONTEND_URL"`
-	LogEvents             bool   `envconfig:"LOG_EVENTS" default:"true"`
-	AutoLinkAlbyAccount   bool   `envconfig:"AUTO_LINK_ALBY_ACCOUNT" default:"true"`
-	PhoenixdAddress       string `envconfig:"PHOENIXD_ADDRESS"`
-	PhoenixdAuthorization string `envconfig:"PHOENIXD_AUTHORIZATION"`
-	GoProfilerAddr        string `envconfig:"GO_PROFILER_ADDR"`
-	DdProfilerEnabled     bool   `envconfig:"DD_PROFILER_ENABLED" default:"false"`
-	EnableAdvancedSetup   bool   `envconfig:"ENABLE_ADVANCED_SETUP" default:"true"`
-	AutoUnlockPassword    string `envconfig:"AUTO_UNLOCK_PASSWORD"`
-	LogDBQueries          bool   `envconfig:"LOG_DB_QUERIES" default:"false"`
+	Relay                    string `envconfig:"RELAY" default:"wss://relay.getalby.com/v1"`
+	LNBackendType            string `envconfig:"LN_BACKEND_TYPE"`
+	LNDAddress               string `envconfig:"LND_ADDRESS"`
+	LNDCertFile              string `envconfig:"LND_CERT_FILE"`
+	LNDMacaroonFile          string `envconfig:"LND_MACAROON_FILE"`
+	Workdir                  string `envconfig:"WORK_DIR"`
+	Port                     string `envconfig:"PORT" default:"8080"`
+	DatabaseUri              string `envconfig:"DATABASE_URI" default:"nwc.db"`
+	JWTSecret                string `envconfig:"JWT_SECRET"`
+	LogLevel                 string `envconfig:"LOG_LEVEL" default:"4"`
+	LogToFile                bool   `envconfig:"LOG_TO_FILE" default:"true"`
+	LDKNetwork               string `envconfig:"LDK_NETWORK" default:"bitcoin"`
+	LDKEsploraServer         string `envconfig:"LDK_ESPLORA_SERVER" default:"https://electrs.getalbypro.com"` // TODO: remove LDK prefix
+	LDKGossipSource          string `envconfig:"LDK_GOSSIP_SOURCE"`
+	LDKLogLevel              string `envconfig:"LDK_LOG_LEVEL" default:"3"`
+	LDKVssUrl                string `envconfig:"LDK_VSS_URL"`
+	LDKListeningAddresses    string `envconfig:"LDK_LISTENING_ADDRESSES" default:"0.0.0.0:9735,[::]:9735"`
+	LDKTransientNetworkGraph bool   `envconfig:"LDK_TRANSIENT_NETWORK_GRAPH" default:"false"`
+	MempoolApi               string `envconfig:"MEMPOOL_API" default:"https://mempool.space/api"`
+	AlbyClientId             string `envconfig:"ALBY_OAUTH_CLIENT_ID" default:"J2PbXS1yOf"`
+	AlbyClientSecret         string `envconfig:"ALBY_OAUTH_CLIENT_SECRET" default:"rABK2n16IWjLTZ9M1uKU"`
+	BaseUrl                  string `envconfig:"BASE_URL"`
+	FrontendUrl              string `envconfig:"FRONTEND_URL"`
+	LogEvents                bool   `envconfig:"LOG_EVENTS" default:"true"`
+	AutoLinkAlbyAccount      bool   `envconfig:"AUTO_LINK_ALBY_ACCOUNT" default:"true"`
+	PhoenixdAddress          string `envconfig:"PHOENIXD_ADDRESS"`
+	PhoenixdAuthorization    string `envconfig:"PHOENIXD_AUTHORIZATION"`
+	GoProfilerAddr           string `envconfig:"GO_PROFILER_ADDR"`
+	DdProfilerEnabled        bool   `envconfig:"DD_PROFILER_ENABLED" default:"false"`
+	EnableAdvancedSetup      bool   `envconfig:"ENABLE_ADVANCED_SETUP" default:"true"`
+	AutoUnlockPassword       string `envconfig:"AUTO_UNLOCK_PASSWORD"`
+	LogDBQueries             bool   `envconfig:"LOG_DB_QUERIES" default:"false"`
 }
 
 func (c *AppConfig) IsDefaultClientId() bool {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/breez/breez-sdk-go v0.5.2
 	github.com/elnosh/gonuts v0.2.0
 	github.com/getAlby/glalby-go v0.0.0-20240621192717-95673c864d59
-	github.com/getAlby/ldk-node-go v0.0.0-20241211081207-8911834564db
+	github.com/getAlby/ldk-node-go v0.0.0-20241223133853-4831e0855720
 	github.com/go-gormigrate/gormigrate/v2 v2.1.3
 	github.com/labstack/echo/v4 v4.12.0
 	github.com/nbd-wtf/go-nostr v0.42.3

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwV
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/getAlby/glalby-go v0.0.0-20240621192717-95673c864d59 h1:fSqdXE9uKhLcOOQaLtzN+D8RN3oEcZQkGX5E8PyiKy0=
 github.com/getAlby/glalby-go v0.0.0-20240621192717-95673c864d59/go.mod h1:ViyJvjlvv0GCesTJ7mb3fBo4G+/qsujDAFN90xZ7a9U=
-github.com/getAlby/ldk-node-go v0.0.0-20241211081207-8911834564db h1:jHUCoYD74IwOsMOc/99ACajlBNwfTy72AX+e5PoPwwo=
-github.com/getAlby/ldk-node-go v0.0.0-20241211081207-8911834564db/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20241223133853-4831e0855720 h1:LvoNtQgJf7rmRIkr9Yo8aFI3OtKvBIPV4cMNTUtJS2g=
+github.com/getAlby/ldk-node-go v0.0.0-20241223133853-4831e0855720/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -105,6 +105,7 @@ func NewLDKService(ctx context.Context, cfg config.Config, eventPublisher events
 		// If LogLevelGossip is changed to 0, this addition can be removed
 		ldkConfig.LogLevel = ldk_node.LogLevel(logLevel) + ldk_node.LogLevelGossip
 	}
+	ldkConfig.TransientNetworkGraph = cfg.GetEnv().LDKTransientNetworkGraph
 	builder := ldk_node.BuilderFromConfig(ldkConfig)
 	builder.SetNodeAlias("Alby Hub") // TODO: allow users to customize
 	builder.SetEntropyBip39Mnemonic(mnemonic, nil)


### PR DESCRIPTION
Consumes https://github.com/getAlby/ldk-node/pull/59

When set to true, the network graph will not be saved to local (secondary in case of vss) sqlite storage.

I added this as an env variable, as I think it should not be enabled for self-hosted nodes.