### PR TITLE
fix: fee limits for LND and LDK, isolated balance calculation

### DIFF
--- a/api/models.go
+++ b/api/models.go
@@ -71,7 +71,7 @@ type App struct {
 	BudgetUsage   uint64     `json:"budgetUsage"`
 	BudgetRenewal string     `json:"budgetRenewal"`
 	Isolated      bool       `json:"isolated"`
-	Balance       uint64     `json:"balance"`
+	Balance       int64      `json:"balance"`
 	Metadata      Metadata   `json:"metadata,omitempty"`
 }
 

--- a/db/queries/get_isolated_balance.go
+++ b/db/queries/get_isolated_balance.go
@@ -5,9 +5,9 @@ import (
 	"gorm.io/gorm"
 )
 
-func GetIsolatedBalance(tx *gorm.DB, appId uint) uint64 {
+func GetIsolatedBalance(tx *gorm.DB, appId uint) int64 {
 	var received struct {
-		Sum uint64
+		Sum int64
 	}
 	tx.
 		Table("transactions").
@@ -15,7 +15,7 @@ func GetIsolatedBalance(tx *gorm.DB, appId uint) uint64 {
 		Where("app_id = ? AND type = ? AND state = ?", appId, constants.TRANSACTION_TYPE_INCOMING, constants.TRANSACTION_STATE_SETTLED).Scan(&received)
 
 	var spent struct {
-		Sum uint64
+		Sum int64
 	}
 
 	tx.

--- a/db/queries/get_isolated_balance_test.go
+++ b/db/queries/get_isolated_balance_test.go
@@ -1,0 +1,69 @@
+package queries
+
+import (
+	"testing"
+
+	"github.com/getAlby/hub/constants"
+	"github.com/getAlby/hub/db"
+	"github.com/getAlby/hub/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetIsolatedBalance_PendingNoOverflow(t *testing.T) {
+	defer tests.RemoveTestService()
+	svc, err := tests.CreateTestService()
+	require.NoError(t, err)
+
+	app, _, err := tests.CreateApp(svc)
+	assert.NoError(t, err)
+	app.Isolated = true
+	svc.DB.Save(&app)
+
+	paymentAmount := uint64(1000) // 1 sat
+
+	tx := db.Transaction{
+		AppId:          &app.ID,
+		RequestEventId: nil,
+		Type:           constants.TRANSACTION_TYPE_OUTGOING,
+		State:          constants.TRANSACTION_STATE_PENDING,
+		FeeReserveMsat: uint64(10000),
+		AmountMsat:     paymentAmount,
+		PaymentRequest: tests.MockInvoice,
+		PaymentHash:    tests.MockPaymentHash,
+		SelfPayment:    true,
+	}
+	svc.DB.Save(&tx)
+
+	balance := GetIsolatedBalance(svc.DB, app.ID)
+	assert.Equal(t, int64(-11000), balance)
+}
+
+func TestGetIsolatedBalance_SettledNoOverflow(t *testing.T) {
+	defer tests.RemoveTestService()
+	svc, err := tests.CreateTestService()
+	require.NoError(t, err)
+
+	app, _, err := tests.CreateApp(svc)
+	assert.NoError(t, err)
+	app.Isolated = true
+	svc.DB.Save(&app)
+
+	paymentAmount := uint64(1000) // 1 sat
+
+	tx := db.Transaction{
+		AppId:          &app.ID,
+		RequestEventId: nil,
+		Type:           constants.TRANSACTION_TYPE_OUTGOING,
+		State:          constants.TRANSACTION_STATE_SETTLED,
+		FeeReserveMsat: uint64(0),
+		AmountMsat:     paymentAmount,
+		PaymentRequest: tests.MockInvoice,
+		PaymentHash:    tests.MockPaymentHash,
+		SelfPayment:    true,
+	}
+	svc.DB.Save(&tx)
+
+	balance := GetIsolatedBalance(svc.DB, app.ID)
+	assert.Equal(t, int64(-1000), balance)
+}

--- a/nip47/controllers/get_balance_controller.go
+++ b/nip47/controllers/get_balance_controller.go
@@ -17,7 +17,7 @@ const (
 )
 
 type getBalanceResponse struct {
-	Balance uint64 `json:"balance"`
+	Balance int64 `json:"balance"`
 	// MaxAmount     int    `json:"max_amount"`
 	// BudgetRenewal string `json:"budget_renewal"`
 }
@@ -29,12 +29,12 @@ func (controller *nip47Controller) HandleGetBalanceEvent(ctx context.Context, ni
 		"request_event_id": requestEventId,
 	}).Debug("Getting balance")
 
-	balance := uint64(0)
+	balance := int64(0)
 	if app.Isolated {
 		balance = queries.GetIsolatedBalance(controller.db, app.ID)
 	} else {
 		balances, err := controller.lnClient.GetBalances(ctx)
-		balance = uint64(balances.Lightning.TotalSpendable)
+		balance = balances.Lightning.TotalSpendable
 		if err != nil {
 			logger.Logger.WithFields(logrus.Fields{
 				"request_event_id": requestEventId,

--- a/nip47/controllers/get_balance_controller_test.go
+++ b/nip47/controllers/get_balance_controller_test.go
@@ -51,7 +51,7 @@ func TestHandleGetBalanceEvent(t *testing.T) {
 	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
 		HandleGetBalanceEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
-	assert.Equal(t, uint64(21000), publishedResponse.Result.(*getBalanceResponse).Balance)
+	assert.Equal(t, int64(21000), publishedResponse.Result.(*getBalanceResponse).Balance)
 	assert.Nil(t, publishedResponse.Error)
 }
 
@@ -85,7 +85,7 @@ func TestHandleGetBalanceEvent_IsolatedApp_NoTransactions(t *testing.T) {
 	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
 		HandleGetBalanceEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
-	assert.Equal(t, uint64(0), publishedResponse.Result.(*getBalanceResponse).Balance)
+	assert.Equal(t, int64(0), publishedResponse.Result.(*getBalanceResponse).Balance)
 	assert.Nil(t, publishedResponse.Error)
 }
 func TestHandleGetBalanceEvent_IsolatedApp_Transactions(t *testing.T) {
@@ -132,6 +132,6 @@ func TestHandleGetBalanceEvent_IsolatedApp_Transactions(t *testing.T) {
 	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
 		HandleGetBalanceEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
 
-	assert.Equal(t, uint64(1000), publishedResponse.Result.(*getBalanceResponse).Balance)
+	assert.Equal(t, int64(1000), publishedResponse.Result.(*getBalanceResponse).Balance)
 	assert.Nil(t, publishedResponse.Error)
 }

--- a/transactions/isolated_app_payments_test.go
+++ b/transactions/isolated_app_payments_test.go
@@ -323,14 +323,9 @@ func TestSendPaymentSync_IsolatedApp_BalanceSufficient_FailedPayment(t *testing.
 }
 
 func TestCalculateFeeReserve(t *testing.T) {
-	defer tests.RemoveTestService()
-	svc, err := tests.CreateTestService()
-	require.NoError(t, err)
-	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-
-	assert.Equal(t, uint64(10_000), transactionsService.calculateFeeReserveMsat(0))
-	assert.Equal(t, uint64(10_000), transactionsService.calculateFeeReserveMsat(10_000))
-	assert.Equal(t, uint64(10_000), transactionsService.calculateFeeReserveMsat(100_000))
-	assert.Equal(t, uint64(10_000), transactionsService.calculateFeeReserveMsat(1000_000))
-	assert.Equal(t, uint64(20_000), transactionsService.calculateFeeReserveMsat(2000_000))
+	assert.Equal(t, uint64(10_000), CalculateFeeReserveMsat(0))
+	assert.Equal(t, uint64(10_000), CalculateFeeReserveMsat(10_000))
+	assert.Equal(t, uint64(10_000), CalculateFeeReserveMsat(100_000))
+	assert.Equal(t, uint64(10_000), CalculateFeeReserveMsat(1000_000))
+	assert.Equal(t, uint64(20_000), CalculateFeeReserveMsat(2000_000))
 }

--- a/transactions/keysend_test.go
+++ b/transactions/keysend_test.go
@@ -418,7 +418,7 @@ func TestSendKeysend_IsolatedAppToNoApp(t *testing.T) {
 	result := svc.DB.Find(&transactions)
 	assert.Equal(t, int64(3), result.RowsAffected)
 	// expect balance to be decreased
-	assert.Equal(t, uint64(10000), queries.GetIsolatedBalance(svc.DB, app.ID))
+	assert.Equal(t, int64(10000), queries.GetIsolatedBalance(svc.DB, app.ID))
 }
 
 func TestSendKeysend_IsolatedAppToIsolatedApp(t *testing.T) {
@@ -510,10 +510,10 @@ func TestSendKeysend_IsolatedAppToIsolatedApp(t *testing.T) {
 	result := svc.DB.Find(&transactions)
 	assert.Equal(t, int64(3), result.RowsAffected)
 	// expect balance to be decreased
-	assert.Equal(t, uint64(10000), queries.GetIsolatedBalance(svc.DB, app.ID))
+	assert.Equal(t, int64(10000), queries.GetIsolatedBalance(svc.DB, app.ID))
 
 	// expect app2 to receive the payment
-	assert.Equal(t, uint64(123000), queries.GetIsolatedBalance(svc.DB, app2.ID))
+	assert.Equal(t, int64(123000), queries.GetIsolatedBalance(svc.DB, app2.ID))
 
 	// check notifications
 	assert.Equal(t, 2, len(mockEventConsumer.GetConsumedEvents()))

--- a/transactions/self_payments_test.go
+++ b/transactions/self_payments_test.go
@@ -106,7 +106,7 @@ func TestSendPaymentSync_SelfPayment_NoAppToIsolatedApp(t *testing.T) {
 	result := svc.DB.Find(&transactions)
 	assert.Equal(t, int64(2), result.RowsAffected)
 	// expect balance to be increased
-	assert.Equal(t, uint64(123000), queries.GetIsolatedBalance(svc.DB, app.ID))
+	assert.Equal(t, int64(123000), queries.GetIsolatedBalance(svc.DB, app.ID))
 }
 
 func TestSendPaymentSync_SelfPayment_NoAppToApp(t *testing.T) {
@@ -229,7 +229,7 @@ func TestSendPaymentSync_SelfPayment_IsolatedAppToNoApp(t *testing.T) {
 	result := svc.DB.Find(&transactions)
 	assert.Equal(t, int64(3), result.RowsAffected)
 	// expect balance to be decreased
-	assert.Equal(t, uint64(10000), queries.GetIsolatedBalance(svc.DB, app.ID))
+	assert.Equal(t, int64(10000), queries.GetIsolatedBalance(svc.DB, app.ID))
 }
 
 func TestSendPaymentSync_SelfPayment_IsolatedAppToApp(t *testing.T) {
@@ -305,7 +305,7 @@ func TestSendPaymentSync_SelfPayment_IsolatedAppToApp(t *testing.T) {
 	result := svc.DB.Find(&transactions)
 	assert.Equal(t, int64(3), result.RowsAffected)
 	// expect balance to be decreased
-	assert.Equal(t, uint64(10000), queries.GetIsolatedBalance(svc.DB, app.ID))
+	assert.Equal(t, int64(10000), queries.GetIsolatedBalance(svc.DB, app.ID))
 }
 
 func TestSendPaymentSync_SelfPayment_IsolatedAppToIsolatedApp(t *testing.T) {
@@ -387,7 +387,7 @@ func TestSendPaymentSync_SelfPayment_IsolatedAppToIsolatedApp(t *testing.T) {
 	result := svc.DB.Find(&transactions)
 	assert.Equal(t, int64(3), result.RowsAffected)
 	// expect balance to be decreased
-	assert.Equal(t, uint64(10000), queries.GetIsolatedBalance(svc.DB, app.ID))
+	assert.Equal(t, int64(10000), queries.GetIsolatedBalance(svc.DB, app.ID))
 
 	// check notifications
 	assert.Equal(t, 2, len(mockEventConsumer.GetConsumedEvents()))
@@ -473,5 +473,5 @@ func TestSendPaymentSync_SelfPayment_IsolatedAppToSelf(t *testing.T) {
 	assert.Equal(t, int64(3), result.RowsAffected)
 
 	// expect balance to be unchanged
-	assert.Equal(t, uint64(133000), queries.GetIsolatedBalance(svc.DB, app.ID))
+	assert.Equal(t, int64(133000), queries.GetIsolatedBalance(svc.DB, app.ID))
 }


### PR DESCRIPTION
There are two isolated app (subwallet) vulnerabilities fixed in this PR:
- use signed integers in isolated app balance calculation to prevent integer overflow
- enforce fee limits when making payments

TESTING:
- [x] LDK: I made 3 nodes, and could pay from A -> C through B, when B sets the routing fee for channel A->B at 10 sats, but fails when B sets the routing fee for channel A->B at 11 sats. Changing back to 10 sats works again. Max fee calculation uses the same code as the transaction service (which is used for isolated apps and budgets).

11 sats:
```
2025-01-05 08:33:37 TRACE [lightning::routing::router:3230] Ignored 0 candidate hops due to insufficient value contribution, 0 due to path length limit, 0 due to CLTV delta limit, 0 due to previous payment failure, 0 due to htlc_minimum_msat limit, 0 to avoid overpaying, 2 due to maximum total fee limit. Total: 2 ignored candidates.
2025-01-05 08:33:37 ERROR [lightning::ln::outbound_payment:997] Failed to find route for payment with id 8a5ecf53b069559f9c6e318a64fc2984d2f0931101170e60f581e7a1161521e6 and hash 8a5ecf53b069559f9c6e318a64fc2984d2f0931101170e60f581e7a1161521e6
2025-01-05 08:33:37 ERROR [ldk_node::payment::bolt11:160] Failed to send payment: RouteNotFound
```
10 sats:
```
2025-01-05 08:35:25 INFO  [lightning::routing::router:3391] Got route: path 0:
 node_id: 0314565c4af998c238a1d286e1feac4e4cd76bc416084096b26d8611f0546e6727, short_channel_id: 1918308041376202752, fee_msat: 10000, cltv_expiry_delta: 72
 node_id: 028052a3659267de42e7e127925594cd5a0cfb2f39563599aff3dc97fc07783d86, short_channel_id: 1918339927213408257, fee_msat: 1000, cltv_expiry_delta: 24
 blinded_tail: None
```
- [x] LND (same as above, with polar, using `lncli updatechanpolicy --base_fee_msat 11000 --chan_point ccd6e82c4d55c0be3a6ff4622a7b213b4aa01f
7ce504b44c1dbce5b306dd5f3a:0 --fee_rate 0 --time_lock_delta 18` the payment cannot be sent, but with `lncli updatechanpolicy --base_fee_msat 10000 --chan_point ccd6e82c4d55c0be3a6ff4622a7b213b4aa01f
7ce504b44c1dbce5b306dd5f3a:0 --fee_rate 0 --time_lock_delta 18` the payment can be sent)


- [x] Balances: I manually edited one of my sent transactions on an isolated app to have a huge fee. I correctly see a negative balance and cannot make payments. nwc get_balance and HTTP API return correct value for negative balances.