### PR TITLE
fix: check alby auth token is valid on start if alby account is connected

### DIFF
--- a/service/start.go
+++ b/service/start.go
@@ -216,6 +216,14 @@ func (svc *service) StartSubscription(ctx context.Context, sub *nostr.Subscripti
 }
 
 func (svc *service) StartApp(encryptionKey string) error {
+	albyIdentifier, err := svc.albyOAuthSvc.GetUserIdentifier()
+	if err != nil {
+		return err
+	}
+	if albyIdentifier != "" && !svc.albyOAuthSvc.IsConnected(svc.ctx) {
+		return errors.New("alby account is not authenticated")
+	}
+
 	if svc.lnClient != nil {
 		return errors.New("app already started")
 	}
@@ -226,7 +234,7 @@ func (svc *service) StartApp(encryptionKey string) error {
 
 	ctx, cancelFn := context.WithCancel(svc.ctx)
 
-	err := svc.keys.Init(svc.cfg, encryptionKey)
+	err = svc.keys.Init(svc.cfg, encryptionKey)
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to init nostr keys")
 		cancelFn()


### PR DESCRIPTION
it seems users sometimes bypass the auth page, and therefore the alby account token is not valid before the node starts

related to https://github.com/getAlby/hub/issues/772