### PR TITLE
feat: auto unlock

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -442,7 +442,15 @@ func (api *api) ChangeUnlockPassword(changeUnlockPasswordRequest *ChangeUnlockPa
 		return errors.New("LNClient not started")
 	}
 
-	err := api.cfg.ChangeUnlockPassword(changeUnlockPasswordRequest.CurrentUnlockPassword, changeUnlockPasswordRequest.NewUnlockPassword)
+	autoUnlockPassword, err := api.cfg.Get("AutoUnlockPassword", "")
+	if err != nil {
+		return err
+	}
+	if autoUnlockPassword != "" {
+		return errors.New("Please disable auto-unlock before using this feature")
+	}
+
+	err = api.cfg.ChangeUnlockPassword(changeUnlockPasswordRequest.CurrentUnlockPassword, changeUnlockPasswordRequest.NewUnlockPassword)
 
 	if err != nil {
 		logger.Logger.WithError(err).Error("failed to change unlock password")
@@ -452,6 +460,21 @@ func (api *api) ChangeUnlockPassword(changeUnlockPasswordRequest *ChangeUnlockPa
 	// Because all the encrypted fields have changed
 	// we also need to stop the lnclient and ask the user to start it again
 	return api.Stop()
+}
+
+func (api *api) SetAutoUnlockPassword(unlockPassword string) error {
+	if api.svc.GetLNClient() == nil {
+		return errors.New("LNClient not started")
+	}
+
+	err := api.cfg.SetAutoUnlockPassword(unlockPassword)
+
+	if err != nil {
+		logger.Logger.WithError(err).Error("failed to set auto unlock password")
+		return err
+	}
+
+	return nil
 }
 
 func (api *api) Stop() error {
@@ -687,6 +710,7 @@ func (api *api) GetInfo(ctx context.Context) (*InfoResponse, error) {
 	info := InfoResponse{}
 	backendType, _ := api.cfg.Get("LNBackendType", "")
 	ldkVssEnabled, _ := api.cfg.Get("LdkVssEnabled", "")
+	autoUnlockPassword, _ := api.cfg.Get("AutoUnlockPassword", "")
 	info.SetupCompleted = api.cfg.SetupCompleted()
 	if api.startupError != nil {
 		info.StartupError = api.startupError.Error()
@@ -700,6 +724,8 @@ func (api *api) GetInfo(ctx context.Context) (*InfoResponse, error) {
 	info.EnableAdvancedSetup = api.cfg.GetEnv().EnableAdvancedSetup
 	info.LdkVssEnabled = ldkVssEnabled == "true"
 	info.VssSupported = backendType == config.LDKBackendType && api.cfg.GetEnv().LDKVssUrl != ""
+	info.AutoUnlockPasswordEnabled = autoUnlockPassword != ""
+	info.AutoUnlockPasswordSupported = api.cfg.GetEnv().IsDefaultClientId()
 	albyUserIdentifier, err := api.albyOAuthSvc.GetUserIdentifier()
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to get alby user identifier")

--- a/api/backup.go
+++ b/api/backup.go
@@ -30,6 +30,14 @@ func (api *api) CreateBackup(unlockPassword string, w io.Writer) error {
 		return errors.New("invalid unlock password")
 	}
 
+	autoUnlockPassword, err := api.cfg.Get("AutoUnlockPassword", "")
+	if err != nil {
+		return err
+	}
+	if autoUnlockPassword != "" {
+		return errors.New("Please disable auto-unlock before using this feature")
+	}
+
 	workDir, err := filepath.Abs(api.cfg.GetEnv().Workdir)
 	if err != nil {
 		return fmt.Errorf("failed to get absolute workdir: %w", err)

--- a/api/models.go
+++ b/api/models.go
@@ -21,6 +21,7 @@ type API interface {
 	GetChannelPeerSuggestions(ctx context.Context) ([]alby.ChannelPeerSuggestion, error)
 	ResetRouter(key string) error
 	ChangeUnlockPassword(changeUnlockPasswordRequest *ChangeUnlockPasswordRequest) error
+	SetAutoUnlockPassword(unlockPassword string) error
 	Stop() error
 	GetNodeConnectionInfo(ctx context.Context) (*lnclient.NodeConnectionInfo, error)
 	GetNodeStatus(ctx context.Context) (*lnclient.NodeStatus, error)
@@ -159,22 +160,24 @@ type User struct {
 }
 
 type InfoResponse struct {
-	BackendType          string    `json:"backendType"`
-	SetupCompleted       bool      `json:"setupCompleted"`
-	OAuthRedirect        bool      `json:"oauthRedirect"`
-	Running              bool      `json:"running"`
-	Unlocked             bool      `json:"unlocked"`
-	AlbyAuthUrl          string    `json:"albyAuthUrl"`
-	NextBackupReminder   string    `json:"nextBackupReminder"`
-	AlbyUserIdentifier   string    `json:"albyUserIdentifier"`
-	AlbyAccountConnected bool      `json:"albyAccountConnected"`
-	Version              string    `json:"version"`
-	Network              string    `json:"network"`
-	EnableAdvancedSetup  bool      `json:"enableAdvancedSetup"`
-	LdkVssEnabled        bool      `json:"ldkVssEnabled"`
-	VssSupported         bool      `json:"vssSupported"`
-	StartupError         string    `json:"startupError"`
-	StartupErrorTime     time.Time `json:"startupErrorTime"`
+	BackendType                 string    `json:"backendType"`
+	SetupCompleted              bool      `json:"setupCompleted"`
+	OAuthRedirect               bool      `json:"oauthRedirect"`
+	Running                     bool      `json:"running"`
+	Unlocked                    bool      `json:"unlocked"`
+	AlbyAuthUrl                 string    `json:"albyAuthUrl"`
+	NextBackupReminder          string    `json:"nextBackupReminder"`
+	AlbyUserIdentifier          string    `json:"albyUserIdentifier"`
+	AlbyAccountConnected        bool      `json:"albyAccountConnected"`
+	Version                     string    `json:"version"`
+	Network                     string    `json:"network"`
+	EnableAdvancedSetup         bool      `json:"enableAdvancedSetup"`
+	LdkVssEnabled               bool      `json:"ldkVssEnabled"`
+	VssSupported                bool      `json:"vssSupported"`
+	StartupError                string    `json:"startupError"`
+	StartupErrorTime            time.Time `json:"startupErrorTime"`
+	AutoUnlockPasswordSupported bool      `json:"autoUnlockPasswordSupported"`
+	AutoUnlockPasswordEnabled   bool      `json:"autoUnlockPasswordEnabled"`
 }
 
 type MnemonicRequest struct {
@@ -188,6 +191,9 @@ type MnemonicResponse struct {
 type ChangeUnlockPasswordRequest struct {
 	CurrentUnlockPassword string `json:"currentUnlockPassword"`
 	NewUnlockPassword     string `json:"newUnlockPassword"`
+}
+type AutoUnlockRequest struct {
+	UnlockPassword string `json:"unlockPassword"`
 }
 
 type ConnectPeerRequest = lnclient.ConnectPeerRequest

--- a/config/config.go
+++ b/config/config.go
@@ -248,6 +248,20 @@ func (cfg *config) ChangeUnlockPassword(currentUnlockPassword string, newUnlockP
 	return nil
 }
 
+func (cfg *config) SetAutoUnlockPassword(unlockPassword string) error {
+	if unlockPassword != "" && !cfg.CheckUnlockPassword(unlockPassword) {
+		return errors.New("incorrect password")
+	}
+
+	err := cfg.SetUpdate("AutoUnlockPassword", unlockPassword, "")
+	if err != nil {
+		logger.Logger.WithError(err).Error("failed to update auto unlock password")
+		return err
+	}
+
+	return nil
+}
+
 func (cfg *config) CheckUnlockPassword(encryptionKey string) bool {
 	decryptedValue, err := cfg.Get("UnlockPasswordCheck", encryptionKey)
 

--- a/config/models.go
+++ b/config/models.go
@@ -61,6 +61,7 @@ type Config interface {
 	GetEnv() *AppConfig
 	CheckUnlockPassword(password string) bool
 	ChangeUnlockPassword(currentUnlockPassword string, newUnlockPassword string) error
+	SetAutoUnlockPassword(unlockPassword string) error
 	SaveUnlockPasswordCheck(encryptionKey string) error
 	SetupCompleted() bool
 }

--- a/frontend/src/components/layouts/SettingsLayout.tsx
+++ b/frontend/src/components/layouts/SettingsLayout.tsx
@@ -98,6 +98,9 @@ export default function SettingsLayout() {
         <aside className="lg:-mx-4 lg:w-1/5">
           <nav className="flex flex-wrap lg:flex-col -space-x-1 lg:space-x-0 lg:space-y-1">
             <MenuItem to="/settings">Theme</MenuItem>
+            {info?.autoUnlockPasswordSupported && (
+              <MenuItem to="/settings/auto-unlock">Auto Unlock</MenuItem>
+            )}
             <MenuItem to="/settings/change-unlock-password">
               Unlock Password
             </MenuItem>

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -43,6 +43,7 @@ import DepositBitcoin from "src/screens/onchain/DepositBitcoin";
 import ConnectPeer from "src/screens/peers/ConnectPeer";
 import Peers from "src/screens/peers/Peers";
 import { AlbyAccount } from "src/screens/settings/AlbyAccount";
+import { AutoUnlock } from "src/screens/settings/AutoUnlock";
 import { ChangeUnlockPassword } from "src/screens/settings/ChangeUnlockPassword";
 import DebugTools from "src/screens/settings/DebugTools";
 import DeveloperSettings from "src/screens/settings/DeveloperSettings";
@@ -168,6 +169,11 @@ const routes = [
               {
                 index: true,
                 element: <Settings />,
+              },
+              {
+                path: "auto-unlock",
+                element: <AutoUnlock />,
+                handle: { crumb: () => "Auto Unlock" },
               },
               {
                 path: "change-unlock-password",

--- a/frontend/src/screens/BackupNode.tsx
+++ b/frontend/src/screens/BackupNode.tsx
@@ -44,8 +44,8 @@ export function BackupNode() {
           }),
         });
 
-        if (!response?.ok) {
-          throw new Error(`Error:${response?.statusText}`);
+        if (!response.ok) {
+          throw new Error(await response.text());
         }
         const blob = await response.blob();
         const url = window.URL.createObjectURL(blob);

--- a/frontend/src/screens/settings/AutoUnlock.tsx
+++ b/frontend/src/screens/settings/AutoUnlock.tsx
@@ -1,0 +1,129 @@
+import { AlertTriangle } from "lucide-react";
+import React from "react";
+
+import Container from "src/components/Container";
+import Loading from "src/components/Loading";
+import SettingsHeader from "src/components/SettingsHeader";
+import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
+import { Input } from "src/components/ui/input";
+import { Label } from "src/components/ui/label";
+import { LoadingButton } from "src/components/ui/loading-button";
+import { useToast } from "src/components/ui/use-toast";
+
+import { useInfo } from "src/hooks/useInfo";
+import { request } from "src/utils/request";
+
+export function AutoUnlock() {
+  const { toast } = useToast();
+  const { data: info, mutate: refetchInfo } = useInfo();
+
+  const [unlockPassword, setUnlockPassword] = React.useState("");
+  const [loading, setLoading] = React.useState(false);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    try {
+      setLoading(true);
+      await request("/api/auto-unlock", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          unlockPassword,
+        }),
+      });
+      await refetchInfo();
+      setUnlockPassword("");
+      toast({
+        title: `Successfully ${unlockPassword ? "enabled" : "disabled"} auto-unlock`,
+      });
+    } catch (error) {
+      toast({
+        title: "Auto Unlock change failed",
+        description: (error as Error).message,
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!info) {
+    return <Loading />;
+  }
+  if (!info.autoUnlockPasswordSupported) {
+    return <p>Your Hub does not support this feature.</p>;
+  }
+
+  return (
+    <>
+      <SettingsHeader
+        title="Auto Unlock"
+        description="Configure Alby Hub will automatically unlock on start (e.g. after machine reboot)"
+      />
+      <Container>
+        {!info.autoUnlockPasswordEnabled && (
+          <>
+            <Alert>
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>Security Warning</AlertTitle>
+              <AlertDescription>
+                By enabling this feature your unlock password will be saved in
+                plaintext on the device running this hub. If the device is
+                compromised,{" "}
+                <span className="underline">your funds will be lost</span>.{" "}
+                <span className="font-semibold">
+                  Do not enable this feature if you do not physically own the
+                  machine Alby Hub is running on.
+                </span>
+              </AlertDescription>
+            </Alert>
+            <form
+              onSubmit={onSubmit}
+              className="w-full flex flex-col gap-3 mt-3"
+            >
+              <div className="grid gap-1.5">
+                <Label htmlFor="unlock-password">Unlock Password</Label>
+                <Input
+                  id="unlock-password"
+                  type="password"
+                  name="password"
+                  onChange={(e) => setUnlockPassword(e.target.value)}
+                  value={unlockPassword}
+                  placeholder="Password"
+                />
+              </div>
+
+              <LoadingButton loading={loading}>
+                Enable Auto Unlock
+              </LoadingButton>
+            </form>
+          </>
+        )}
+        {info.autoUnlockPasswordEnabled && (
+          <>
+            <Alert>
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>Security Warning</AlertTitle>
+              <AlertDescription>
+                Your unlock password is currently saved in plaintext on the
+                device running this hub. If your device is compromised, your
+                funds will be lost.
+              </AlertDescription>
+            </Alert>
+            <form
+              onSubmit={onSubmit}
+              className="w-full flex flex-col gap-3 mt-3"
+            >
+              <LoadingButton loading={loading}>
+                Disable Auto Unlock
+              </LoadingButton>
+            </form>
+          </>
+        )}
+      </Container>
+    </>
+  );
+}

--- a/frontend/src/screens/settings/AutoUnlock.tsx
+++ b/frontend/src/screens/settings/AutoUnlock.tsx
@@ -64,22 +64,22 @@ export function AutoUnlock() {
         description="Configure Alby Hub will automatically unlock on start (e.g. after machine reboot)"
       />
       <Container>
+        <p className="text-muted-foreground">
+          In some situations it can be impractical to manually unlock the wallet
+          every time Alby Hub is started. In those cases you can save the unlock
+          password in plaintext so that Alby Hub can auto-unlock itself.
+        </p>
+        <Alert className="mt-3">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>Attention</AlertTitle>
+          <AlertDescription>
+            Everyone who has access to the machine running this hub could read
+            that password and take your funds. Use this only in a secure
+            environment.
+          </AlertDescription>
+        </Alert>
         {!info.autoUnlockPasswordEnabled && (
           <>
-            <Alert>
-              <AlertTriangle className="h-4 w-4" />
-              <AlertTitle>Security Warning</AlertTitle>
-              <AlertDescription>
-                By enabling this feature your unlock password will be saved in
-                plaintext on the device running this hub. If the device is
-                compromised,{" "}
-                <span className="underline">your funds will be lost</span>.{" "}
-                <span className="font-semibold">
-                  Do not enable this feature if you do not physically own the
-                  machine Alby Hub is running on.
-                </span>
-              </AlertDescription>
-            </Alert>
             <form
               onSubmit={onSubmit}
               className="w-full flex flex-col gap-3 mt-3"
@@ -104,15 +104,6 @@ export function AutoUnlock() {
         )}
         {info.autoUnlockPasswordEnabled && (
           <>
-            <Alert>
-              <AlertTriangle className="h-4 w-4" />
-              <AlertTitle>Security Warning</AlertTitle>
-              <AlertDescription>
-                Your unlock password is currently saved in plaintext on the
-                device running this hub. If your device is compromised, your
-                funds will be lost.
-              </AlertDescription>
-            </Alert>
             <form
               onSubmit={onSubmit}
               className="w-full flex flex-col gap-3 mt-3"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -153,6 +153,8 @@ export interface InfoResponse {
   enableAdvancedSetup: boolean;
   startupError: string;
   startupErrorTime: string;
+  autoUnlockPasswordSupported: boolean;
+  autoUnlockPasswordEnabled: boolean;
 }
 
 export type Network = "bitcoin" | "testnet" | "signet";

--- a/http/http_service.go
+++ b/http/http_service.go
@@ -98,6 +98,7 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	e.POST("/api/start", httpSvc.startHandler, unlockRateLimiter)
 	e.POST("/api/unlock", httpSvc.unlockHandler, unlockRateLimiter)
 	e.PATCH("/api/unlock-password", httpSvc.changeUnlockPasswordHandler, unlockRateLimiter)
+	e.PATCH("/api/auto-unlock", httpSvc.autoUnlockHandler, unlockRateLimiter)
 	e.POST("/api/backup", httpSvc.createBackupHandler, unlockRateLimiter)
 	e.GET("/logout", httpSvc.logoutHandler, unlockRateLimiter)
 
@@ -285,6 +286,24 @@ func (httpSvc *HttpService) changeUnlockPasswordHandler(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{
 			Message: fmt.Sprintf("Failed to change unlock password: %s", err.Error()),
+		})
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+func (httpSvc *HttpService) autoUnlockHandler(c echo.Context) error {
+	var autoUnlockRequest api.AutoUnlockRequest
+	if err := c.Bind(&autoUnlockRequest); err != nil {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{
+			Message: fmt.Sprintf("Bad request: %s", err.Error()),
+		})
+	}
+
+	err := httpSvc.api.SetAutoUnlockPassword(autoUnlockRequest.UnlockPassword)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Message: fmt.Sprintf("Failed to set auto unlock password: %s", err.Error()),
 		})
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -96,6 +96,15 @@ func NewService(ctx context.Context) (*service, error) {
 		return nil, err
 	}
 
+	// read auto unlock password from user config or env
+	autoUnlockPassword, err := cfg.Get("AutoUnlockPassword", "")
+	if err != nil {
+		return nil, err
+	}
+	if autoUnlockPassword == "" {
+		autoUnlockPassword = appConfig.AutoUnlockPassword
+	}
+
 	eventPublisher := events.NewEventPublisher()
 
 	keys := keys.NewKeys()
@@ -132,10 +141,10 @@ func NewService(ctx context.Context) (*service, error) {
 		startDataDogProfiler(ctx)
 	}
 
-	if appConfig.AutoUnlockPassword != "" {
+	if autoUnlockPassword != "" {
 		nodeLastStartTime, _ := cfg.Get("NodeLastStartTime", "")
 		if nodeLastStartTime != "" {
-			svc.StartApp(appConfig.AutoUnlockPassword)
+			svc.StartApp(autoUnlockPassword)
 		}
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -96,13 +96,16 @@ func NewService(ctx context.Context) (*service, error) {
 		return nil, err
 	}
 
-	// read auto unlock password from user config or env
+	// write auto unlock password from env to user config
+	if appConfig.AutoUnlockPassword != "" {
+		err = cfg.SetUpdate("AutoUnlockPassword", appConfig.AutoUnlockPassword, "")
+		if err != nil {
+			return nil, err
+		}
+	}
 	autoUnlockPassword, err := cfg.Get("AutoUnlockPassword", "")
 	if err != nil {
 		return nil, err
-	}
-	if autoUnlockPassword == "" {
-		autoUnlockPassword = appConfig.AutoUnlockPassword
 	}
 
 	eventPublisher := events.NewEventPublisher()

--- a/wails/wails_handlers.go
+++ b/wails/wails_handlers.go
@@ -699,6 +699,28 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
 		return WailsRequestRouterResponse{Body: nil, Error: ""}
+	case "/api/auto-unlock":
+		autoUnlockRequest := &api.AutoUnlockRequest{}
+		err := json.Unmarshal([]byte(body), autoUnlockRequest)
+		if err != nil {
+			logger.Logger.WithFields(logrus.Fields{
+				"route":  route,
+				"method": method,
+				"body":   body,
+			}).WithError(err).Error("Failed to decode request to wails router")
+			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
+		}
+
+		err = app.api.SetAutoUnlockPassword(autoUnlockRequest.UnlockPassword)
+		if err != nil {
+			logger.Logger.WithFields(logrus.Fields{
+				"route":  route,
+				"method": method,
+				"body":   body,
+			}).WithError(err).Error("Failed to set auto unlock password")
+			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
+		}
+		return WailsRequestRouterResponse{Body: nil, Error: ""}
 	case "/api/start":
 		startRequest := &api.StartRequest{}
 		err := json.Unmarshal([]byte(body), startRequest)


### PR DESCRIPTION
Closes https://github.com/getAlby/hub/issues/720

Users can optionally save their unlock password to their user_config as plaintext to enable auto start of the node after a machine restart or alby hub update. The unlock password is still required to access the UI.

if the AUTO_UNLOCK_PASSWORD environment variable is set it will overwrite the entry in user_configs.

This feature is only enabled for non-Alby Cloud environments by checking if the default OAuth client is used. Because we do not control other hosting environments (e.g. nodana, and others) there is an additional warning before enabling the feature.

This feature **must be disabled** before backing up the node for migration to ensure that the unlock password is not unintentionally moved to another machine. It also must be disabled before changing the unlock password just for simplicity. (Checks are added to both functions)

![image](https://github.com/user-attachments/assets/c24caf8b-bfff-4686-8c5d-d68578eb8fd7)

![image](https://github.com/user-attachments/assets/faf8900c-bb9f-423d-8952-a9ea37e861b6)


