### PR TITLE
chore: add extra migration warning to ensure users start with a fresh hub

### DIFF
--- a/frontend/src/screens/BackupNode.tsx
+++ b/frontend/src/screens/BackupNode.tsx
@@ -92,7 +92,7 @@ export function BackupNode() {
       </Alert>
       <Alert>
         <AlertTriangleIcon className="h-4 w-4" />
-        <AlertTitle>Migration Requires a Fresh Alby Hub</AlertTitle>
+        <AlertTitle>Migration requires a fresh Alby Hub</AlertTitle>
         <AlertDescription>
           To import the migration file, you must have a brand new Alby Hub on
           another device and use the "Advanced" option in the onboarding.

--- a/frontend/src/screens/BackupNode.tsx
+++ b/frontend/src/screens/BackupNode.tsx
@@ -91,6 +91,14 @@ export function BackupNode() {
         </AlertDescription>
       </Alert>
       <Alert>
+        <AlertTriangleIcon className="h-4 w-4" />
+        <AlertTitle>Migration Requires a Fresh Alby Hub</AlertTitle>
+        <AlertDescription>
+          To import the migration file, you must have a brand new Alby Hub on
+          another device and use the "Advanced" option in the onboarding.
+        </AlertDescription>
+      </Alert>
+      <Alert>
         <InfoCircledIcon className="h-4 w-4" />
         <AlertTitle>What Happens Next</AlertTitle>
         <AlertDescription>


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/893

![image](https://github.com/user-attachments/assets/fdc91a15-c529-48e1-9eca-a548b415f18f)
