### PR TITLE
fix: nil dereference in GetNodeStatus of cashu backend

### DIFF
--- a/wails/wails_handlers.go
+++ b/wails/wails_handlers.go
@@ -582,6 +582,9 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 		if err != nil {
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
+		if nodeStatus == nil {
+			return WailsRequestRouterResponse{Body: nil, Error: ""}
+		}
 		return WailsRequestRouterResponse{Body: *nodeStatus, Error: ""}
 	case "/api/info":
 		infoResponse, err := app.api.GetInfo(ctx)


### PR DESCRIPTION
app crashes if tries `Get Node Status` for cashu backend. 

Currently `GetNodeStatus` returns nil and then it tries to dereference that here https://github.com/getAlby/hub/blob/master/wails/wails_handlers.go#L573 causing it to crash. 

Returning an empty object rather than nil.