### PR TITLE
feat: get info metadata

### DIFF
--- a/nip47/controllers/get_info_controller_test.go
+++ b/nip47/controllers/get_info_controller_test.go
@@ -120,6 +120,61 @@ func TestHandleGetInfoEvent_WithPermission(t *testing.T) {
 	assert.Equal(t, []string{}, nodeInfo.Notifications)
 }
 
+func TestHandleGetInfoEvent_WithMetadata(t *testing.T) {
+	ctx := context.TODO()
+	defer tests.RemoveTestService()
+	svc, err := tests.CreateTestService()
+	require.NoError(t, err)
+
+	metadata := map[string]interface{}{
+		"a": 123,
+	}
+
+	app, _, err := svc.AppsService.CreateApp("test", "", 0, "monthly", nil, nil, false, metadata)
+	assert.NoError(t, err)
+
+	nip47Request := &models.Request{}
+	err = json.Unmarshal([]byte(nip47GetInfoJson), nip47Request)
+	assert.NoError(t, err)
+
+	dbRequestEvent := &db.RequestEvent{}
+	err = svc.DB.Create(&dbRequestEvent).Error
+	assert.NoError(t, err)
+
+	appPermission := &db.AppPermission{
+		AppId:     app.ID,
+		Scope:     constants.GET_INFO_SCOPE,
+		ExpiresAt: nil,
+	}
+	err = svc.DB.Create(appPermission).Error
+	assert.NoError(t, err)
+
+	var publishedResponse *models.Response
+
+	publishResponse := func(response *models.Response, tags nostr.Tags) {
+		publishedResponse = response
+	}
+
+	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
+	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
+	NewNip47Controller(svc.LNClient, svc.DB, svc.EventPublisher, permissionsSvc, transactionsSvc).
+		HandleGetInfoEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse)
+
+	assert.Nil(t, publishedResponse.Error)
+	nodeInfo := publishedResponse.Result.(*getInfoResponse)
+	assert.Equal(t, tests.MockNodeInfo.Alias, nodeInfo.Alias)
+	assert.Equal(t, tests.MockNodeInfo.Color, nodeInfo.Color)
+	assert.Equal(t, tests.MockNodeInfo.Pubkey, nodeInfo.Pubkey)
+	assert.Equal(t, tests.MockNodeInfo.Network, nodeInfo.Network)
+	assert.Equal(t, tests.MockNodeInfo.BlockHeight, nodeInfo.BlockHeight)
+	assert.Equal(t, tests.MockNodeInfo.BlockHash, nodeInfo.BlockHash)
+	assert.Contains(t, nodeInfo.Methods, "get_info")
+	assert.Equal(t, []string{}, nodeInfo.Notifications)
+
+	assert.NoError(t, err)
+	assert.Equal(t, float64(123), nodeInfo.Metadata.(map[string]interface{})["a"])
+}
+
 func TestHandleGetInfoEvent_WithNotifications(t *testing.T) {
 	ctx := context.TODO()
 	defer tests.RemoveTestService()


### PR DESCRIPTION
Closes https://github.com/getAlby/hub/issues/785

See example output: https://github.com/getAlby/js-sdk/pull/287

Merges the existing app metadata with two general fields (the id and name of the app)

Allows keysend receive support to be added in getalby.com for accounts that are connected to an Alby Hub subwallet