### PR TITLE
fix: shorten tooltip delay duration

### DIFF
--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -23,6 +23,11 @@ import { cn } from "src/lib/utils";
 
 const TooltipProvider = TooltipPrimitive.Provider;
 
+TooltipProvider.defaultProps = {
+  ...(TooltipProvider.defaultProps || {}),
+  delayDuration: 200,
+};
+
 const Tooltip = TooltipPrimitive.Root;
 
 const TooltipTrigger = TooltipPrimitive.Trigger;


### PR DESCRIPTION
Tooltip was appearing too slowly - and if you click then the tooltip does not show.

It is not set to 0 but 200ms, so if your mouse briefly moves past a tooltip, it will not open immediately.