### PR TITLE
fix: allow unlink account before node start

### DIFF
--- a/http/alby_http_service.go
+++ b/http/alby_http_service.go
@@ -30,13 +30,14 @@ func (albyHttpSvc *AlbyHttpService) RegisterSharedRoutes(restrictedGroup *echo.G
 	e.GET("/api/alby/callback", albyHttpSvc.albyCallbackHandler)
 	e.GET("/api/alby/info", albyHttpSvc.albyInfoHandler)
 	e.GET("/api/alby/rates", albyHttpSvc.albyBitcoinRateHandler)
+	// allow unlinking even without a JWT token as this can be done before node start (which will give a new JWT)
+	e.POST("/api/alby/unlink-account", albyHttpSvc.unlinkHandler)
 	restrictedGroup.GET("/api/alby/me", albyHttpSvc.albyMeHandler)
 	restrictedGroup.GET("/api/alby/balance", albyHttpSvc.albyBalanceHandler)
 	restrictedGroup.POST("/api/alby/pay", albyHttpSvc.albyPayHandler)
 	restrictedGroup.POST("/api/alby/drain", albyHttpSvc.albyDrainHandler)
 	restrictedGroup.POST("/api/alby/link-account", albyHttpSvc.albyLinkAccountHandler)
 	restrictedGroup.POST("/api/alby/auto-channel", albyHttpSvc.autoChannelHandler)
-	restrictedGroup.POST("/api/alby/unlink-account", albyHttpSvc.unlinkHandler)
 }
 
 func (albyHttpSvc *AlbyHttpService) autoChannelHandler(c echo.Context) error {


### PR DESCRIPTION
I ran into the issue that I tried to unlink my account on a hub with expired tokens. I could not call this endpoint because I did not have a JWT yet, and you can only get one by starting the node.