### PR TITLE
fix: new connection deeplink flow

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -102,6 +102,8 @@ func (api *api) CreateApp(createAppRequest *CreateAppRequest) (*CreateAppRespons
 	responseBody.Name = createAppRequest.Name
 	responseBody.Pubkey = app.AppPubkey
 	responseBody.PairingSecret = pairingSecretKey
+	responseBody.WalletPubkey = *app.WalletPubkey
+	responseBody.RelayUrl = relayUrl
 
 	lightningAddress, err := api.albyOAuthSvc.GetLightningAddress()
 	if err != nil {

--- a/api/models.go
+++ b/api/models.go
@@ -151,6 +151,8 @@ type CreateAppResponse struct {
 	PairingUri    string `json:"pairingUri"`
 	PairingSecret string `json:"pairingSecretKey"`
 	Pubkey        string `json:"pairingPublicKey"`
+	RelayUrl      string `json:"relayUrl"`
+	WalletPubkey  string `json:"walletPubkey"`
 	Id            uint   `json:"id"`
 	Name          string `json:"name"`
 	ReturnTo      string `json:"returnTo"`

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,8 @@
-import { RouterProvider, createHashRouter } from "react-router-dom";
+import {
+  RouterProvider,
+  createBrowserRouter,
+  createHashRouter,
+} from "react-router-dom";
 
 import { ThemeProvider } from "src/components/ui/theme-provider";
 
@@ -6,8 +10,10 @@ import { Toaster } from "src/components/ui/toaster";
 import { TouchProvider } from "src/components/ui/tooltip";
 import { useInfo } from "src/hooks/useInfo";
 import routes from "src/routes.tsx";
+import { isHttpMode } from "src/utils/isHttpMode";
 
-const router = createHashRouter(routes);
+const createRouterFunc = isHttpMode() ? createBrowserRouter : createHashRouter;
+const router = createRouterFunc(routes);
 
 function App() {
   const { data: info } = useInfo();

--- a/frontend/src/components/SuggestedAppData.tsx
+++ b/frontend/src/components/SuggestedAppData.tsx
@@ -417,7 +417,7 @@ export const suggestedApps: SuggestedApp[] = [
             <li>
               4. Click{" "}
               <Link
-                to="/#/apps/new?app=btcpay"
+                to="/apps/new?app=btcpay"
                 className="font-medium text-foreground underline"
               >
                 Connect to BTCPay Server
@@ -492,7 +492,7 @@ export const suggestedApps: SuggestedApp[] = [
             <li>
               4. Click{" "}
               <Link
-                to="/#/apps/new?app=lnbits"
+                to="/apps/new?app=lnbits"
                 className="font-medium text-foreground underline"
               >
                 Connect to LNbits
@@ -569,7 +569,7 @@ export const suggestedApps: SuggestedApp[] = [
             <li>
               4. Click{" "}
               <Link
-                to="/#/apps/new?app=coracle"
+                to="/apps/new?app=coracle"
                 className="font-medium text-foreground underline"
               >
                 Connect to Coracle
@@ -639,7 +639,7 @@ export const suggestedApps: SuggestedApp[] = [
             <li>
               3. Click{" "}
               <Link
-                to="/#/apps/new?app=nostter"
+                to="/apps/new?app=nostter"
                 className="font-medium text-foreground underline"
               >
                 Connect to Nostter

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,11 +1,18 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "src/App.tsx";
-import "src/index.css";
 import "src/fonts.css";
+import "src/index.css";
+import { isHttpMode } from "src/utils/isHttpMode";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+// redirect hash router links to browser router links
+// TODO: remove after 2026-01-01
+if (isHttpMode() && window.location.href.indexOf("/#/") > -1) {
+  window.location.href = window.location.href.replace("/#/", "/");
+} else {
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}

--- a/frontend/src/screens/apps/AppCreated.tsx
+++ b/frontend/src/screens/apps/AppCreated.tsx
@@ -61,7 +61,11 @@ function AppCreatedInternal() {
     }
     // dispatch a success event which can be listened to by the opener or by the app that embedded the webview
     // this gives those apps the chance to know the user has enabled the connection
-    const nwcEvent = new CustomEvent("nwc:success", { detail: {} });
+    const nwcEvent = new CustomEvent("nwc:success", {
+      detail: {
+        nostrWalletConnectUrl: pairingUri,
+      },
+    });
     window.dispatchEvent(nwcEvent);
 
     // notify the opener of the successful connection
@@ -69,12 +73,12 @@ function AppCreatedInternal() {
       window.opener.postMessage(
         {
           type: "nwc:success",
-          payload: { success: true },
+          nostrWalletConnectUrl: pairingUri,
         },
         "*"
       );
     }
-  }, [appstoreApp]);
+  }, [appstoreApp, pairingUri]);
 
   if (!createAppResponse) {
     return <Navigate to="/apps/new" />;

--- a/frontend/src/screens/apps/AppCreated.tsx
+++ b/frontend/src/screens/apps/AppCreated.tsx
@@ -56,6 +56,7 @@ function AppCreatedInternal() {
   }, [app?.lastEventAt, navigate, toast]);
 
   useEffect(() => {
+    // TODO: find a better way to only execute for deeplink flow
     if (appstoreApp) {
       return;
     }
@@ -63,7 +64,8 @@ function AppCreatedInternal() {
     // this gives those apps the chance to know the user has enabled the connection
     const nwcEvent = new CustomEvent("nwc:success", {
       detail: {
-        nostrWalletConnectUrl: pairingUri,
+        relayUrl: createAppResponse.relayUrl,
+        walletPubkey: createAppResponse.walletPubkey,
       },
     });
     window.dispatchEvent(nwcEvent);
@@ -73,12 +75,13 @@ function AppCreatedInternal() {
       window.opener.postMessage(
         {
           type: "nwc:success",
-          nostrWalletConnectUrl: pairingUri,
+          relayUrl: createAppResponse.relayUrl,
+          walletPubkey: createAppResponse.walletPubkey,
         },
         "*"
       );
     }
-  }, [appstoreApp, pairingUri]);
+  }, [appstoreApp, createAppResponse.relayUrl, createAppResponse.walletPubkey]);
 
   if (!createAppResponse) {
     return <Navigate to="/apps/new" />;

--- a/frontend/src/screens/apps/AppCreated.tsx
+++ b/frontend/src/screens/apps/AppCreated.tsx
@@ -56,10 +56,6 @@ function AppCreatedInternal() {
   }, [app?.lastEventAt, navigate, toast]);
 
   useEffect(() => {
-    // TODO: find a better way to only execute for deeplink flow
-    if (appstoreApp) {
-      return;
-    }
     // dispatch a success event which can be listened to by the opener or by the app that embedded the webview
     // this gives those apps the chance to know the user has enabled the connection
     const nwcEvent = new CustomEvent("nwc:success", {
@@ -81,7 +77,7 @@ function AppCreatedInternal() {
         "*"
       );
     }
-  }, [appstoreApp, createAppResponse.relayUrl, createAppResponse.walletPubkey]);
+  }, [createAppResponse.relayUrl, createAppResponse.walletPubkey]);
 
   if (!createAppResponse) {
     return <Navigate to="/apps/new" />;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -201,6 +201,8 @@ export interface CreateAppResponse {
   pairingUri: string;
   pairingPublicKey: string;
   pairingSecretKey: string;
+  relayUrl: string;
+  walletPubkey: string;
   returnTo: string;
 }
 


### PR DESCRIPTION
Part of https://github.com/getAlby/hub/issues/328

The deeplink flow does not work well with a hash router, this will likely break for developers who try to implement it and inject query parameters to configure the new app connection.

We might need to update a few guides, etc. For now I added a redirect to ensure old links still work.