### PR TITLE
fix: delete access token when creating backup to migrate node

### DIFF
--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -88,6 +88,14 @@ func NewAlbyOAuthService(db *gorm.DB, cfg config.Config, keys keys.Keys, eventPu
 	return albyOAuthSvc
 }
 
+func (svc *albyOAuthService) RemoveOAuthAccessToken() error {
+	err := svc.cfg.SetUpdate(accessTokenKey, "", "")
+	if err != nil {
+		logger.Logger.WithError(err).Error("failed to remove access token")
+	}
+	return err
+}
+
 func (svc *albyOAuthService) CallbackHandler(ctx context.Context, code string, lnClient lnclient.LNClient) error {
 	token, err := svc.oauthConf.Exchange(ctx, code)
 	if err != nil {

--- a/alby/models.go
+++ b/alby/models.go
@@ -25,6 +25,7 @@ type AlbyOAuthService interface {
 	UnlinkAccount(ctx context.Context) error
 	RequestAutoChannel(ctx context.Context, lnClient lnclient.LNClient, isPublic bool) (*AutoChannelResponse, error)
 	GetVssAuthToken(ctx context.Context, nodeIdentifier string) (string, error)
+	RemoveOAuthAccessToken() error
 }
 
 type AlbyBalanceResponse struct {

--- a/api/backup.go
+++ b/api/backup.go
@@ -67,6 +67,14 @@ func (api *api) CreateBackup(unlockPassword string, w io.Writer) error {
 	// Stop the app to ensure no new requests are processed.
 	api.svc.StopApp()
 
+	// Remove the OAuth access token from the DB to ensure the user
+	// has to re-auth with the correct OAuth client when they restore the backup
+	err = api.albyOAuthSvc.RemoveOAuthAccessToken()
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to remove oauth access token")
+		return errors.New("failed to remove oauth access token")
+	}
+
 	// Closing the database leaves the service in an inconsistent state,
 	// but that should not be a problem since the app is not expected
 	// to be used after its data is exported.


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/961