### PR TITLE
feat: use DATABASE_URL if present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,12 +46,17 @@ RUN ./copy_dylibs.sh $(echo "$TARGETPLATFORM" | cut -d'/' -f2)
 FROM debian as final
 
 ENV LD_LIBRARY_PATH=/usr/lib/nwc
-#
-# # Copy the binaries and entrypoint from the builder image.
+
+# Copy the entrypoint script
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Copy the binaries from the builder image.
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /build/libbreez_sdk_bindings.so /usr/lib/nwc/
 COPY --from=builder /build/libglalby_bindings.so /usr/lib/nwc/
 COPY --from=builder /build/libldk_node.so /usr/lib/nwc/
 COPY --from=builder /build/main /bin/
 
-ENTRYPOINT [ "/bin/main" ]
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
+CMD [ "/bin/main" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# entrypoint.sh
+
+# Check if DATABASE_URL is defined and not empty
+if [ -n "$DATABASE_URL" ]; then
+  export DATABASE_URI="$DATABASE_URL"
+  echo "DATABASE_URI set from DATABASE_URL"
+fi
+
+# Execute the main application
+exec "$@"


### PR DESCRIPTION
If DATABASE_URL env variable is set, it will overwrite DATABASE_URI with that value
This allows to use the secret that fly sets on the fly app when attaching a postgres instance which also creates the user and database.