### PR TITLE
fix: also include lud16 in nwc success event

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -99,6 +99,11 @@ func (api *api) CreateApp(createAppRequest *CreateAppRequest) (*CreateAppRespons
 
 	relayUrl := api.cfg.GetRelayUrl()
 
+	lightningAddress, err := api.albyOAuthSvc.GetLightningAddress()
+	if err != nil {
+		return nil, err
+	}
+
 	responseBody := &CreateAppResponse{}
 	responseBody.Id = app.ID
 	responseBody.Name = createAppRequest.Name
@@ -106,11 +111,7 @@ func (api *api) CreateApp(createAppRequest *CreateAppRequest) (*CreateAppRespons
 	responseBody.PairingSecret = pairingSecretKey
 	responseBody.WalletPubkey = *app.WalletPubkey
 	responseBody.RelayUrl = relayUrl
-
-	lightningAddress, err := api.albyOAuthSvc.GetLightningAddress()
-	if err != nil {
-		return nil, err
-	}
+	responseBody.Lud16 = lightningAddress
 
 	if createAppRequest.ReturnTo != "" {
 		returnToUrl, err := url.Parse(createAppRequest.ReturnTo)

--- a/api/models.go
+++ b/api/models.go
@@ -156,6 +156,7 @@ type CreateAppResponse struct {
 	Pubkey        string `json:"pairingPublicKey"`
 	RelayUrl      string `json:"relayUrl"`
 	WalletPubkey  string `json:"walletPubkey"`
+	Lud16         string `json:"lud16"`
 	Id            uint   `json:"id"`
 	Name          string `json:"name"`
 	ReturnTo      string `json:"returnTo"`

--- a/frontend/src/screens/apps/AppCreated.tsx
+++ b/frontend/src/screens/apps/AppCreated.tsx
@@ -62,6 +62,7 @@ function AppCreatedInternal() {
       detail: {
         relayUrl: createAppResponse.relayUrl,
         walletPubkey: createAppResponse.walletPubkey,
+        lud16: createAppResponse.lud16,
       },
     });
     window.dispatchEvent(nwcEvent);
@@ -73,11 +74,16 @@ function AppCreatedInternal() {
           type: "nwc:success",
           relayUrl: createAppResponse.relayUrl,
           walletPubkey: createAppResponse.walletPubkey,
+          lud16: createAppResponse.lud16,
         },
         "*"
       );
     }
-  }, [createAppResponse.relayUrl, createAppResponse.walletPubkey]);
+  }, [
+    createAppResponse.relayUrl,
+    createAppResponse.walletPubkey,
+    createAppResponse.lud16,
+  ]);
 
   if (!createAppResponse) {
     return <Navigate to="/apps/new" />;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -204,6 +204,7 @@ export interface CreateAppResponse {
   pairingSecretKey: string;
   relayUrl: string;
   walletPubkey: string;
+  lud16: string;
   returnTo: string;
 }
 


### PR DESCRIPTION
Allows e.g. nostr clients to immediately set a lightning address for receiving payments after connecting via the new nwc deeplink flow.