### PR TITLE
fix: replace LDK trusted 0-anchor reserve peers with 0 per channel reserve

### DIFF
--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -594,7 +594,7 @@ export default function Channels() {
                       Your on-chain balance can be used to open new outgoing
                       lightning channels and to ensure channels can be closed
                       when required. When channels are closed, funds on your
-                      side of your channel will be returned to your savings
+                      side of your channel will be returned to your on-chain
                       balance.
                     </TooltipContent>
                   </Tooltip>
@@ -630,8 +630,8 @@ export default function Channels() {
                               You have insufficient funds in reserve to close
                               channels or bump on-chain transactions and
                               currently rely on the counterparty. It is
-                              recommended to deposit at least 25,000 sats
-                              on-chain.
+                              recommended to deposit at least 25,000 sats to
+                              your on-chain balance.
                             </TooltipContent>
                           </Tooltip>
                         </TooltipProvider>

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -592,8 +592,9 @@ export default function Channels() {
                     </TooltipTrigger>
                     <TooltipContent className="w-[300px]">
                       Your on-chain balance can be used to open new outgoing
-                      lightning channels. When channels are closed, funds on
-                      your side of your channel will be returned to your savings
+                      lightning channels and to ensure channels can be closed
+                      when required. When channels are closed, funds on your
+                      side of your channel will be returned to your savings
                       balance.
                     </TooltipContent>
                   </Tooltip>
@@ -610,11 +611,31 @@ export default function Channels() {
             <div className="text-2xl balance sensitive">
               {balances && (
                 <>
-                  <div className="text-2xl font-bold balance sensitive">
-                    {new Intl.NumberFormat().format(
-                      Math.floor(balances.onchain.spendable)
-                    )}{" "}
-                    sats
+                  <div className="balance sensitive flex gap-2">
+                    <span className="text-2xl font-bold">
+                      {new Intl.NumberFormat().format(
+                        Math.floor(balances.onchain.spendable)
+                      )}{" "}
+                      sats
+                    </span>
+                    {!!channels?.length &&
+                      balances.onchain.reserved + balances.onchain.spendable <
+                        25_000 && (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger>
+                              <AlertTriangle className="w-3 h-3 text-muted-foreground" />
+                            </TooltipTrigger>
+                            <TooltipContent className="w-[300px]">
+                              You have insufficient funds in reserve to close
+                              channels or bump on-chain transactions and
+                              currently rely on the counterparty. It is
+                              recommended to deposit at least 25,000 sats
+                              on-chain.
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      )}
                   </div>
                   <FormattedFiatAmount amount={balances.onchain.spendable} />
                   {balances &&

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -79,8 +79,17 @@ func NewLDKService(ctx context.Context, cfg config.Config, eventPublisher events
 		lsp.OlympusMutinynetLSP().Pubkey,
 		lsp.MegalithMutinynetLSP().Pubkey,
 	}
+
+	// rather than fully trusting our LSPs, we set the channel reserve to 0.
+	// this allows us to receive incoming channels without any on-chain balance
+	// but if the user has 0 on-chain balance when the channel is closed,
+	// we rely on the counterparty to bump the transaction.
+	// It's also possible in rare situations the counterparty can take
+	// funds if the channel was closed due to a stuck HTLC.
+	// Therefore, the user SHOULD add some on-chain funds to prevent this.
+	ldkConfig.AnchorChannelsConfig.PerChannelReserveSats = 0
 	ldkConfig.AnchorChannelsConfig.TrustedPeersNoReserve = []string{
-		lsp.OlympusLSP().Pubkey,
+		/*lsp.OlympusLSP().Pubkey,
 		lsp.AlbyPlebsLSP().Pubkey,
 		lsp.MegalithLSP().Pubkey,
 		"02b4552a7a85274e4da01a7c71ca57407181752e8568b31d51f13c111a2941dce3", // LNServer_Wave
@@ -93,7 +102,7 @@ func NewLDKService(ctx context.Context, cfg config.Config, eventPublisher events
 		lsp.OlympusMutinynetLSP().Pubkey,
 		lsp.MegalithMutinynetLSP().Pubkey,
 		"0296820bbba5bd33719962bafd69996ee89e03ce7164d8f368cbb85463f5f47876", // flashsats
-		"035e8a9034a8c68f219aacadae748c7a3cd719109309db39b09886e5ff17696b1b", // lqwd
+		"035e8a9034a8c68f219aacadae748c7a3cd719109309db39b09886e5ff17696b1b", // lqwd*/
 	}
 
 	ldkConfig.ListeningAddresses = &listeningAddresses


### PR DESCRIPTION
Closes https://github.com/getAlby/hub/issues/1065

This PR stops requiring all users to trust the LSPs to correctly return the correct amount on channel closure (which when channels are closed due to stuck payments they do not), and instead allow the user to choose whether or not they will protect themselves or trust the counterparty. It introduces one extra warning icon to the UI but I think this is important for users to understand.

Tests in mutinynet:
- [x] Existing channels are unaffected
- [x] New channels with no on-chain balance are still opened successfully.

![image](https://github.com/user-attachments/assets/7f898804-72b9-49fb-acb9-6e739352d35c)

![image](https://github.com/user-attachments/assets/8a118063-abfd-473f-8a65-57a0d196c5a1)

![image](https://github.com/user-attachments/assets/a77b3dd3-0e64-445f-b487-5a05d1781415)
