### PR TITLE
fix: offline channel detection in health endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1077,7 +1077,13 @@ func (api *api) Health(ctx context.Context) (*HealthResponse, error) {
 		}
 
 		offlineChannels := slices.DeleteFunc(channels, func(channel lnclient.Channel) bool {
-			return channel.Active
+			if channel.Active {
+				return true
+			}
+			if channel.Confirmations == nil || channel.ConfirmationsRequired == nil {
+				return false
+			}
+			return *channel.Confirmations < *channel.ConfirmationsRequired
 		})
 
 		if len(offlineChannels) > 0 {

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -614,7 +614,7 @@ func (svc *LNDService) ListChannels(ctx context.Context) ([]lnclient.Channel, er
 
 		// first 3 bytes of the channel ID are the block height
 		channelOpeningBlockHeight := lndChannel.ChanId >> 40
-		confirmations := nodeInfo.BlockHeight - uint32(channelOpeningBlockHeight)
+		confirmations := nodeInfo.BlockHeight - uint32(channelOpeningBlockHeight) + 1
 
 		var forwardingFee uint32
 		if !lndChannel.Private {


### PR DESCRIPTION
When a channel is being opened, health endpoint showsss red saying one or more channels are offline, which is wrong.

Also fixes the wrong calculation of Channel Confs in LND (we don't count the funding tx block currently)

## Screenshots
<img width="49%" alt="Screenshot 2025-02-10 at 7 27 39 PM" src="https://github.com/user-attachments/assets/349062b9-0884-40c7-8ee6-d2c840f2fabe" />
<img width="49%" alt="Screenshot 2025-02-10 at 7 30 35 PM" src="https://github.com/user-attachments/assets/800301c3-9413-4ae3-be1b-a0f0a7955ebe" />
