### PR TITLE
fix: show total channels and peers

### DIFF
--- a/frontend/src/components/home/widgets/NodeStatusWidget.tsx
+++ b/frontend/src/components/home/widgets/NodeStatusWidget.tsx
@@ -25,12 +25,12 @@ export function NodeStatusWidget() {
           <p className="text-muted-foreground text-xs">Channels Online</p>
           <p className="text-xl font-semibold">
             {channels.filter((c) => c.active).length || 0} /{" "}
-            {channels.filter((c) => c.active).length || 0}
+            {channels.length || 0}
           </p>
           <p className="text-muted-foreground text-xs mt-6">Connected Peers</p>
           <p className="text-xl font-semibold">
             {peers.filter((p) => p.isConnected).length || 0} /{" "}
-            {peers.filter((p) => p.isConnected).length || 0}
+            {peers.length || 0}
           </p>
         </CardContent>
       </Card>


### PR DESCRIPTION
Fixes #1070

In LND, ListPeers only returns the list of connected peers so this fix will not make a difference there, not sure about LDK.
Channels should be fixed though.

## Screenshots
<img width="566" alt="Screenshot 2025-02-10 at 7 57 52 PM" src="https://github.com/user-attachments/assets/a822fb15-3371-4fd3-be15-3661031ced58" />

### On switching off a node in Polar: (Notice Peers)
<img width="568" alt="Screenshot 2025-02-10 at 7 57 16 PM" src="https://github.com/user-attachments/assets/360f85f5-eb9f-4ab6-97af-0b6033f8c663" />