### PR TITLE
feat: add peer and return_to query parameters to peer connection page

### DIFF
--- a/frontend/src/screens/peers/ConnectPeer.tsx
+++ b/frontend/src/screens/peers/ConnectPeer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import AppHeader from "src/components/AppHeader";
 import { Input } from "src/components/ui/input";
 import { Label } from "src/components/ui/label";
@@ -12,9 +12,14 @@ import { request } from "src/utils/request";
 
 export default function ConnectPeer() {
   const { toast } = useToast();
-  const [isLoading, setLoading] = React.useState(false);
-  const [connectionString, setConnectionString] = React.useState("");
   const navigate = useNavigate();
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const [isLoading, setLoading] = React.useState(false);
+  const [connectionString, setConnectionString] = React.useState(
+    queryParams.get("peer") ?? ""
+  );
+  const returnTo = queryParams.get("return_to") ?? "";
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -43,6 +48,10 @@ export default function ConnectPeer() {
         },
         body: JSON.stringify(connectPeerRequest),
       });
+      if (returnTo) {
+        window.location.href = returnTo;
+        return;
+      }
       toast({ title: "Successfully connected with peer" });
       setConnectionString("");
       navigate("/channels");
@@ -77,6 +86,11 @@ export default function ConnectPeer() {
               }}
             />
           </div>
+          {returnTo && (
+            <p className="text-xs text-muted-foreground mt-4">
+              You will automatically return to {returnTo}
+            </p>
+          )}
           <div className="mt-4">
             <LoadingButton
               loading={isLoading}

--- a/frontend/src/screens/peers/ConnectPeer.tsx
+++ b/frontend/src/screens/peers/ConnectPeer.tsx
@@ -48,20 +48,20 @@ export default function ConnectPeer() {
         },
         body: JSON.stringify(connectPeerRequest),
       });
+      toast({ title: "Successfully connected with peer" });
       if (returnTo) {
         window.location.href = returnTo;
-        return;
+      } else {
+        setConnectionString("");
+        navigate("/channels");
+        setLoading(false);
       }
-      toast({ title: "Successfully connected with peer" });
-      setConnectionString("");
-      navigate("/channels");
     } catch (e) {
       toast({
         variant: "destructive",
         title: "Failed to connect peer: " + e,
       });
       console.error(e);
-    } finally {
       setLoading(false);
     }
   };

--- a/frontend/src/screens/peers/ConnectPeer.tsx
+++ b/frontend/src/screens/peers/ConnectPeer.tsx
@@ -51,19 +51,18 @@ export default function ConnectPeer() {
       toast({ title: "Successfully connected with peer" });
       if (returnTo) {
         window.location.href = returnTo;
-      } else {
-        setConnectionString("");
-        navigate("/channels");
-        setLoading(false);
+        return;
       }
+      setConnectionString("");
+      navigate("/channels");
     } catch (e) {
       toast({
         variant: "destructive",
         title: "Failed to connect peer: " + e,
       });
       console.error(e);
-      setLoading(false);
     }
+    setLoading(false);
   };
 
   return (


### PR DESCRIPTION
## Why

Instructing a user to copy and paste connection strings to establish a connection (or channel) is tedious and error-prone. Allowing a service to pass the connection string and a return URL as query parameters simplifies this experience.

## How

Similar to the new app page, a redirect URL (`return_to`) and the connection string (`peer`) can now be passed as query parameters to the new peer page.

Example: https://my.albyhub.com/#/peers/new?peer=03b65c19de2da9d35895b37e6fa263cefbf8d184e6b61c0713747ebf12409d219f%40164.90.241.111%3A9735&return_to=https%3A%2F%2Fwebhook.site%2Fa2a6fd93-0f48-4ef9-8b74-1baf201d4cae


![grafik](https://github.com/user-attachments/assets/975ec21b-86e4-49de-ae2d-613fb9fa58d6)
