### PR TITLE
fix: pending transaction icon bg color

### DIFF
--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -73,7 +73,7 @@ function TransactionItem({ tx }: Props) {
           tx.state === "failed"
             ? "bg-red-100 dark:bg-rose-950"
             : tx.state === "pending"
-              ? "bg-blue-500 dark:bg-sky-500"
+              ? "bg-blue-100 dark:bg-sky-950"
               : type === "outgoing"
                 ? "bg-orange-100 dark:bg-amber-950"
                 : "bg-green-100 dark:bg-emerald-950"


### PR DESCRIPTION
This fixes the pending transaction icon's bg color

## Screenshots
<img width="49%" alt="Screenshot 2025-02-14 at 1 49 40 PM" src="https://github.com/user-attachments/assets/e2d27067-b311-4d69-ace0-ffcd80ced57a" />
<img width="49%" alt="Screenshot 2025-02-14 at 1 49 18 PM" src="https://github.com/user-attachments/assets/bdf356ac-4c19-4240-a134-09f66a09f51e" />
