### PR TITLE
fix: make body optional for payments endpoint in wails handler

### DIFF
--- a/wails/wails_handlers.go
+++ b/wails/wails_handlers.go
@@ -286,14 +286,16 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 	case len(invoiceMatch) > 1:
 		invoice := invoiceMatch[1]
 		payRequest := &api.PayInvoiceRequest{}
-		err := json.Unmarshal([]byte(body), payRequest)
-		if err != nil {
-			logger.Logger.WithFields(logrus.Fields{
-				"route":  route,
-				"method": method,
-				"body":   body,
-			}).WithError(err).Error("Failed to decode request to wails router")
-			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
+		if body != "" {
+			err := json.Unmarshal([]byte(body), payRequest)
+			if err != nil {
+				logger.Logger.WithFields(logrus.Fields{
+					"route":  route,
+					"method": method,
+					"body":   body,
+				}).WithError(err).Error("Failed to decode request to wails router")
+				return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
+			}
 		}
 		paymentResponse, err := app.api.SendPayment(ctx, invoice, payRequest.Amount)
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/1101

I accidentally broke this when adding support to pay 0-amount invoices