### PR TITLE
chore: show total and reserved lightning balances in LND

### DIFF
--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -70,6 +70,7 @@ import {
 import { useAlbyBalance } from "src/hooks/useAlbyBalance.ts";
 import { useBalances } from "src/hooks/useBalances.ts";
 import { useChannels } from "src/hooks/useChannels";
+import { useInfo } from "src/hooks/useInfo";
 import { useIsDesktop } from "src/hooks/useMediaQuery.ts";
 import { useNodeConnectionInfo } from "src/hooks/useNodeConnectionInfo.ts";
 import { useOnchainAddress } from "src/hooks/useOnchainAddress";
@@ -82,6 +83,7 @@ import { request } from "src/utils/request";
 
 export default function Channels() {
   useSyncWallet();
+  const { data: info } = useInfo();
   const { data: channels, mutate: reloadChannels } = useChannels();
   const { data: nodeConnectionInfo } = useNodeConnectionInfo();
   const { data: balances, mutate: reloadBalances } = useBalances();
@@ -506,8 +508,18 @@ export default function Channels() {
                         </div>
                       </TooltipTrigger>
                       <TooltipContent className="w-[300px]">
-                        Your spending balance is the funds on your side of your
-                        channels, which you can use to make lightning payments.
+                        Your spending balance is the spendable funds on your
+                        side of your channels, which you can use to make
+                        lightning payments.{" "}
+                        {info?.backendType === "LND" &&
+                          balances &&
+                          `Your total lightning balance is ${new Intl.NumberFormat().format(
+                            Math.floor(balances.lightning.totalBalance / 1000)
+                          )} sats which includes ${new Intl.NumberFormat().format(
+                            Math.floor(
+                              balances.lightning.reservedBalance / 1000
+                            )
+                          )} sats reserved in your channels which cannot be spent.`}
                       </TooltipContent>
                     </Tooltip>
                   </TooltipProvider>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -425,6 +425,8 @@ export type RedeemOnchainFundsResponse = {
 };
 
 export type LightningBalanceResponse = {
+  totalBalance: number;
+  reservedBalance: number;
   totalSpendable: number;
   totalReceivable: number;
   nextMaxSpendable: number;

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -164,6 +164,8 @@ type PeerDetails struct {
 	IsConnected bool   `json:"isConnected"`
 }
 type LightningBalanceResponse struct {
+	TotalBalance         int64 `json:"totalBalance"`
+	ReservedBalance      int64 `json:"reservedBalance"`
 	TotalSpendable       int64 `json:"totalSpendable"`
 	TotalReceivable      int64 `json:"totalReceivable"`
 	NextMaxSpendable     int64 `json:"nextMaxSpendable"`


### PR DESCRIPTION
This helps reduce confusion in LND users as we can now point people to check this if people raise support requests titled "Sats are missing/not showing in Alby Hub"

## Screenshot
<img width="356" alt="Screenshot 2025-02-18 at 10 07 26 PM" src="https://github.com/user-attachments/assets/1fce8850-ce74-40e1-a495-178dc0ee3ce0" />

