### PR TITLE
fix: use msats for deeplink max_amount param to be consistent with NIP-47

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ If the client creates the secret the client only needs to share the public key o
 - `pubkey`: the public key of the client's secret for the user to authorize
 - `return_to`: (optional) if a `return_to` URL is provided the user will be redirected to that URL after authorization. The `lud16`, `relay` and `pubkey` query parameters will be added to the URL.
 - `expires_at` (optional) connection cannot be used after this date. Unix timestamp in seconds.
-- `max_amount` (optional) maximum amount in sats that can be sent per renewal period
+- `max_amount` (optional) maximum amount in millisats that can be sent per renewal period
 - `budget_renewal` (optional) reset the budget at the end of the given budget renewal. Can be `never` (default), `daily`, `weekly`, `monthly`, `yearly`
 - `request_methods` (optional) url encoded, space separated list of request types that you need permission for: `pay_invoice` (default), `get_balance` (see NIP47). For example: `..&request_methods=pay_invoice%20get_balance`
 - `notification_types` (optional) url encoded, space separated list of notification types that you need permission for: For example: `..&notification_types=payment_received%20payment_sent`

--- a/frontend/src/screens/apps/NewApp.tsx
+++ b/frontend/src/screens/apps/NewApp.tsx
@@ -65,7 +65,7 @@ const NewAppInternal = ({ capabilities }: NewAppInternalProps) => {
   const budgetRenewalParam = queryParams.get(
     "budget_renewal"
   ) as BudgetRenewalType;
-  const budgetMaxAmountParam = queryParams.get("max_amount") ?? "";
+  const budgetMaxAmountMsatParam = queryParams.get("max_amount") ?? "";
   const isolatedParam = queryParams.get("isolated") ?? "";
   const expiresAtParam = queryParams.get("expires_at") ?? "";
 
@@ -165,10 +165,12 @@ const NewAppInternal = ({ capabilities }: NewAppInternalProps) => {
 
   const [permissions, setPermissions] = useState<AppPermissions>({
     scopes: initialScopes,
-    maxAmount: budgetMaxAmountParam ? parseInt(budgetMaxAmountParam) : 0,
+    maxAmount: budgetMaxAmountMsatParam
+      ? Math.floor(parseInt(budgetMaxAmountMsatParam) / 1000)
+      : 0,
     budgetRenewal: validBudgetRenewals.includes(budgetRenewalParam)
       ? budgetRenewalParam
-      : budgetMaxAmountParam
+      : budgetMaxAmountMsatParam
         ? "never"
         : "monthly",
     expiresAt: parseExpiresParam(expiresAtParam),
@@ -273,7 +275,7 @@ const NewAppInternal = ({ capabilities }: NewAppInternalProps) => {
             scopesReadOnly={
               !!reqMethodsParam || !!notificationTypesParam || !!isolatedParam
             }
-            budgetReadOnly={!!budgetMaxAmountParam}
+            budgetReadOnly={!!budgetMaxAmountMsatParam}
             expiresAtReadOnly={!!expiresAtParam}
           />
         </div>


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/1108

Minimal change to consistently use msat values. The deep link flow changes were a breaking change and hopefully a spec can be created around this for http-accessible wallets, so it's good to fix this inconsistency now.

![image](https://github.com/user-attachments/assets/7a08feb2-b529-4013-9cff-ac98edf2b571)

