### PR TITLE
feat: show app creation time in connection summary

### DIFF
--- a/frontend/src/screens/apps/ShowApp.tsx
+++ b/frontend/src/screens/apps/ShowApp.tsx
@@ -274,6 +274,12 @@ function AppInternal({ app, refetchApp, capabilities }: AppInternalProps) {
                         : "Never"}
                     </TableCell>
                   </TableRow>
+                  <TableRow>
+                    <TableCell className="font-medium">Created At</TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {new Date(app.createdAt).toString()}
+                    </TableCell>
+                  </TableRow>
                   {app.metadata && (
                     <TableRow>
                       <TableCell className="font-medium">Metadata</TableCell>


### PR DESCRIPTION
Adds app creation time to the connection summary card

<img width="600" alt="Screenshot 2025-02-25 at 3 59 59 PM" src="https://github.com/user-attachments/assets/b8632511-ec80-46bc-a5c7-61b711a6b001" />
