### PR TITLE
feat: add app cleanup page

### DIFF
--- a/frontend/src/components/connections/AppCard.tsx
+++ b/frontend/src/components/connections/AppCard.tsx
@@ -17,9 +17,10 @@ dayjs.extend(relativeTime);
 type Props = {
   app: App;
   actions?: React.ReactNode;
+  readonly?: boolean;
 };
 
-export default function AppCard({ app, actions }: Props) {
+export default function AppCard({ app, actions, readonly = false }: Props) {
   const navigate = useNavigate();
 
   return (
@@ -48,7 +49,7 @@ export default function AppCard({ app, actions }: Props) {
         </CardTitle>
       </CardHeader>
       <CardContent className="flex-1 flex flex-col slashed-zero">
-        <AppCardConnectionInfo connection={app} />
+        <AppCardConnectionInfo connection={app} readonly={readonly} />
       </CardContent>
     </Card>
   );

--- a/frontend/src/components/connections/AppCard.tsx
+++ b/frontend/src/components/connections/AppCard.tsx
@@ -31,6 +31,7 @@ export default function AppCard({ app, actions, readonly = false }: Props) {
       <CardHeader>
         <CardTitle className="relative">
           <div className="flex flex-row items-center">
+            {!actions && <AppCardNotice app={app} />}
             <AppAvatar className="w-10 h-10" app={app} />
             <div className="flex-1 font-semibold text-xl whitespace-nowrap text-ellipsis overflow-hidden ml-4">
               {app.name}
@@ -42,7 +43,6 @@ export default function AppCard({ app, actions, readonly = false }: Props) {
                   e.stopPropagation() /* stop the above navigation click handler */
               }
             >
-              <AppCardNotice app={app} />
               {actions}
             </div>
           </div>

--- a/frontend/src/components/connections/AppCard.tsx
+++ b/frontend/src/components/connections/AppCard.tsx
@@ -29,16 +29,21 @@ export default function AppCard({ app, actions }: Props) {
     >
       <CardHeader>
         <CardTitle className="relative">
-          <AppCardNotice app={app} />
           <div className="flex flex-row items-center">
             <AppAvatar className="w-10 h-10" app={app} />
             <div className="flex-1 font-semibold text-xl whitespace-nowrap text-ellipsis overflow-hidden ml-4">
               {app.name}
             </div>
-            {!!actions && (
-              // stop the above navigation click handler
-              <div onClick={(e) => e.stopPropagation()}>{actions}</div>
-            )}
+            <div
+              className="flex items-center gap-2"
+              onClick={
+                (e) =>
+                  e.stopPropagation() /* stop the above navigation click handler */
+              }
+            >
+              <AppCardNotice app={app} />
+              {actions}
+            </div>
           </div>
         </CardTitle>
       </CardHeader>

--- a/frontend/src/components/connections/AppCardConnectionInfo.tsx
+++ b/frontend/src/components/connections/AppCardConnectionInfo.tsx
@@ -39,7 +39,7 @@ export function AppCardConnectionInfo({
           <div className="text-sm text-secondary-foreground font-medium w-full h-full flex flex-col gap-2">
             <div className="flex flex-row items-center gap-2">
               <BrickWall className="w-4 h-4" />
-              Isolated
+              Sub-wallet
             </div>
           </div>
           <div className="flex flex-row justify-between text-xs items-end mt-2">

--- a/frontend/src/components/connections/AppCardConnectionInfo.tsx
+++ b/frontend/src/components/connections/AppCardConnectionInfo.tsx
@@ -9,11 +9,13 @@ import { App, BudgetRenewalType } from "src/types";
 type AppCardConnectionInfoProps = {
   connection: App;
   budgetRemainingText?: string | React.ReactNode;
+  readonly?: boolean;
 };
 
 export function AppCardConnectionInfo({
   connection,
   budgetRemainingText = "Left in budget",
+  readonly = false,
 }: AppCardConnectionInfoProps) {
   function getBudgetRenewalLabel(renewalType: BudgetRenewalType): string {
     switch (renewalType) {
@@ -117,12 +119,14 @@ export function AppCardConnectionInfo({
                 ? dayjs(connection.lastEventAt).fromNow()
                 : "Never"}
             </div>
-            <Link to={`/apps/${connection.appPubkey}?edit=true`}>
-              <Button variant="outline">
-                <PlusCircle className="w-4 h-4 mr-2" />
-                Set Budget
-              </Button>
-            </Link>
+            {!readonly && (
+              <Link to={`/apps/${connection.appPubkey}?edit=true`}>
+                <Button variant="outline">
+                  <PlusCircle className="w-4 h-4 mr-2" />
+                  Set Budget
+                </Button>
+              </Link>
+            )}
           </div>
         </>
       ) : (
@@ -152,15 +156,17 @@ export function AppCardConnectionInfo({
                 ? dayjs(connection.lastEventAt).fromNow()
                 : "Never"}
             </div>
-            <Link
-              to={`/apps/${connection.appPubkey}?edit=true`}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <Button variant="outline">
-                <PlusCircle className="w-4 h-4 mr-2" />
-                Enable Payments
-              </Button>
-            </Link>
+            {!readonly && (
+              <Link
+                to={`/apps/${connection.appPubkey}?edit=true`}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Button variant="outline">
+                  <PlusCircle className="w-4 h-4 mr-2" />
+                  Enable Payments
+                </Button>
+              </Link>
+            )}
           </div>
         </>
       )}

--- a/frontend/src/components/connections/AppCardNotice.tsx
+++ b/frontend/src/components/connections/AppCardNotice.tsx
@@ -24,7 +24,7 @@ export function AppCardNotice({ app }: AppCardNoticeProps) {
   const expiresSoon = expiresAt.isBetween(now, now.add(7, "days"));
 
   return (
-    <div>
+    <div className="absolute top-0 right-0">
       {app.expiresAt ? (
         isExpired ? (
           <TooltipProvider>

--- a/frontend/src/components/connections/AppCardNotice.tsx
+++ b/frontend/src/components/connections/AppCardNotice.tsx
@@ -24,7 +24,7 @@ export function AppCardNotice({ app }: AppCardNoticeProps) {
   const expiresSoon = expiresAt.isBetween(now, now.add(7, "days"));
 
   return (
-    <div className="absolute top-0 right-0">
+    <div>
       {app.expiresAt ? (
         isExpired ? (
           <TooltipProvider>

--- a/frontend/src/hooks/useUnusedApps.ts
+++ b/frontend/src/hooks/useUnusedApps.ts
@@ -1,0 +1,11 @@
+import dayjs from "dayjs";
+import { useApps } from "src/hooks/useApps";
+
+export function useUnusedApps() {
+  const { data: apps } = useApps();
+
+  const oldDate = dayjs().subtract(2, "months");
+  return apps?.filter(
+    (app) => !app.lastEventAt || dayjs(app.lastEventAt).isBefore(oldDate)
+  );
+}

--- a/frontend/src/hooks/useUnusedApps.ts
+++ b/frontend/src/hooks/useUnusedApps.ts
@@ -2,14 +2,17 @@ import dayjs from "dayjs";
 import React from "react";
 import { useApps } from "src/hooks/useApps";
 
-const oldDate = dayjs().subtract(2, "months");
+const OLD_DATE = dayjs().subtract(2, "months");
+
 export function useUnusedApps() {
   const { data: apps } = useApps();
 
   return React.useMemo(
     () =>
       apps?.filter(
-        (app) => !app.lastEventAt || dayjs(app.lastEventAt).isBefore(oldDate)
+        (app) =>
+          (!app.lastEventAt || dayjs(app.lastEventAt).isBefore(OLD_DATE)) &&
+          app.metadata?.app_store_app_id != "uncle-jim"
       ),
     [apps]
   );

--- a/frontend/src/hooks/useUnusedApps.ts
+++ b/frontend/src/hooks/useUnusedApps.ts
@@ -1,11 +1,16 @@
 import dayjs from "dayjs";
+import React from "react";
 import { useApps } from "src/hooks/useApps";
 
+const oldDate = dayjs().subtract(2, "months");
 export function useUnusedApps() {
   const { data: apps } = useApps();
 
-  const oldDate = dayjs().subtract(2, "months");
-  return apps?.filter(
-    (app) => !app.lastEventAt || dayjs(app.lastEventAt).isBefore(oldDate)
+  return React.useMemo(
+    () =>
+      apps?.filter(
+        (app) => !app.lastEventAt || dayjs(app.lastEventAt).isBefore(oldDate)
+      ),
+    [apps]
   );
 }

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -22,6 +22,7 @@ import AlbyAuthRedirect from "src/screens/alby/AlbyAuthRedirect";
 import SupportAlby from "src/screens/alby/SupportAlby";
 import AppCreated from "src/screens/apps/AppCreated";
 import AppList from "src/screens/apps/AppList";
+import { AppsCleanup } from "src/screens/apps/AppsCleanup";
 import NewApp from "src/screens/apps/NewApp";
 import ShowApp from "src/screens/apps/ShowApp";
 import AppStore from "src/screens/appstore/AppStore";
@@ -230,6 +231,10 @@ const routes = [
           {
             path: "created",
             element: <AppCreated />,
+          },
+          {
+            path: "cleanup",
+            element: <AppsCleanup />,
           },
         ],
       },

--- a/frontend/src/screens/apps/AppList.tsx
+++ b/frontend/src/screens/apps/AppList.tsx
@@ -37,20 +37,20 @@ function AppList() {
         description="Apps that you connected to already"
         contentRight={
           <>
+            {!!unusedApps.length && (
+              <Link to="/apps/cleanup">
+                <Button variant="outline">
+                  <Trash className="h-4 w-4 mr-2" />
+                  Cleanup Unused
+                </Button>
+              </Link>
+            )}
             <Link to="/apps/new">
               <Button>
                 <CirclePlus className="h-4 w-4 mr-2" />
                 Add Connection
               </Button>
             </Link>
-            {!!unusedApps.length && (
-              <Link to="/apps/cleanup">
-                <Button variant="secondary">
-                  <Trash className="h-4 w-4 mr-2" />
-                  Cleanup Unused
-                </Button>
-              </Link>
-            )}
           </>
         }
       />

--- a/frontend/src/screens/apps/AppList.tsx
+++ b/frontend/src/screens/apps/AppList.tsx
@@ -1,4 +1,4 @@
-import { Cable, CirclePlus, SquareMinus } from "lucide-react";
+import { Cable, CirclePlus, Trash } from "lucide-react";
 import { Link } from "react-router-dom";
 import AppHeader from "src/components/AppHeader";
 import EmptyState from "src/components/EmptyState";
@@ -8,14 +8,16 @@ import AppCard from "src/components/connections/AppCard";
 import { Button } from "src/components/ui/button";
 import { useApps } from "src/hooks/useApps";
 import { useInfo } from "src/hooks/useInfo";
+import { useUnusedApps } from "src/hooks/useUnusedApps";
 
 const albyConnectionName = "getalby.com";
 
 function AppList() {
   const { data: apps } = useApps();
   const { data: info } = useInfo();
+  const unusedApps = useUnusedApps();
 
-  if (!apps || !info) {
+  if (!apps || !unusedApps || !info) {
     return <Loading />;
   }
 
@@ -41,10 +43,10 @@ function AppList() {
                 Add Connection
               </Button>
             </Link>
-            {apps.length > 5 && (
+            {!!unusedApps.length && (
               <Link to="/apps/cleanup">
                 <Button variant="secondary">
-                  <SquareMinus className="h-4 w-4 mr-2" />
+                  <Trash className="h-4 w-4 mr-2" />
                   Cleanup Unused
                 </Button>
               </Link>

--- a/frontend/src/screens/apps/AppList.tsx
+++ b/frontend/src/screens/apps/AppList.tsx
@@ -1,4 +1,4 @@
-import { Cable, CirclePlus } from "lucide-react";
+import { Cable, CirclePlus, SquareMinus } from "lucide-react";
 import { Link } from "react-router-dom";
 import AppHeader from "src/components/AppHeader";
 import EmptyState from "src/components/EmptyState";
@@ -34,12 +34,22 @@ function AppList() {
         title="Connections"
         description="Apps that you connected to already"
         contentRight={
-          <Link to="/apps/new">
-            <Button>
-              <CirclePlus className="h-4 w-4 mr-2" />
-              Add Connection
-            </Button>
-          </Link>
+          <>
+            <Link to="/apps/new">
+              <Button>
+                <CirclePlus className="h-4 w-4 mr-2" />
+                Add Connection
+              </Button>
+            </Link>
+            {apps.length > 5 && (
+              <Link to="/apps/cleanup">
+                <Button variant="secondary">
+                  <SquareMinus className="h-4 w-4 mr-2" />
+                  Cleanup Unused
+                </Button>
+              </Link>
+            )}
+          </>
         }
       />
 

--- a/frontend/src/screens/apps/AppsCleanup.tsx
+++ b/frontend/src/screens/apps/AppsCleanup.tsx
@@ -1,4 +1,4 @@
-import { InfoIcon, SkipForward, Trash2 } from "lucide-react";
+import { SkipForward, Trash2, TriangleAlert } from "lucide-react";
 import React from "react";
 import AppHeader from "src/components/AppHeader";
 import AppCard from "src/components/connections/AppCard";
@@ -55,20 +55,20 @@ export function AppsCleanup() {
         title="Cleanup Unused Apps"
         description="Review apps that haven't been used for 2 months or longer"
       />
+      <Alert variant="destructive">
+        <AlertTitle className="flex gap-2">
+          <TriangleAlert className="h-4 w-4" />
+          Warning
+        </AlertTitle>
+        <AlertDescription>
+          Review the app carefully before deleting it, deleted apps cannot be
+          recovered.
+        </AlertDescription>
+      </Alert>
       <div className="grid grid-cols-1 lg:grid-cols-5 gap-6">
         <div className="lg:col-span-3 flex flex-col gap-3">
           {currentApp && (
             <>
-              <Alert variant="destructive">
-                <AlertTitle className="flex gap-2">
-                  <InfoIcon className="h-4 w-4" />
-                  asdf
-                </AlertTitle>
-                <AlertDescription>
-                  Review the app carefully before deleting it. Deleted apps
-                  cannot be recovered.
-                </AlertDescription>
-              </Alert>
               <div className="w-full h-full">
                 <AppCard
                   app={currentApp}

--- a/frontend/src/screens/apps/AppsCleanup.tsx
+++ b/frontend/src/screens/apps/AppsCleanup.tsx
@@ -11,6 +11,8 @@ import { App } from "src/types";
 export function AppsCleanup() {
   const { data: apps } = useApps();
   const [appIndex, setAppIndex] = React.useState<number>();
+  const [skippedCount, setSkippedCount] = React.useState<number>(0);
+  const [deletedCount, setDeletedCount] = React.useState<number>(0);
   const [appsToReview, setAppsToReview] = React.useState<App[]>();
   const { deleteApp } = useDeleteApp();
   React.useEffect(() => {
@@ -56,7 +58,8 @@ export function AppsCleanup() {
       {currentApp && (
         <>
           <p className="font-mono">
-            {appIndex + 1} / {appsToReview.length} unused apps to review
+            {appIndex + 1} / {appsToReview.length} unused apps to review,{" "}
+            {skippedCount} skipped, {deletedCount} deleted
           </p>
 
           <div className="w-full">
@@ -70,6 +73,7 @@ export function AppsCleanup() {
                     onClick={() => {
                       deleteApp(currentApp.appPubkey);
                       setAppIndex(appIndex + 1);
+                      setDeletedCount((current) => current + 1);
                     }}
                   >
                     Delete
@@ -79,6 +83,7 @@ export function AppsCleanup() {
                     className="w-full"
                     onClick={() => {
                       setAppIndex(appIndex + 1);
+                      setSkippedCount((current) => current + 1);
                     }}
                   >
                     Skip

--- a/frontend/src/screens/apps/AppsCleanup.tsx
+++ b/frontend/src/screens/apps/AppsCleanup.tsx
@@ -58,7 +58,7 @@ export function AppsCleanup() {
       {currentApp && (
         <>
           <p className="font-mono">
-            {appIndex + 1} / {appsToReview.length} unused apps to review,{" "}
+            {appIndex + 1} / {appsToReview.length} unused apps reviewed,{" "}
             {skippedCount} skipped, {deletedCount} deleted
           </p>
 
@@ -86,7 +86,7 @@ export function AppsCleanup() {
                       setSkippedCount((current) => current + 1);
                     }}
                   >
-                    Skip
+                    Keep
                   </Button>
                 </>
               }

--- a/frontend/src/screens/apps/AppsCleanup.tsx
+++ b/frontend/src/screens/apps/AppsCleanup.tsx
@@ -1,31 +1,28 @@
-import dayjs from "dayjs";
 import React from "react";
 import AppHeader from "src/components/AppHeader";
 import AppCard from "src/components/connections/AppCard";
 import Loading from "src/components/Loading";
 import { Button, LinkButton } from "src/components/ui/button";
-import { useApps } from "src/hooks/useApps";
 import { useDeleteApp } from "src/hooks/useDeleteApp";
+import { useUnusedApps } from "src/hooks/useUnusedApps";
 import { App } from "src/types";
 
 export function AppsCleanup() {
-  const { data: apps } = useApps();
+  const unusedApps = useUnusedApps();
   const [appIndex, setAppIndex] = React.useState<number>();
   const [skippedCount, setSkippedCount] = React.useState<number>(0);
   const [deletedCount, setDeletedCount] = React.useState<number>(0);
   const [appsToReview, setAppsToReview] = React.useState<App[]>();
   const { deleteApp } = useDeleteApp();
   React.useEffect(() => {
-    if (!apps) {
+    if (!unusedApps) {
       return;
     }
     // only allow initializing once
     if (appIndex === undefined) {
       setAppIndex(0);
-      const oldDate = dayjs().subtract(1, "month");
-      const _appsToReview = apps.filter(
-        (app) => !app.lastEventAt || dayjs(app.lastEventAt).isBefore(oldDate)
-      );
+
+      const _appsToReview = [...unusedApps];
       _appsToReview.sort((a, b) => {
         return (
           (a.lastEventAt ? new Date(a.lastEventAt).getTime() : 0) -
@@ -34,7 +31,7 @@ export function AppsCleanup() {
       });
       setAppsToReview(_appsToReview);
     }
-  }, [appIndex, apps]);
+  }, [appIndex, unusedApps]);
 
   if (!appsToReview || appIndex === undefined) {
     return <Loading />;

--- a/frontend/src/screens/apps/AppsCleanup.tsx
+++ b/frontend/src/screens/apps/AppsCleanup.tsx
@@ -1,8 +1,18 @@
+import { InfoIcon, SkipForward, Trash2 } from "lucide-react";
 import React from "react";
 import AppHeader from "src/components/AppHeader";
 import AppCard from "src/components/connections/AppCard";
 import Loading from "src/components/Loading";
+import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
 import { Button, LinkButton } from "src/components/ui/button";
+import {
+  Card,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "src/components/ui/card";
+import { Progress } from "src/components/ui/progress";
 import { useDeleteApp } from "src/hooks/useDeleteApp";
 import { useUnusedApps } from "src/hooks/useUnusedApps";
 import { App } from "src/types";
@@ -40,72 +50,81 @@ export function AppsCleanup() {
   const currentApp = appsToReview[appIndex];
 
   return (
-    <div className="max-w-lg flex flex-col gap-4 items-center">
-      <div className="w-full">
-        <AppHeader
-          title="App Cleanup"
-          description="Quickly remove unused apps"
-        />
+    <>
+      <AppHeader
+        title="Cleanup Unused Apps"
+        description="Review apps that haven't been used for 2 months or longer"
+      />
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-6">
+        <div className="lg:col-span-3 flex flex-col gap-3">
+          {currentApp && (
+            <>
+              <Alert variant="destructive">
+                <AlertTitle className="flex gap-2">
+                  <InfoIcon className="h-4 w-4" />
+                  asdf
+                </AlertTitle>
+                <AlertDescription>
+                  Review the app carefully before deleting it. Deleted apps
+                  cannot be recovered.
+                </AlertDescription>
+              </Alert>
+              <div className="w-full h-full">
+                <AppCard
+                  app={currentApp}
+                  actions={
+                    <>
+                      <Button
+                        onClick={() => {
+                          setAppIndex(appIndex + 1);
+                          setSkippedCount((current) => current + 1);
+                        }}
+                      >
+                        <SkipForward className="h-4 w-4 mr-2" />
+                        Skip
+                      </Button>
+                      <Button
+                        variant="destructive"
+                        onClick={() => {
+                          deleteApp(currentApp.appPubkey);
+                          setAppIndex(appIndex + 1);
+                          setDeletedCount((current) => current + 1);
+                        }}
+                      >
+                        <Trash2 className="h-4 w-4 mr-2" />
+                        Delete
+                      </Button>
+                    </>
+                  }
+                  readonly
+                />
+              </div>
+            </>
+          )}
+          {!currentApp && (
+            <>
+              <div>No more unused apps to review.</div>
+              <div>
+                <LinkButton to="/apps">Back to overview</LinkButton>
+              </div>
+            </>
+          )}
+        </div>
+        <div className="lg:col-span-2">
+          <Card className="w-full">
+            <CardHeader>
+              <CardTitle>Progress</CardTitle>
+              <CardDescription>
+                {appIndex} of {appsToReview.length} unused apps reviewed (
+                {skippedCount} skipped, {deletedCount} deleted)
+              </CardDescription>
+            </CardHeader>
+            <CardFooter>
+              <Progress value={(appIndex / appsToReview.length) * 100} />
+            </CardFooter>
+          </Card>
+        </div>
       </div>
-      <p className="text-muted-foreground">
-        Review the app carefully before deleting it. Deleted apps cannot be
-        recovered. Take care before deleting{" "}
-        <span className="font-semibold">Friends & Family</span> apps.
-      </p>
-      {currentApp && (
-        <>
-          <p className="font-mono">
-            {appIndex + 1} / {appsToReview.length} unused apps reviewed,{" "}
-            {skippedCount} skipped, {deletedCount} deleted
-          </p>
-
-          <div className="w-full">
-            <AppCard
-              app={currentApp}
-              actions={
-                <>
-                  <Button
-                    variant="destructive"
-                    className="w-full"
-                    onClick={() => {
-                      deleteApp(currentApp.appPubkey);
-                      setAppIndex(appIndex + 1);
-                      setDeletedCount((current) => current + 1);
-                    }}
-                  >
-                    Delete
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    className="w-full"
-                    onClick={() => {
-                      setAppIndex(appIndex + 1);
-                      setSkippedCount((current) => current + 1);
-                    }}
-                  >
-                    Keep
-                  </Button>
-                </>
-              }
-            />
-          </div>
-        </>
-      )}
-      {!currentApp && (
-        <>
-          <p className="my-8">🎉 All apps reviewed!</p>
-          <LinkButton to="/" className="w-full">
-            Home
-          </LinkButton>
-          <Button
-            variant="secondary"
-            className="w-full"
-            onClick={() => window.location.reload()}
-          >
-            Restart
-          </Button>
-        </>
-      )}
-    </div>
+    </>
   );
 }

--- a/frontend/src/screens/apps/AppsCleanup.tsx
+++ b/frontend/src/screens/apps/AppsCleanup.tsx
@@ -66,7 +66,7 @@ export function AppsCleanup() {
             <AppCard
               app={currentApp}
               actions={
-                <div className="flex gap-2">
+                <>
                   <Button
                     variant="destructive"
                     className="w-full"
@@ -88,7 +88,7 @@ export function AppsCleanup() {
                   >
                     Skip
                   </Button>
-                </div>
+                </>
               }
             />
           </div>

--- a/frontend/src/screens/apps/AppsCleanup.tsx
+++ b/frontend/src/screens/apps/AppsCleanup.tsx
@@ -1,0 +1,109 @@
+import dayjs from "dayjs";
+import React from "react";
+import AppHeader from "src/components/AppHeader";
+import AppCard from "src/components/connections/AppCard";
+import Loading from "src/components/Loading";
+import { Button, LinkButton } from "src/components/ui/button";
+import { useApps } from "src/hooks/useApps";
+import { useDeleteApp } from "src/hooks/useDeleteApp";
+import { App } from "src/types";
+
+export function AppsCleanup() {
+  const { data: apps } = useApps();
+  const [appIndex, setAppIndex] = React.useState<number>();
+  const [appsToReview, setAppsToReview] = React.useState<App[]>();
+  const { deleteApp } = useDeleteApp();
+  React.useEffect(() => {
+    if (!apps) {
+      return;
+    }
+    // only allow initializing once
+    if (appIndex === undefined) {
+      setAppIndex(0);
+      const oldDate = dayjs().subtract(1, "month");
+      const _appsToReview = apps.filter(
+        (app) => !app.lastEventAt || dayjs(app.lastEventAt).isBefore(oldDate)
+      );
+      _appsToReview.sort((a, b) => {
+        return (
+          (a.lastEventAt ? new Date(a.lastEventAt).getTime() : 0) -
+          (b.lastEventAt ? new Date(b.lastEventAt).getTime() : 0)
+        );
+      });
+      setAppsToReview(_appsToReview);
+    }
+  }, [appIndex, apps]);
+
+  if (!appsToReview || appIndex === undefined) {
+    return <Loading />;
+  }
+
+  const currentApp = appsToReview[appIndex];
+
+  return (
+    <div className="max-w-lg flex flex-col gap-4 items-center">
+      <div className="w-full">
+        <AppHeader
+          title="App Cleanup"
+          description="Quickly remove unused apps"
+        />
+      </div>
+      <p className="text-muted-foreground">
+        Review the app carefully before deleting it. Deleted apps cannot be
+        recovered. Take care before deleting{" "}
+        <span className="font-semibold">Friends & Family</span> apps.
+      </p>
+      {currentApp && (
+        <>
+          <p className="font-mono">
+            {appIndex + 1} / {appsToReview.length} unused apps to review
+          </p>
+
+          <div className="w-full">
+            <AppCard
+              app={currentApp}
+              actions={
+                <div className="flex gap-2">
+                  <Button
+                    variant="destructive"
+                    className="w-full"
+                    onClick={() => {
+                      deleteApp(currentApp.appPubkey);
+                      setAppIndex(appIndex + 1);
+                    }}
+                  >
+                    Delete
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    className="w-full"
+                    onClick={() => {
+                      setAppIndex(appIndex + 1);
+                    }}
+                  >
+                    Skip
+                  </Button>
+                </div>
+              }
+            />
+          </div>
+        </>
+      )}
+      {!currentApp && (
+        <>
+          <p className="my-8">🎉 All apps reviewed!</p>
+          <LinkButton to="/" className="w-full">
+            Home
+          </LinkButton>
+          <Button
+            variant="secondary"
+            className="w-full"
+            onClick={() => window.location.reload()}
+          >
+            Restart
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/screens/apps/AppsCleanup.tsx
+++ b/frontend/src/screens/apps/AppsCleanup.tsx
@@ -55,16 +55,18 @@ export function AppsCleanup() {
         title="Cleanup Unused Apps"
         description="Review apps that haven't been used for 2 months or longer"
       />
-      <Alert variant="destructive">
-        <AlertTitle className="flex gap-2">
-          <TriangleAlert className="h-4 w-4" />
-          Warning
-        </AlertTitle>
-        <AlertDescription>
-          Review the app carefully before deleting it, deleted apps cannot be
-          recovered.
-        </AlertDescription>
-      </Alert>
+      {currentApp && (
+        <Alert variant="destructive">
+          <AlertTitle className="flex gap-2">
+            <TriangleAlert className="h-4 w-4" />
+            Warning
+          </AlertTitle>
+          <AlertDescription>
+            Review the app carefully before deleting it, deleted apps cannot be
+            recovered.
+          </AlertDescription>
+        </Alert>
+      )}
       <div className="grid grid-cols-1 lg:grid-cols-5 gap-6">
         <div className="lg:col-span-3 flex flex-col gap-3">
           {currentApp && (


### PR DESCRIPTION
A satisfying way to delete apps with one click. Button only shows when the user has more than 5 connections, apps are ordered by unused and then oldest first. Only apps used more than a month ago are considered.

I have many apps I didn't clean up, leading to poor performance especially with firing unnecessary notifications.

![image](https://github.com/user-attachments/assets/02b08da4-431e-4b75-bf65-e73041f1d5bf)

![image](https://github.com/user-attachments/assets/d85ca037-dfec-43f1-b02f-8e7e8e965d59)

![image](https://github.com/user-attachments/assets/684b939f-dd77-4fb0-ae66-56400b9bb409)
