### PR TITLE
fix: close swap dialogs after opening new window

### DIFF
--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -209,6 +209,7 @@ export default function Channels() {
                         openLink(
                           `https://boltz.exchange/?sendAsset=LN&receiveAsset=BTC&sendAmount=${swapOutAmount}&destination=${onchainAddress}&ref=alby`
                         );
+                        setSwapOutDialogOpen(false);
                       }
                       setLoadingSwap(false);
                     }}
@@ -271,6 +272,7 @@ export default function Channels() {
                         openLink(
                           `https://boltz.exchange/?sendAsset=BTC&receiveAsset=LN&sendAmount=${swapInAmount}&destination=${transaction.invoice}&ref=alby`
                         );
+                        setSwapInDialogOpen(false);
                       } catch (error) {
                         toast({
                           variant: "destructive",


### PR DESCRIPTION
Currently you have to first manually close the dialog before you can e.g. pay the invoice from this flow. 