### PR TITLE
chore: show wallet pubkey on connection page

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -284,20 +284,29 @@ func (api *api) GetApp(dbApp *db.App) *App {
 		}
 	}
 
+	walletPubkey := api.keys.GetNostrPublicKey()
+	uniqueWalletPubkey := false
+	if dbApp.WalletPubkey != nil {
+		walletPubkey = *dbApp.WalletPubkey
+		uniqueWalletPubkey = true
+	}
+
 	response := App{
-		ID:            dbApp.ID,
-		Name:          dbApp.Name,
-		Description:   dbApp.Description,
-		CreatedAt:     dbApp.CreatedAt,
-		UpdatedAt:     dbApp.UpdatedAt,
-		AppPubkey:     dbApp.AppPubkey,
-		ExpiresAt:     expiresAt,
-		MaxAmountSat:  maxAmount,
-		Scopes:        requestMethods,
-		BudgetUsage:   budgetUsage,
-		BudgetRenewal: paySpecificPermission.BudgetRenewal,
-		Isolated:      dbApp.Isolated,
-		Metadata:      metadata,
+		ID:                 dbApp.ID,
+		Name:               dbApp.Name,
+		Description:        dbApp.Description,
+		CreatedAt:          dbApp.CreatedAt,
+		UpdatedAt:          dbApp.UpdatedAt,
+		AppPubkey:          dbApp.AppPubkey,
+		ExpiresAt:          expiresAt,
+		MaxAmountSat:       maxAmount,
+		Scopes:             requestMethods,
+		BudgetUsage:        budgetUsage,
+		BudgetRenewal:      paySpecificPermission.BudgetRenewal,
+		Isolated:           dbApp.Isolated,
+		Metadata:           metadata,
+		WalletPubkey:       walletPubkey,
+		UniqueWalletPubkey: uniqueWalletPubkey,
 	}
 
 	if dbApp.Isolated {
@@ -335,14 +344,22 @@ func (api *api) ListApps() ([]App, error) {
 
 	apiApps := []App{}
 	for _, dbApp := range dbApps {
+		walletPubkey := api.keys.GetNostrPublicKey()
+		uniqueWalletPubkey := false
+		if dbApp.WalletPubkey != nil {
+			walletPubkey = *dbApp.WalletPubkey
+			uniqueWalletPubkey = true
+		}
 		apiApp := App{
-			ID:          dbApp.ID,
-			Name:        dbApp.Name,
-			Description: dbApp.Description,
-			CreatedAt:   dbApp.CreatedAt,
-			UpdatedAt:   dbApp.UpdatedAt,
-			AppPubkey:   dbApp.AppPubkey,
-			Isolated:    dbApp.Isolated,
+			ID:                 dbApp.ID,
+			Name:               dbApp.Name,
+			Description:        dbApp.Description,
+			CreatedAt:          dbApp.CreatedAt,
+			UpdatedAt:          dbApp.UpdatedAt,
+			AppPubkey:          dbApp.AppPubkey,
+			Isolated:           dbApp.Isolated,
+			WalletPubkey:       walletPubkey,
+			UniqueWalletPubkey: uniqueWalletPubkey,
 		}
 
 		if dbApp.Isolated {

--- a/api/models.go
+++ b/api/models.go
@@ -63,21 +63,23 @@ type API interface {
 }
 
 type App struct {
-	ID            uint       `json:"id"`
-	Name          string     `json:"name"`
-	Description   string     `json:"description"`
-	AppPubkey     string     `json:"appPubkey"`
-	CreatedAt     time.Time  `json:"createdAt"`
-	UpdatedAt     time.Time  `json:"updatedAt"`
-	LastEventAt   *time.Time `json:"lastEventAt"`
-	ExpiresAt     *time.Time `json:"expiresAt"`
-	Scopes        []string   `json:"scopes"`
-	MaxAmountSat  uint64     `json:"maxAmount"`
-	BudgetUsage   uint64     `json:"budgetUsage"`
-	BudgetRenewal string     `json:"budgetRenewal"`
-	Isolated      bool       `json:"isolated"`
-	Balance       int64      `json:"balance"`
-	Metadata      Metadata   `json:"metadata,omitempty"`
+	ID                 uint       `json:"id"`
+	Name               string     `json:"name"`
+	Description        string     `json:"description"`
+	AppPubkey          string     `json:"appPubkey"`
+	CreatedAt          time.Time  `json:"createdAt"`
+	UpdatedAt          time.Time  `json:"updatedAt"`
+	LastEventAt        *time.Time `json:"lastEventAt"`
+	ExpiresAt          *time.Time `json:"expiresAt"`
+	Scopes             []string   `json:"scopes"`
+	MaxAmountSat       uint64     `json:"maxAmount"`
+	BudgetUsage        uint64     `json:"budgetUsage"`
+	BudgetRenewal      string     `json:"budgetRenewal"`
+	Isolated           bool       `json:"isolated"`
+	WalletPubkey       string     `json:"walletPubkey"`
+	UniqueWalletPubkey bool       `json:"uniqueWalletPubkey"`
+	Balance            int64      `json:"balance"`
+	Metadata           Metadata   `json:"metadata,omitempty"`
 }
 
 type ListAppsResponse struct {

--- a/frontend/src/screens/apps/ShowApp.tsx
+++ b/frontend/src/screens/apps/ShowApp.tsx
@@ -14,7 +14,7 @@ import {
 import { handleRequestError } from "src/utils/handleRequestError";
 import { request } from "src/utils/request"; // build the project for this to appear
 
-import { PencilIcon, Trash2 } from "lucide-react";
+import { AlertCircle, PencilIcon, Trash2 } from "lucide-react";
 import AppAvatar from "src/components/AppAvatar";
 import AppHeader from "src/components/AppHeader";
 import { IsolatedAppTopupDialog } from "src/components/IsolatedAppTopupDialog";
@@ -41,6 +41,12 @@ import {
 } from "src/components/ui/card";
 import { Input } from "src/components/ui/input";
 import { Table, TableBody, TableCell, TableRow } from "src/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "src/components/ui/tooltip";
 import { useToast } from "src/components/ui/use-toast";
 import { useCapabilities } from "src/hooks/useCapabilities";
 
@@ -225,9 +231,32 @@ function AppInternal({ app, refetchApp, capabilities }: AppInternalProps) {
                     </TableCell>
                   </TableRow>
                   <TableRow>
-                    <TableCell className="font-medium">Public Key</TableCell>
+                    <TableCell className="font-medium">
+                      App Public Key
+                    </TableCell>
                     <TableCell className="text-muted-foreground break-all">
                       {app.appPubkey}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell className="font-medium">
+                      Wallet Public Key
+                    </TableCell>
+                    <TableCell className="text-muted-foreground whitespace-pre-wrap flex items-center">
+                      {app.walletPubkey}
+                      {!app.uniqueWalletPubkey && (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <AlertCircle className="w-3 h-3 ml-2" />
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              This connection does not have its own unique
+                              wallet pubkey. Re-connect for additional privacy.
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      )}
                     </TableCell>
                   </TableRow>
                   {app.isolated && (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -118,6 +118,8 @@ export interface App {
   name: string;
   description: string;
   appPubkey: string;
+  uniqueWalletPubkey: boolean;
+  walletPubkey: string;
   createdAt: string;
   updatedAt: string;
   lastEventAt?: string;


### PR DESCRIPTION
We were not showing the wallet service pubkey anywhere which is useful info. I also added an alert to show if the app is a legacy one or not. It's not a critical issue, but I think it's nice to know and be able to see.

![image](https://github.com/user-attachments/assets/e2a9bdb1-44aa-4d8a-9fe6-e31ce9b59659)
