### PR TITLE
fix: channels sorting on node page

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -439,28 +439,17 @@ func (api *api) ListChannels(ctx context.Context) ([]Channel, error) {
 		})
 	}
 
-	slices.SortFunc(apiChannels, func(a Channel, b Channel) int {
-
+	slices.SortFunc(apiChannels, func(a, b Channel) int {
 		// sort by channel size first
-		cmp := (b.LocalBalance + b.RemoteBalance) - (a.LocalBalance + a.RemoteBalance)
-		if cmp != 0 {
-			if cmp > 0 {
-				return 1
-			}
-			if cmp < 0 {
-				return -1
-			}
+		aSize := a.LocalBalance + a.RemoteBalance
+		bSize := b.LocalBalance + b.RemoteBalance
+		if aSize != bSize {
+			return int(bSize - aSize)
 		}
 
 		// then by local balance in the channel
-		cmp = b.LocalBalance - a.LocalBalance
-		if cmp != 0 {
-			if cmp > 0 {
-				return 1
-			}
-			if cmp < 0 {
-				return -1
-			}
+		if a.LocalBalance != b.LocalBalance {
+			return int(b.LocalBalance - a.LocalBalance)
 		}
 
 		// finally sort by channel ID to prevent sort randomly changing

--- a/api/api.go
+++ b/api/api.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -437,6 +438,35 @@ func (api *api) ListChannels(ctx context.Context) ([]Channel, error) {
 			Status:                                   status,
 		})
 	}
+
+	slices.SortFunc(apiChannels, func(a Channel, b Channel) int {
+
+		// sort by channel size first
+		cmp := (b.LocalBalance + b.RemoteBalance) - (a.LocalBalance + a.RemoteBalance)
+		if cmp != 0 {
+			if cmp > 0 {
+				return 1
+			}
+			if cmp < 0 {
+				return -1
+			}
+		}
+
+		// then by local balance in the channel
+		cmp = b.LocalBalance - a.LocalBalance
+		if cmp != 0 {
+			if cmp > 0 {
+				return 1
+			}
+			if cmp < 0 {
+				return -1
+			}
+		}
+
+		// finally sort by channel ID to prevent sort randomly changing
+		return strings.Compare(b.Id, a.Id)
+	})
+
 	return apiChannels, nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/1063

consistently sorts channels - channel capacity first, then spending balance second

![image](https://github.com/user-attachments/assets/613e2b26-b9f9-48be-b96c-5eba4f027dc0)
