### PR TITLE
feat: add swap alert

### DIFF
--- a/frontend/src/components/CloseChannelDialogContent.tsx
+++ b/frontend/src/components/CloseChannelDialogContent.tsx
@@ -5,6 +5,7 @@ import {
   ExternalLinkIcon,
 } from "lucide-react";
 import React from "react";
+import { SwapAlert } from "src/components/channels/SwapAlert";
 import ExternalLink from "src/components/ExternalLink";
 import { MempoolAlert } from "src/components/MempoolAlert";
 import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
@@ -113,6 +114,7 @@ export function CloseChannelDialogContent({ alias, channel }: Props) {
               Are you sure you want to close the channel with {alias}?
             </AlertDialogTitle>
             <AlertDialogDescription className="text-left">
+              <SwapAlert className="mb-4" />
               <Alert className="mb-4">
                 <AlertCircleIcon className="h-4 w-4" />
                 <AlertDescription>

--- a/frontend/src/components/channels/SwapAlert.tsx
+++ b/frontend/src/components/channels/SwapAlert.tsx
@@ -18,10 +18,9 @@ export function SwapAlert({ className }: SwapAlertProps) {
     return null;
   }
 
-  const directionText =
-    balances.lightning.totalSpendable > balances.lightning.totalReceivable
-      ? "out from"
-      : "into";
+  const isSwapOut =
+    balances.lightning.totalSpendable > balances.lightning.totalReceivable;
+  const directionText = isSwapOut ? "out from" : "into";
 
   return (
     <Alert className={className}>
@@ -43,7 +42,7 @@ export function SwapAlert({ className }: SwapAlertProps) {
             <ExternalLinkIcon className="w-4 h-4 ml-2" />
           </ExternalLinkButton>
           <LinkButton to="/channels?swap=true" variant="secondary">
-            Swap
+            Swap {isSwapOut ? "Out" : "In"}
           </LinkButton>
         </div>
       </AlertDescription>

--- a/frontend/src/components/channels/SwapAlert.tsx
+++ b/frontend/src/components/channels/SwapAlert.tsx
@@ -1,6 +1,7 @@
 import { ArrowDownUp, ExternalLinkIcon } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
 import { ExternalLinkButton, LinkButton } from "src/components/ui/button";
+import { useBalances } from "src/hooks/useBalances";
 import { useChannels } from "src/hooks/useChannels";
 
 type SwapAlertProps = {
@@ -8,24 +9,30 @@ type SwapAlertProps = {
 };
 export function SwapAlert({ className }: SwapAlertProps) {
   const { data: channels } = useChannels();
+  const { data: balances } = useBalances();
 
-  if (!channels) {
+  if (!channels || !balances) {
     return null;
   }
   if (channels.length < 2) {
     return null;
   }
 
+  const directionText =
+    balances.lightning.totalSpendable > balances.lightning.totalReceivable
+      ? "out from"
+      : "into";
+
   return (
     <Alert className={className}>
       <AlertTitle className="flex items-center gap-1">
         <ArrowDownUp className="h-4 w-4" />
-        Swap funds in or out of existing channels
+        Swap {directionText} existing channels
       </AlertTitle>
       <AlertDescription className="text-xs text-muted-foreground">
         <p>
-          It can be more economic to swap funds in and out of existing channels
-          rather than opening new channels or closing existing ones.
+          It can be more economic to swap funds {directionText} existing
+          channels rather than opening new channels or closing existing ones.
         </p>
         <div className="flex items-center justify-end mt-2 gap-2">
           <ExternalLinkButton

--- a/frontend/src/components/channels/SwapAlert.tsx
+++ b/frontend/src/components/channels/SwapAlert.tsx
@@ -1,4 +1,4 @@
-import { RefreshCcw } from "lucide-react";
+import { ArrowDownUp, ExternalLinkIcon } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
 import { ExternalLinkButton, LinkButton } from "src/components/ui/button";
 import { useChannels } from "src/hooks/useChannels";
@@ -18,23 +18,26 @@ export function SwapAlert({ className }: SwapAlertProps) {
 
   return (
     <Alert className={className}>
-      <AlertTitle className="flex items-center gap-2">
-        <RefreshCcw className="h-4 w-4" />
+      <AlertTitle className="flex items-center gap-1">
+        <ArrowDownUp className="h-4 w-4" />
         Swap funds in or out of existing channels
       </AlertTitle>
-      <AlertDescription>
+      <AlertDescription className="text-xs text-muted-foreground">
         <p>
           It can be more economic to swap funds in and out of existing channels
           rather than opening new channels or closing existing ones.
         </p>
-        <div className="flex justify-end mt-2 gap-2">
+        <div className="flex items-center justify-end mt-2 gap-2">
           <ExternalLinkButton
             to="https://guides.getalby.com/user-guide/alby-account-and-browser-extension/alby-hub/node/swaps-in-and-out"
-            variant="secondary"
+            variant="outline"
           >
             Learn more
+            <ExternalLinkIcon className="w-4 h-4 ml-2" />
           </ExternalLinkButton>
-          <LinkButton to="/channels?swap=true">Swap</LinkButton>
+          <LinkButton to="/channels?swap=true" variant="secondary">
+            Swap
+          </LinkButton>
         </div>
       </AlertDescription>
     </Alert>

--- a/frontend/src/components/channels/SwapAlert.tsx
+++ b/frontend/src/components/channels/SwapAlert.tsx
@@ -1,0 +1,42 @@
+import { RefreshCcw } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
+import { ExternalLinkButton, LinkButton } from "src/components/ui/button";
+import { useChannels } from "src/hooks/useChannels";
+
+type SwapAlertProps = {
+  className?: string;
+};
+export function SwapAlert({ className }: SwapAlertProps) {
+  const { data: channels } = useChannels();
+
+  if (!channels) {
+    return null;
+  }
+  if (channels.length < 2) {
+    return null;
+  }
+
+  return (
+    <Alert className={className}>
+      <AlertTitle className="flex items-center gap-2">
+        <RefreshCcw className="h-4 w-4" />
+        Swap funds in or out of existing channels
+      </AlertTitle>
+      <AlertDescription>
+        <p>
+          It can be more economic to swap funds in and out of existing channels
+          rather than opening new channels or closing existing ones.
+        </p>
+        <div className="flex justify-end mt-2 gap-2">
+          <ExternalLinkButton
+            to="https://guides.getalby.com/user-guide/alby-account-and-browser-extension/alby-hub/node/swaps-in-and-out"
+            variant="secondary"
+          >
+            Learn more
+          </ExternalLinkButton>
+          <LinkButton to="/channels?swap=true">Swap</LinkButton>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/frontend/src/components/channels/SwapDialogs.tsx
+++ b/frontend/src/components/channels/SwapDialogs.tsx
@@ -1,0 +1,202 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "src/components/ui/dialog";
+import { Input } from "src/components/ui/input";
+import { Label } from "src/components/ui/label";
+import { LoadingButton } from "src/components/ui/loading-button";
+import { useToast } from "src/components/ui/use-toast.ts";
+import { useChannels } from "src/hooks/useChannels";
+import { useOnchainAddress } from "src/hooks/useOnchainAddress";
+import { Channel, CreateInvoiceRequest, Transaction } from "src/types";
+import { openLink } from "src/utils/openLink";
+import { request } from "src/utils/request";
+
+type SwapDialogsProps = {
+  swapInDialogOpen: boolean;
+  setSwapInDialogOpen: (open: boolean) => void;
+  swapOutDialogOpen: boolean;
+  setSwapOutDialogOpen: (open: boolean) => void;
+};
+
+export function SwapDialogs({
+  swapInDialogOpen,
+  setSwapInDialogOpen,
+  swapOutDialogOpen,
+  setSwapOutDialogOpen,
+}: SwapDialogsProps) {
+  const { toast } = useToast();
+  const [swapInAmount, setSwapInAmount] = React.useState("");
+  const [swapOutAmount, setSwapOutAmount] = React.useState("");
+
+  const [loadingSwap, setLoadingSwap] = React.useState(false);
+  const { getNewAddress } = useOnchainAddress();
+  const { data: channels } = useChannels();
+
+  const findChannelWithLargestBalance = React.useCallback(
+    (
+      balanceType: "remoteBalance" | "localSpendableBalance"
+    ): Channel | undefined => {
+      if (!channels || channels.length === 0) {
+        return undefined;
+      }
+
+      return channels.reduce((prevLargest, current) => {
+        return current[balanceType] > prevLargest[balanceType]
+          ? current
+          : prevLargest;
+      }, channels[0]);
+    },
+    [channels]
+  );
+
+  React.useEffect(() => {
+    if (swapOutDialogOpen) {
+      setSwapOutAmount(
+        Math.floor(
+          ((findChannelWithLargestBalance("localSpendableBalance")
+            ?.localSpendableBalance || 0) *
+            0.9) /
+            1000
+        ).toString()
+      );
+    }
+  }, [findChannelWithLargestBalance, swapOutDialogOpen]);
+
+  React.useEffect(() => {
+    if (swapInDialogOpen) {
+      setSwapInAmount(
+        Math.floor(
+          ((findChannelWithLargestBalance("remoteBalance")?.remoteBalance ||
+            0) *
+            0.9) /
+            1000
+        ).toString()
+      );
+    }
+  }, [findChannelWithLargestBalance, swapInDialogOpen]);
+
+  return (
+    <>
+      <Dialog open={swapOutDialogOpen} onOpenChange={setSwapOutDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Swap out funds</DialogTitle>
+            <DialogDescription>
+              Funds from one of your channels will be sent to your on-chain
+              balance via a swap service. This helps restore your inbound
+              liquidity.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid grid-cols-4">
+            <Label className="pt-3">Amount (sats)</Label>
+            <div className="col-span-3">
+              <Input
+                value={swapOutAmount}
+                onChange={(e) => setSwapOutAmount(e.target.value)}
+              />
+              <p className="text-muted-foreground text-xs p-2">
+                The amount is set to 90% of the maximum spending capacity
+                available in one of your lightning channels.
+              </p>
+            </div>
+          </div>
+          <DialogFooter>
+            <LoadingButton
+              loading={loadingSwap}
+              type="submit"
+              onClick={async () => {
+                setLoadingSwap(true);
+                const onchainAddress = await getNewAddress();
+                if (onchainAddress) {
+                  openLink(
+                    `https://boltz.exchange/?sendAsset=LN&receiveAsset=BTC&sendAmount=${swapOutAmount}&destination=${onchainAddress}&ref=alby`
+                  );
+                  setSwapOutDialogOpen(false);
+                }
+                setLoadingSwap(false);
+              }}
+            >
+              Swap out
+            </LoadingButton>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={swapInDialogOpen} onOpenChange={setSwapInDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Swap in funds</DialogTitle>
+            <DialogDescription>
+              Swap on-chain funds into your lightning channels via a swap
+              service, increasing your spending balance using on-chain funds
+              from{" "}
+              <Link to="/wallet/withdraw" className="underline">
+                your hub
+              </Link>{" "}
+              or an external wallet.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid grid-cols-4">
+            <Label className="pt-3">Amount (sats)</Label>
+            <div className="col-span-3">
+              <Input
+                value={swapInAmount}
+                onChange={(e) => setSwapInAmount(e.target.value)}
+              />
+              <p className="text-muted-foreground text-xs p-2">
+                The amount is set to 90% of the maximum receiving capacity
+                available in one of your lightning channels.
+              </p>
+            </div>
+          </div>
+          <DialogFooter>
+            <LoadingButton
+              loading={loadingSwap}
+              type="submit"
+              onClick={async () => {
+                setLoadingSwap(true);
+                try {
+                  const transaction = await request<Transaction>(
+                    "/api/invoices",
+                    {
+                      method: "POST",
+                      headers: {
+                        "Content-Type": "application/json",
+                      },
+                      body: JSON.stringify({
+                        amount: parseInt(swapInAmount) * 1000,
+                        description: "Boltz Swap In",
+                      } as CreateInvoiceRequest),
+                    }
+                  );
+                  if (!transaction) {
+                    throw new Error("no transaction in response");
+                  }
+                  openLink(
+                    `https://boltz.exchange/?sendAsset=BTC&receiveAsset=LN&sendAmount=${swapInAmount}&destination=${transaction.invoice}&ref=alby`
+                  );
+                  setSwapInDialogOpen(false);
+                } catch (error) {
+                  toast({
+                    variant: "destructive",
+                    title: "Failed to generate swap invoice",
+                    description: "" + error,
+                  });
+                }
+                setLoadingSwap(false);
+              }}
+            >
+              Swap in
+            </LoadingButton>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -13,10 +13,11 @@ import {
   ZapIcon,
 } from "lucide-react";
 import React from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import AppHeader from "src/components/AppHeader.tsx";
 import { ChannelsCards } from "src/components/channels/ChannelsCards.tsx";
 import { ChannelsTable } from "src/components/channels/ChannelsTable.tsx";
+import { SwapDialogs } from "src/components/channels/SwapDialogs";
 import EmptyState from "src/components/EmptyState.tsx";
 import ExternalLink from "src/components/ExternalLink";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
@@ -33,14 +34,6 @@ import {
   CardTitle,
 } from "src/components/ui/card.tsx";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "src/components/ui/dialog";
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
@@ -49,9 +42,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "src/components/ui/dropdown-menu.tsx";
-import { Input } from "src/components/ui/input";
-import { Label } from "src/components/ui/label";
-import { LoadingButton } from "src/components/ui/loading-button";
 import { CircleProgress } from "src/components/ui/progress.tsx";
 import {
   Tooltip,
@@ -65,12 +55,10 @@ import { useBalances } from "src/hooks/useBalances.ts";
 import { useChannels } from "src/hooks/useChannels";
 import { useIsDesktop } from "src/hooks/useMediaQuery.ts";
 import { useNodeConnectionInfo } from "src/hooks/useNodeConnectionInfo.ts";
-import { useOnchainAddress } from "src/hooks/useOnchainAddress";
 import { useSyncWallet } from "src/hooks/useSyncWallet.ts";
 import { copyToClipboard } from "src/lib/clipboard.ts";
 import { cn } from "src/lib/utils.ts";
-import { Channel, CreateInvoiceRequest, Node, Transaction } from "src/types";
-import { openLink } from "src/utils/openLink";
+import { Channel, Node } from "src/types";
 import { request } from "src/utils/request";
 
 export default function Channels() {
@@ -80,12 +68,28 @@ export default function Channels() {
   const { data: balances } = useBalances();
   const navigate = useNavigate();
   const [nodes, setNodes] = React.useState<Node[]>([]);
-  const [swapInAmount, setSwapInAmount] = React.useState("");
-  const [swapOutAmount, setSwapOutAmount] = React.useState("");
   const [swapOutDialogOpen, setSwapOutDialogOpen] = React.useState(false);
   const [swapInDialogOpen, setSwapInDialogOpen] = React.useState(false);
-  const [loadingSwap, setLoadingSwap] = React.useState(false);
-  const { getNewAddress } = useOnchainAddress();
+  const [hasOpenedSwapDialog, setOpenedSwapDialog] = React.useState(false);
+  const [searchParams] = useSearchParams();
+
+  React.useEffect(() => {
+    if (
+      !hasOpenedSwapDialog &&
+      balances &&
+      channels &&
+      searchParams.has("swap", "true")
+    ) {
+      setOpenedSwapDialog(true);
+      if (
+        balances.lightning.totalSpendable > balances.lightning.totalReceivable
+      ) {
+        setSwapOutDialogOpen(true);
+      } else {
+        setSwapInDialogOpen(true);
+      }
+    }
+  }, [balances, channels, hasOpenedSwapDialog, searchParams]);
 
   const { toast } = useToast();
   const isDesktop = useIsDesktop();
@@ -117,42 +121,6 @@ export default function Channels() {
     loadNodeStats();
   }, [loadNodeStats]);
 
-  function openSwapOutDialog() {
-    setSwapOutAmount(
-      Math.floor(
-        ((findChannelWithLargestBalance("localSpendableBalance")
-          ?.localSpendableBalance || 0) *
-          0.9) /
-          1000
-      ).toString()
-    );
-    setSwapOutDialogOpen(true);
-  }
-  function openSwapInDialog() {
-    setSwapInAmount(
-      Math.floor(
-        ((findChannelWithLargestBalance("remoteBalance")?.remoteBalance || 0) *
-          0.9) /
-          1000
-      ).toString()
-    );
-    setSwapInDialogOpen(true);
-  }
-
-  function findChannelWithLargestBalance(
-    balanceType: "remoteBalance" | "localSpendableBalance"
-  ): Channel | undefined {
-    if (!channels || channels.length === 0) {
-      return undefined;
-    }
-
-    return channels.reduce((prevLargest, current) => {
-      return current[balanceType] > prevLargest[balanceType]
-        ? current
-        : prevLargest;
-    }, channels[0]);
-  }
-
   return (
     <>
       <AppHeader
@@ -160,123 +128,12 @@ export default function Channels() {
         description="Manage your lightning node liquidity."
         contentRight={
           <div className="flex gap-3 items-center justify-center">
-            {/* TODO: move these dialogs to a new file */}
-            <Dialog
-              open={swapOutDialogOpen}
-              onOpenChange={setSwapOutDialogOpen}
-            >
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>Swap out funds</DialogTitle>
-                  <DialogDescription>
-                    Funds from one of your channels will be sent to your
-                    on-chain balance via a swap service. This helps restore your
-                    inbound liquidity.
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="grid grid-cols-4">
-                  <Label className="pt-3">Amount (sats)</Label>
-                  <div className="col-span-3">
-                    <Input
-                      value={swapOutAmount}
-                      onChange={(e) => setSwapOutAmount(e.target.value)}
-                    />
-                    <p className="text-muted-foreground text-xs p-2">
-                      The amount is set to 90% of the maximum spending capacity
-                      available in one of your lightning channels.
-                    </p>
-                  </div>
-                </div>
-                <DialogFooter>
-                  <LoadingButton
-                    loading={loadingSwap}
-                    type="submit"
-                    onClick={async () => {
-                      setLoadingSwap(true);
-                      const onchainAddress = await getNewAddress();
-                      if (onchainAddress) {
-                        openLink(
-                          `https://boltz.exchange/?sendAsset=LN&receiveAsset=BTC&sendAmount=${swapOutAmount}&destination=${onchainAddress}&ref=alby`
-                        );
-                        setSwapOutDialogOpen(false);
-                      }
-                      setLoadingSwap(false);
-                    }}
-                  >
-                    Swap out
-                  </LoadingButton>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
-            <Dialog open={swapInDialogOpen} onOpenChange={setSwapInDialogOpen}>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>Swap in funds</DialogTitle>
-                  <DialogDescription>
-                    Swap on-chain funds into your lightning channels via a swap
-                    service, increasing your spending balance using on-chain
-                    funds from{" "}
-                    <Link to="/wallet/withdraw" className="underline">
-                      your hub
-                    </Link>{" "}
-                    or an external wallet.
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="grid grid-cols-4">
-                  <Label className="pt-3">Amount (sats)</Label>
-                  <div className="col-span-3">
-                    <Input
-                      value={swapInAmount}
-                      onChange={(e) => setSwapInAmount(e.target.value)}
-                    />
-                    <p className="text-muted-foreground text-xs p-2">
-                      The amount is set to 90% of the maximum receiving capacity
-                      available in one of your lightning channels.
-                    </p>
-                  </div>
-                </div>
-                <DialogFooter>
-                  <LoadingButton
-                    loading={loadingSwap}
-                    type="submit"
-                    onClick={async () => {
-                      setLoadingSwap(true);
-                      try {
-                        const transaction = await request<Transaction>(
-                          "/api/invoices",
-                          {
-                            method: "POST",
-                            headers: {
-                              "Content-Type": "application/json",
-                            },
-                            body: JSON.stringify({
-                              amount: parseInt(swapInAmount) * 1000,
-                              description: "Boltz Swap In",
-                            } as CreateInvoiceRequest),
-                          }
-                        );
-                        if (!transaction) {
-                          throw new Error("no transaction in response");
-                        }
-                        openLink(
-                          `https://boltz.exchange/?sendAsset=BTC&receiveAsset=LN&sendAmount=${swapInAmount}&destination=${transaction.invoice}&ref=alby`
-                        );
-                        setSwapInDialogOpen(false);
-                      } catch (error) {
-                        toast({
-                          variant: "destructive",
-                          title: "Failed to generate swap invoice",
-                          description: "" + error,
-                        });
-                      }
-                      setLoadingSwap(false);
-                    }}
-                  >
-                    Swap in
-                  </LoadingButton>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
+            <SwapDialogs
+              setSwapOutDialogOpen={setSwapOutDialogOpen}
+              swapOutDialogOpen={swapOutDialogOpen}
+              setSwapInDialogOpen={setSwapInDialogOpen}
+              swapInDialogOpen={swapInDialogOpen}
+            />
             <DropdownMenu modal={false}>
               <DropdownMenuTrigger asChild>
                 {isDesktop ? (
@@ -345,7 +202,7 @@ export default function Channels() {
                 <DropdownMenuGroup>
                   <DropdownMenuLabel>Swaps</DropdownMenuLabel>
                   <DropdownMenuItem
-                    onClick={openSwapInDialog}
+                    onClick={() => setSwapInDialogOpen(true)}
                     className="cursor-pointer"
                   >
                     <div className="mr-2 text-muted-foreground flex flex-row items-center">
@@ -356,7 +213,7 @@ export default function Channels() {
                     Swap in
                   </DropdownMenuItem>
                   <DropdownMenuItem
-                    onClick={openSwapOutDialog}
+                    onClick={() => setSwapOutDialogOpen(true)}
                     className="cursor-pointer"
                   >
                     <div className="mr-2 text-muted-foreground flex flex-row items-center">
@@ -433,9 +290,18 @@ export default function Channels() {
               <AlertTitle>Low receiving limit</AlertTitle>
               <AlertDescription>
                 You likely won't be able to receive payments until you{" "}
+                <Link
+                  className="underline"
+                  to="#"
+                  onClick={() => setSwapOutDialogOpen(true)}
+                >
+                  swap out funds
+                </Link>{" "}
+                or{" "}
                 <Link className="underline" to="/channels/incoming">
-                  increase your receiving limits.
+                  increase your receiving limits
                 </Link>
+                .
               </AlertDescription>
             </Alert>
           )}

--- a/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
@@ -8,6 +8,7 @@ import { MempoolAlert } from "src/components/MempoolAlert";
 import { ChannelPeerNote } from "src/components/channels/ChannelPeerNote";
 import { ChannelPublicPrivateAlert } from "src/components/channels/ChannelPublicPrivateAlert";
 import { DuplicateChannelAlert } from "src/components/channels/DuplicateChannelAlert";
+import { SwapAlert } from "src/components/channels/SwapAlert";
 import {
   Button,
   ExternalLinkButton,
@@ -410,6 +411,7 @@ function NewChannelInternal({
             </Button>
           )}
           <MempoolAlert />
+          <SwapAlert />
           {channels?.some((channel) => channel.public !== !!order.isPublic) && (
             <ChannelPublicPrivateAlert />
           )}

--- a/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
@@ -8,6 +8,7 @@ import { MempoolAlert } from "src/components/MempoolAlert";
 import { ChannelPeerNote } from "src/components/channels/ChannelPeerNote";
 import { ChannelPublicPrivateAlert } from "src/components/channels/ChannelPublicPrivateAlert";
 import { DuplicateChannelAlert } from "src/components/channels/DuplicateChannelAlert";
+import { SwapAlert } from "src/components/channels/SwapAlert";
 import {
   Button,
   ExternalLinkButton,
@@ -373,6 +374,7 @@ function NewChannelInternal({ network }: { network: Network }) {
             </div>
           </>
           <MempoolAlert />
+          <SwapAlert />
           {channels?.some((channel) => channel.public !== !!order.isPublic) && (
             <ChannelPublicPrivateAlert />
           )}


### PR DESCRIPTION
Closes https://github.com/getAlby/hub/issues/1134

Adds an alert to swap rather than opening/closing channels in certain relevant places:
- when opening a channel
- when closing a channel
- low receiving capacity on channels page

The alert on other pages will open a link to `/channels?swap=true` which will auto-detect which swap should be used.

Channels page - low receiving capacity

![image](https://github.com/user-attachments/assets/338b6a31-5e0d-428c-aabc-ee4b87d6aa31)

Open new channel pages

![image](https://github.com/user-attachments/assets/42f6971b-d4de-4345-bb8d-75f2b1a4289c)

Close channel dialog

![image](https://github.com/user-attachments/assets/5ff5e81b-00a2-48bb-96dd-c90fb5bd2b28)

I'm wondering if we should have a similar alert somewhere to swap in to "top up" channels. Maybe on the receive page?

Copy needs review.

Swap dialogs were moved into a separate file to keep the channels component as small as possible.