### PR TITLE
feat: show channel duration on open channel pages

### DIFF
--- a/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
@@ -227,10 +227,10 @@ function NewChannelInternal({
         <p className="text-muted-foreground">
           Alby Hub works with selected service providers (LSPs) which provide
           the best network connectivity and liquidity to receive payments. The
-          channel typically stays open as long as there is usage.{" "}
+          channel may stay open for a year or more as long as there is usage.{" "}
           <ExternalLink
             className="underline"
-            to="https://guides.getalby.com/user-guide/alby-account-and-browser-extension/alby-hub/faq-alby-hub/how-to-open-a-channel"
+            to="https://guides.getalby.com/user-guide/alby-account-and-browser-extension/alby-hub/faq-alby-hub/why-was-my-lightning-channel-closed-and-what-to-do-next"
           >
             Learn more
           </ExternalLink>
@@ -391,8 +391,13 @@ function NewChannelInternal({
                     Public Channel
                   </Label>
                   <p className="text-xs text-muted-foreground">
-                    Only enable if you want to receive keysend payments. (e.g.
-                    podcasting)
+                    Not recommended for most users.{" "}
+                    <ExternalLink
+                      className="underline"
+                      to="https://guides.getalby.com/user-guide/alby-account-and-browser-extension/alby-hub/faq-alby-hub/how-to-open-a-channel"
+                    >
+                      Learn more
+                    </ExternalLink>
                   </p>
                 </div>
               </div>

--- a/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
@@ -206,6 +206,26 @@ function NewChannelInternal({ network }: { network: Network }) {
           src="/images/illustrations/lightning-network-light.svg"
           className="w-full dark:hidden"
         />
+        <p className="text-muted-foreground">
+          Open a channel with on-chain funds. Both parties are free to close the
+          channel at any time. However, by keeping more funds on your side of
+          the channel and using it regularly, there is more chance the channel
+          will stay open. Learn more about{" "}
+          <ExternalLink
+            className="underline"
+            to="https://guides.getalby.com/user-guide/alby-account-and-browser-extension/alby-hub/faq-alby-hub/how-to-open-a-channel"
+          >
+            opening channels
+          </ExternalLink>{" "}
+          and{" "}
+          <ExternalLink
+            className="underline"
+            to="https://guides.getalby.com/user-guide/alby-account-and-browser-extension/alby-hub/faq-alby-hub/why-was-my-lightning-channel-closed-and-what-to-do-next"
+          >
+            channel closures
+          </ExternalLink>
+          .
+        </p>
         <form
           onSubmit={onSubmit}
           className="md:max-w-md max-w-full flex flex-col gap-5 flex-1"
@@ -366,8 +386,13 @@ function NewChannelInternal({ network }: { network: Network }) {
                   Public Channel
                 </Label>
                 <p className="text-xs text-muted-foreground">
-                  Enable if you want to receive keysend payments. (e.g.
-                  podcasting)
+                  Not recommended for most users.{" "}
+                  <ExternalLink
+                    className="underline"
+                    to="https://guides.getalby.com/user-guide/alby-account-and-browser-extension/alby-hub/faq-alby-hub/how-to-open-a-channel"
+                  >
+                    Learn more
+                  </ExternalLink>
                 </p>
               </div>
             </div>

--- a/frontend/src/screens/channels/auto/AutoChannel.tsx
+++ b/frontend/src/screens/channels/auto/AutoChannel.tsx
@@ -154,6 +154,18 @@ export function AutoChannel() {
                 immediately be able to receive and send bitcoin through this
                 channel with your Hub.
               </p>
+              <p className="text-muted-foreground">
+                Alby Hub works with selected service providers (LSPs) which
+                provide the best network connectivity and liquidity to receive
+                payments. The channel may stay open for a year or more as long
+                as there is usage.{" "}
+                <ExternalLink
+                  className="underline"
+                  to="https://guides.getalby.com/user-guide/alby-account-and-browser-extension/alby-hub/faq-alby-hub/why-was-my-lightning-channel-closed-and-what-to-do-next"
+                >
+                  Learn more
+                </ExternalLink>
+              </p>
             </>
             {showAdvanced && (
               <>
@@ -171,8 +183,13 @@ export function AutoChannel() {
                       Public Channel
                     </Label>
                     <p className="text-xs text-muted-foreground">
-                      Only enable if you want to receive keysend payments. (e.g.
-                      podcasting)
+                      Not recommended for most users.{" "}
+                      <ExternalLink
+                        className="underline"
+                        to="https://guides.getalby.com/user-guide/alby-account-and-browser-extension/alby-hub/faq-alby-hub/how-to-open-a-channel"
+                      >
+                        Learn more
+                      </ExternalLink>
                     </p>
                   </div>
                 </div>

--- a/frontend/src/screens/channels/first/FirstChannel.tsx
+++ b/frontend/src/screens/channels/first/FirstChannel.tsx
@@ -165,6 +165,18 @@ export function FirstChannel() {
                   you'll immediately be able to receive and send bitcoin with
                   your Hub.
                 </p>
+                <p className="text-muted-foreground">
+                  Alby Hub works with selected service providers (LSPs) which
+                  provide the best network connectivity and liquidity to receive
+                  payments. The channel may stay open for a year or more as long
+                  as there is usage.{" "}
+                  <ExternalLink
+                    className="underline"
+                    to="https://guides.getalby.com/user-guide/alby-account-and-browser-extension/alby-hub/faq-alby-hub/why-was-my-lightning-channel-closed-and-what-to-do-next"
+                  >
+                    Learn more
+                  </ExternalLink>
+                </p>
               </>
             )}
             {showAdvanced && (
@@ -183,8 +195,13 @@ export function FirstChannel() {
                       Public Channel
                     </Label>
                     <p className="text-xs text-muted-foreground">
-                      Only enable if you want to receive keysend payments. (e.g.
-                      podcasting)
+                      Not recommended for most users.{" "}
+                      <ExternalLink
+                        className="underline"
+                        to="https://guides.getalby.com/user-guide/alby-account-and-browser-extension/alby-hub/faq-alby-hub/how-to-open-a-channel"
+                      >
+                        Learn more
+                      </ExternalLink>
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
This change is only copy and links changes to better communicate to users about their channels. Please review carefully.

Guides also need to be updated: [how to open a channel](https://guides.getalby.com/user-guide/alby-account-and-browser-extension/alby-hub/faq-alby-hub/how-to-open-a-channel) and [why was my channel closed](https://guides.getalby.com/user-guide/alby-account-and-browser-extension/alby-hub/faq-alby-hub/why-was-my-lightning-channel-closed-and-what-to-do-next).

Default first channel flow and auto channel flow:

![image](https://github.com/user-attachments/assets/447462ce-cdc4-4c4d-a39e-60d7a7d6dd46)

![image](https://github.com/user-attachments/assets/9c8ba693-4943-4326-9811-b67e3a99e285)

Increase receiving capacity (non-first channel flow)

![image](https://github.com/user-attachments/assets/88bb8d5c-33aa-405f-a89e-58e4327e5b7c)

Increase spending balance (on-chain flow)

![image](https://github.com/user-attachments/assets/b76ea262-22c0-4d9f-92f7-3cc96184a6f6)

