### PR TITLE
feat: show total and reserved balance in spending balance tooltip

### DIFF
--- a/frontend/src/components/channels/ChannelsCards.tsx
+++ b/frontend/src/components/channels/ChannelsCards.tsx
@@ -137,7 +137,9 @@ export function ChannelsCards({ channels, nodes }: ChannelsCardsProps) {
                               cheating by ensuring each party has something at
                               stake. This reserve cannot be spent during the
                               channel's lifetime and typically amounts to 1% of
-                              the channel capacity.
+                              the channel capacity. The reserve will
+                              automatically be filled when payments are received
+                              on the channel.
                             </TooltipContent>
                           </Tooltip>
                         </TooltipProvider>

--- a/frontend/src/components/channels/ChannelsTable.tsx
+++ b/frontend/src/components/channels/ChannelsTable.tsx
@@ -99,7 +99,9 @@ export function ChannelsTable({ channels, nodes }: ChannelsTableProps) {
                       Funds each participant sets aside to discourage cheating
                       by ensuring each party has something at stake. This
                       reserve cannot be spent during the channel's lifetime and
-                      typically amounts to 1% of the channel capacity.
+                      typically amounts to 1% of the channel capacity. The
+                      reserve will automatically be filled when payments are
+                      received on the channel.
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -466,6 +466,28 @@ export default function Channels() {
                       <TooltipContent className="w-[300px]">
                         Your spending balance is the funds on your side of your
                         channels, which you can use to make lightning payments.
+                        Your total lightning balance is{" "}
+                        {new Intl.NumberFormat().format(
+                          channels
+                            ?.map((channel) =>
+                              Math.floor(channel.localBalance / 1000)
+                            )
+                            .reduce((a, b) => a + b, 0) || 0
+                        )}{" "}
+                        sats which includes{" "}
+                        {new Intl.NumberFormat().format(
+                          Math.floor(
+                            channels
+                              ?.map((channel) =>
+                                Math.min(
+                                  Math.floor(channel.localBalance / 1000),
+                                  channel.unspendablePunishmentReserve
+                                )
+                              )
+                              .reduce((a, b) => a + b, 0) || 0
+                          )
+                        )}{" "}
+                        sats reserved in your channels which cannot be spent.
                       </TooltipContent>
                     </Tooltip>
                   </TooltipProvider>


### PR DESCRIPTION
We can point people to check this if they think sats are missing from the spending balance (actually are part of channel reserves)

Fixes https://github.com/getAlby/hub/issues/1159

Alternative to https://github.com/getAlby/hub/pull/1105