### PR TITLE
fix: do not publish info events on relay reconnect

### DIFF
--- a/nip47/publish_nip47_info.go
+++ b/nip47/publish_nip47_info.go
@@ -83,6 +83,7 @@ func (svc *nip47Service) PublishNip47Info(ctx context.Context, relay nostrmodels
 	if err != nil {
 		return nil, fmt.Errorf("nostr publish not successful: %s", err)
 	}
+	logger.Logger.WithField("wallet_pubkey", appWalletPubKey).Debug("published info event")
 	return ev, nil
 }
 


### PR DESCRIPTION
This is redundant and causes a lot of events to be published on the relay at the same time