### PR TITLE
chore: remove duplicated nip-47 notifier

### DIFF
--- a/nip47/notifications/nip47_notifier.go
+++ b/nip47/notifications/nip47_notifier.go
@@ -8,38 +8,32 @@ import (
 	"github.com/getAlby/hub/constants"
 	"github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/events"
-	"github.com/getAlby/hub/lnclient"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/nip47/cipher"
 	"github.com/getAlby/hub/nip47/models"
 	"github.com/getAlby/hub/nip47/permissions"
 	nostrmodels "github.com/getAlby/hub/nostr/models"
 	"github.com/getAlby/hub/service/keys"
-	"github.com/getAlby/hub/transactions"
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
 type Nip47Notifier struct {
-	relay               nostrmodels.Relay
-	cfg                 config.Config
-	keys                keys.Keys
-	lnClient            lnclient.LNClient
-	db                  *gorm.DB
-	permissionsSvc      permissions.PermissionsService
-	transactionsService transactions.TransactionsService
+	relay          nostrmodels.Relay
+	cfg            config.Config
+	keys           keys.Keys
+	db             *gorm.DB
+	permissionsSvc permissions.PermissionsService
 }
 
-func NewNip47Notifier(relay nostrmodels.Relay, db *gorm.DB, cfg config.Config, keys keys.Keys, permissionsSvc permissions.PermissionsService, transactionsService transactions.TransactionsService, lnClient lnclient.LNClient) *Nip47Notifier {
+func NewNip47Notifier(relay nostrmodels.Relay, db *gorm.DB, cfg config.Config, keys keys.Keys, permissionsSvc permissions.PermissionsService) *Nip47Notifier {
 	return &Nip47Notifier{
-		relay:               relay,
-		cfg:                 cfg,
-		db:                  db,
-		lnClient:            lnClient,
-		permissionsSvc:      permissionsSvc,
-		transactionsService: transactionsService,
-		keys:                keys,
+		relay:          relay,
+		cfg:            cfg,
+		db:             db,
+		permissionsSvc: permissionsSvc,
+		keys:           keys,
 	}
 }
 

--- a/nip47/notifications/nip47_notifier_test.go
+++ b/nip47/notifications/nip47_notifier_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/getAlby/hub/lnclient"
 	"github.com/getAlby/hub/nip47/permissions"
 	"github.com/getAlby/hub/tests"
-	"github.com/getAlby/hub/transactions"
 )
 
 type mockConsumer struct {
@@ -80,9 +79,8 @@ func doTestSendNotificationPaymentReceived(t *testing.T, svc *tests.TestService,
 	relay := tests.NewMockRelay()
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
-	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
 
-	notifier := NewNip47Notifier(relay, svc.DB, svc.Cfg, svc.Keys, permissionsSvc, transactionsSvc, svc.LNClient)
+	notifier := NewNip47Notifier(relay, svc.DB, svc.Cfg, svc.Keys, permissionsSvc)
 	notifier.ConsumeEvent(ctx, receivedEvent)
 
 	var publishedEvent *nostr.Event
@@ -195,9 +193,8 @@ func doTestSendNotificationPaymentSent(t *testing.T, svc *tests.TestService, cre
 	relay := tests.NewMockRelay()
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
-	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
 
-	notifier := NewNip47Notifier(relay, svc.DB, svc.Cfg, svc.Keys, permissionsSvc, transactionsSvc, svc.LNClient)
+	notifier := NewNip47Notifier(relay, svc.DB, svc.Cfg, svc.Keys, permissionsSvc)
 	notifier.ConsumeEvent(ctx, receivedEvent)
 
 	var publishedEvent *nostr.Event
@@ -289,9 +286,8 @@ func doTestSendNotificationNoPermission(t *testing.T, svc *tests.TestService) {
 	relay := tests.NewMockRelay()
 
 	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
-	transactionsSvc := transactions.NewTransactionsService(svc.DB, svc.EventPublisher)
 
-	notifier := NewNip47Notifier(relay, svc.DB, svc.Cfg, svc.Keys, permissionsSvc, transactionsSvc, svc.LNClient)
+	notifier := NewNip47Notifier(relay, svc.DB, svc.Cfg, svc.Keys, permissionsSvc)
 	notifier.ConsumeEvent(ctx, receivedEvent)
 
 	assert.Nil(t, relay.PublishedEvents)

--- a/service/start.go
+++ b/service/start.go
@@ -90,6 +90,8 @@ func (svc *service) startNostr(ctx context.Context) error {
 			}).Info("Connected to the relay")
 			waitToReconnectSeconds = 0
 
+			svc.nip47Service.StartNotifier(relay.Context(), relay)
+
 			// register a subscriber for events of "nwc_app_created" which handles creation of nostr subscription for new app
 			if createAppEventListener != nil {
 				svc.eventPublisher.RemoveSubscriber(createAppEventListener)
@@ -201,8 +203,6 @@ func (svc *service) startAppWalletSubscription(ctx context.Context, relay *nostr
 }
 
 func (svc *service) StartSubscription(ctx context.Context, sub *nostr.Subscription) error {
-	svc.nip47Service.StartNotifier(ctx, sub.Relay, svc.lnClient)
-
 	go func() {
 		// loop through incoming events
 		for event := range sub.Events {


### PR DESCRIPTION
we were starting a nip-47 notifier for each subscription rather than once per relay connection.

I also removed some unused dependencies from the notifier.