### PR TITLE
fix: reset latest_rgs_snapshot_timestamp on startup if using transient network graph

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.3
 require (
 	github.com/adrg/xdg v0.5.3
 	github.com/elnosh/gonuts v0.4.0
-	github.com/getAlby/ldk-node-go v0.0.0-20250313063409-c465f4e6e089
+	github.com/getAlby/ldk-node-go v0.0.0-20250317054222-37346892e729
 	github.com/go-gormigrate/gormigrate/v2 v2.1.3
 	github.com/labstack/echo/v4 v4.13.3
 	github.com/nbd-wtf/go-nostr v0.50.0

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
-github.com/getAlby/ldk-node-go v0.0.0-20250313063409-c465f4e6e089 h1:39wtrlg8SxbjJDj/hGdhS4GPlDk9kwxTy36kvrDP5mU=
-github.com/getAlby/ldk-node-go v0.0.0-20250313063409-c465f4e6e089/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20250317054222-37346892e729 h1:mfRbKeU2PhlunwiwOBTCPOh4h6ZxOfpIZD1/0DlFjaI=
+github.com/getAlby/ldk-node-go v0.0.0-20250317054222-37346892e729/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=


### PR DESCRIPTION
Part of https://github.com/getAlby/hub/issues/1174