### PR TITLE
feat: link to node page from healthcheck indicator and show healthcheck alert

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1085,10 +1085,7 @@ func (api *api) Health(ctx context.Context) (*HealthResponse, error) {
 	lnClient := api.svc.GetLNClient()
 
 	if lnClient != nil {
-		nodeStatus, err := lnClient.GetNodeStatus(ctx)
-		if err != nil {
-			return nil, err
-		}
+		nodeStatus, _ := lnClient.GetNodeStatus(ctx)
 		if nodeStatus == nil || !nodeStatus.IsReady {
 			alarms = append(alarms, NewHealthAlarm(HealthAlarmKindNodeNotReady, nodeStatus))
 		}

--- a/frontend/src/components/channels/HealthcheckAlert.tsx
+++ b/frontend/src/components/channels/HealthcheckAlert.tsx
@@ -1,0 +1,90 @@
+import { AlertTriangle, CheckCircle2 } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
+import { ExternalLinkButton } from "src/components/ui/button";
+import { useHealthCheck } from "src/hooks/useHealthCheck";
+import { AlbyInfoIncident, HealthAlarm } from "src/types";
+
+type HealthCheckAlertProps = {
+  showOk?: boolean;
+};
+
+export function HealthCheckAlert({ showOk }: HealthCheckAlertProps) {
+  const { data: health } = useHealthCheck();
+
+  const ok = !health?.alarms?.length;
+
+  if (!health) {
+    return null;
+  }
+
+  if (!showOk && ok) {
+    return null;
+  }
+
+  function getAlarmTitle(alarm: HealthAlarm) {
+    // TODO: could show extra data from alarm.rawDetails
+    // for some alarm types
+    switch (alarm.kind) {
+      case "alby_service":
+        return (
+          "Alby Services: " +
+          (alarm.rawDetails as AlbyInfoIncident[])
+            ?.map((incident) => `${incident.name} (${incident.status})`)
+            .join(", ")
+        );
+      case "channels_offline":
+        return "One or more channels are offline";
+      case "node_not_ready":
+        return "Node is not ready";
+      case "nostr_relay_offline":
+        return "Could not connect to relay";
+      default:
+        return "Unknown error";
+    }
+  }
+
+  return (
+    <>
+      <Alert className="animate-highlight">
+        {ok ? (
+          <>
+            <CheckCircle2 className="h-4 w-4" />
+            <AlertTitle>Alby Hub is running smoothly</AlertTitle>
+          </>
+        ) : (
+          <>
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>
+              {health.alarms.length} issues impacting your hub were found
+            </AlertTitle>
+          </>
+        )}
+        <AlertDescription>
+          {health.alarms?.length && (
+            <ul className="mt-2 whitespace-pre-wrap list-disc list-inside">
+              {health.alarms?.map((alarm) => (
+                <li key={alarm.kind}>{getAlarmTitle(alarm)}</li>
+              ))}
+            </ul>
+          )}
+          <div className="mt-4 flex gap-2">
+            <ExternalLinkButton
+              size="sm"
+              variant="secondary"
+              to="https://alby.instatus.com/"
+            >
+              Alby Service Status
+            </ExternalLinkButton>
+            <ExternalLinkButton
+              size="sm"
+              variant="secondary"
+              to="https://guides.getalby.com/user-guide/alby-account-and-browser-extension/alby-hub/faq-alby-hub/what-happens-if-the-healthcheck-indicator-turns-red"
+            >
+              Learn More
+            </ExternalLinkButton>
+          </div>
+        </AlertDescription>
+      </Alert>
+    </>
+  );
+}

--- a/frontend/src/components/channels/HealthcheckAlert.tsx
+++ b/frontend/src/components/channels/HealthcheckAlert.tsx
@@ -74,7 +74,7 @@ export function HealthCheckAlert({ showOk }: HealthCheckAlertProps) {
             <ExternalLinkButton
               size="sm"
               variant="secondary"
-              to="https://alby.instatus.com/"
+              to="https://status.getalby.com"
             >
               Alby Service Status
             </ExternalLinkButton>

--- a/frontend/src/components/channels/HealthcheckAlert.tsx
+++ b/frontend/src/components/channels/HealthcheckAlert.tsx
@@ -24,23 +24,26 @@ export function HealthCheckAlert({ showOk }: HealthCheckAlertProps) {
   function getAlarmTitle(alarm: HealthAlarm) {
     // TODO: could show extra data from alarm.rawDetails
     // for some alarm types
-    switch (alarm.kind) {
-      case "alby_service":
-        return (
-          "Alby Services: " +
-          (alarm.rawDetails as AlbyInfoIncident[])
-            ?.map((incident) => `${incident.name} (${incident.status})`)
-            .join(", ")
-        );
-      case "channels_offline":
-        return "One or more channels are offline";
-      case "node_not_ready":
-        return "Node is not ready";
-      case "nostr_relay_offline":
-        return "Could not connect to relay";
-      default:
-        return "Unknown error";
+    try {
+      switch (alarm.kind) {
+        case "alby_service":
+          return (
+            "Alby Services: " +
+            (alarm.rawDetails as AlbyInfoIncident[])
+              ?.map((incident) => `${incident.name} (${incident.status})`)
+              .join(", ")
+          );
+        case "channels_offline":
+          return "One or more channels are offline";
+        case "node_not_ready":
+          return "Node is not ready";
+        case "nostr_relay_offline":
+          return "Could not connect to relay";
+      }
+    } catch (error) {
+      console.error("failed to parse alarm details", alarm.kind, error);
     }
+    return alarm.kind || "Unknown";
   }
 
   return (

--- a/frontend/src/components/layouts/AppLayout.tsx
+++ b/frontend/src/components/layouts/AppLayout.tsx
@@ -54,7 +54,6 @@ import { useNotifyReceivedPayments } from "src/hooks/useNotifyReceivedPayments";
 import { useRemoveSuccessfulChannelOrder } from "src/hooks/useRemoveSuccessfulChannelOrder";
 import { deleteAuthToken } from "src/lib/auth";
 import { cn } from "src/lib/utils";
-import { HealthAlarm } from "src/types";
 import { isHttpMode } from "src/utils/isHttpMode";
 import { openLink } from "src/utils/openLink";
 import ExternalLink from "../ExternalLink";
@@ -351,54 +350,15 @@ function HealthIndicator() {
 
   const ok = !health.alarms?.length;
 
-  function getAlarmTitle(alarm: HealthAlarm) {
-    // TODO: could show extra data from alarm.rawDetails
-    // for some alarm types
-    switch (alarm.kind) {
-      case "alby_service":
-        return "One or more Alby Services are offline";
-      case "channels_offline":
-        return "One or more channels are offline";
-      case "node_not_ready":
-        return "Node is not ready";
-      case "nostr_relay_offline":
-        return "Could not connect to relay";
-      default:
-        return "Unknown error";
-    }
-  }
-
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger>
-          <span className="text-xs flex items-center text-muted-foreground">
-            <div
-              className={cn(
-                "w-2 h-2 rounded-full",
-                ok ? "bg-green-300" : "bg-destructive"
-              )}
-            />
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>
-          {ok ? (
-            <p>Alby Hub is running</p>
-          ) : (
-            <div>
-              <p className="font-semibold">
-                {health.alarms.length} issues were found
-              </p>
-              <ul className="mt-2 max-w-xs whitespace-pre-wrap list-disc list-inside">
-                {health.alarms.map((alarm) => (
-                  <li key={alarm.kind}>{getAlarmTitle(alarm)}</li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Link to="/channels?healthcheck=true">
+      <div
+        className={cn(
+          "w-2 h-2 rounded-full",
+          ok ? "bg-green-300" : "bg-destructive"
+        )}
+      />
+    </Link>
   );
 }
 

--- a/frontend/src/hooks/useHealthCheck.ts
+++ b/frontend/src/hooks/useHealthCheck.ts
@@ -4,7 +4,7 @@ import { HealthResponse } from "src/types";
 import { swrFetcher } from "src/utils/swr";
 
 const pollConfiguration: SWRConfiguration = {
-  refreshInterval: 30000,
+  refreshInterval: 5 * 60 * 1000, // 5 minutes
 };
 
 export function useHealthCheck(poll = true) {

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -17,6 +17,7 @@ import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import AppHeader from "src/components/AppHeader.tsx";
 import { ChannelsCards } from "src/components/channels/ChannelsCards.tsx";
 import { ChannelsTable } from "src/components/channels/ChannelsTable.tsx";
+import { HealthCheckAlert } from "src/components/channels/HealthcheckAlert";
 import { SwapDialogs } from "src/components/channels/SwapDialogs";
 import EmptyState from "src/components/EmptyState.tsx";
 import ExternalLink from "src/components/ExternalLink";
@@ -277,6 +278,7 @@ export default function Channels() {
         }
       ></AppHeader>
 
+      <HealthCheckAlert showOk={searchParams.has("healthcheck", "true")} />
       {!!channels?.length && (
         <>
           {/* If all channels have less than 20% incoming capacity, show a warning */}

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -54,6 +54,7 @@ import { useToast } from "src/components/ui/use-toast.ts";
 import { ONCHAIN_DUST_SATS } from "src/constants.ts";
 import { useBalances } from "src/hooks/useBalances.ts";
 import { useChannels } from "src/hooks/useChannels";
+import { useInfo } from "src/hooks/useInfo";
 import { useIsDesktop } from "src/hooks/useMediaQuery.ts";
 import { useNodeConnectionInfo } from "src/hooks/useNodeConnectionInfo.ts";
 import { useSyncWallet } from "src/hooks/useSyncWallet.ts";
@@ -66,6 +67,7 @@ export default function Channels() {
   useSyncWallet();
   const { data: channels } = useChannels();
   const { data: nodeConnectionInfo } = useNodeConnectionInfo();
+  const { hasChannelManagement } = useInfo();
   const { data: balances } = useBalances();
   const navigate = useNavigate();
   const [nodes, setNodes] = React.useState<Node[]>([]);
@@ -126,242 +128,343 @@ export default function Channels() {
     <>
       <AppHeader
         title="Node"
-        description="Manage your lightning node liquidity."
+        description="Manage your lightning node."
         contentRight={
-          <div className="flex gap-3 items-center justify-center">
-            <SwapDialogs
-              setSwapOutDialogOpen={setSwapOutDialogOpen}
-              swapOutDialogOpen={swapOutDialogOpen}
-              setSwapInDialogOpen={setSwapInDialogOpen}
-              swapInDialogOpen={swapInDialogOpen}
-            />
-            <DropdownMenu modal={false}>
-              <DropdownMenuTrigger asChild>
-                {isDesktop ? (
-                  <Button
-                    className="inline-flex"
-                    variant="outline"
-                    size="default"
-                  >
-                    Advanced
-                    <ChevronDown />
-                  </Button>
-                ) : (
-                  <Button variant="outline" size="icon">
-                    <Settings2 className="w-4 h-4" />
-                  </Button>
-                )}
-              </DropdownMenuTrigger>
-              <DropdownMenuContent className="w-56">
-                <DropdownMenuGroup>
-                  <DropdownMenuItem>
-                    <div
-                      className="flex flex-row gap-4 items-center w-full cursor-pointer"
-                      onClick={() => {
-                        if (!nodeConnectionInfo) {
-                          return;
-                        }
-                        copyToClipboard(nodeConnectionInfo.pubkey, toast);
-                      }}
+          hasChannelManagement && (
+            <div className="flex gap-3 items-center justify-center">
+              <SwapDialogs
+                setSwapOutDialogOpen={setSwapOutDialogOpen}
+                swapOutDialogOpen={swapOutDialogOpen}
+                setSwapInDialogOpen={setSwapInDialogOpen}
+                swapInDialogOpen={swapInDialogOpen}
+              />
+              <DropdownMenu modal={false}>
+                <DropdownMenuTrigger asChild>
+                  {isDesktop ? (
+                    <Button
+                      className="inline-flex"
+                      variant="outline"
+                      size="default"
                     >
-                      <div>Node</div>
-                      <div className="overflow-hidden text-ellipsis flex-1">
-                        {nodeConnectionInfo?.pubkey || "Loading..."}
-                      </div>
-                      {nodeConnectionInfo && (
-                        <CopyIcon className="shrink-0 w-4 h-4" />
-                      )}
-                    </div>
-                  </DropdownMenuItem>
-                </DropdownMenuGroup>
-                <DropdownMenuSeparator />
-                <DropdownMenuGroup>
-                  <DropdownMenuLabel>On-Chain</DropdownMenuLabel>
-                  <DropdownMenuItem>
-                    <Link
-                      to="/channels/onchain/deposit-bitcoin"
-                      className="w-full"
-                    >
-                      Deposit Bitcoin
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem>
-                    <Link to="onchain/buy-bitcoin" className="w-full">
-                      Buy Bitcoin
-                    </Link>
-                  </DropdownMenuItem>
-                  {(balances?.onchain.spendable || 0) > ONCHAIN_DUST_SATS && (
-                    <DropdownMenuItem
-                      onClick={() => navigate("/wallet/withdraw")}
-                      className="w-full cursor-pointer"
-                    >
-                      Withdraw On-Chain Balance
-                    </DropdownMenuItem>
+                      Advanced
+                      <ChevronDown />
+                    </Button>
+                  ) : (
+                    <Button variant="outline" size="icon">
+                      <Settings2 className="w-4 h-4" />
+                    </Button>
                   )}
-                </DropdownMenuGroup>
-                <DropdownMenuSeparator />
-                <DropdownMenuGroup>
-                  <DropdownMenuLabel>Swaps</DropdownMenuLabel>
-                  <DropdownMenuItem
-                    onClick={() => setSwapInDialogOpen(true)}
-                    className="cursor-pointer"
-                  >
-                    <div className="mr-2 text-muted-foreground flex flex-row items-center">
-                      <LinkIcon className="w-4 h-4" />
-                      <ArrowRight className="w-4 h-4" />
-                      <ZapIcon className="w-4 h-4" />
-                    </div>
-                    Swap in
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => setSwapOutDialogOpen(true)}
-                    className="cursor-pointer"
-                  >
-                    <div className="mr-2 text-muted-foreground flex flex-row items-center">
-                      <ZapIcon className="w-4 h-4" />
-                      <ArrowRight className="w-4 h-4" />
-                      <LinkIcon className="w-4 h-4" />
-                    </div>
-                    Swap out
-                  </DropdownMenuItem>
-                </DropdownMenuGroup>
-                <DropdownMenuSeparator />
-                <DropdownMenuGroup>
-                  <DropdownMenuLabel>Management</DropdownMenuLabel>
-                  <DropdownMenuItem>
-                    <Link className="w-full" to="/peers">
-                      Connected Peers
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem>
-                    <Link className="w-full" to="/wallet/sign-message">
-                      Sign Message
-                    </Link>
-                  </DropdownMenuItem>
-                </DropdownMenuGroup>
-              </DropdownMenuContent>
-            </DropdownMenu>
-
-            <Link to="/channels/incoming">
-              <Button>Open Channel</Button>
-            </Link>
-            <ExternalLink to="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/liquidity/node-health">
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger>
-                    <CircleProgress
-                      value={nodeHealth}
-                      className="w-9 h-9 relative"
-                    >
-                      {nodeHealth === 100 && (
-                        <div className="absolute w-full h-full opacity-20">
-                          <div className="absolute w-full h-full bg-primary animate-pulse" />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="w-56">
+                  <DropdownMenuGroup>
+                    <DropdownMenuItem>
+                      <div
+                        className="flex flex-row gap-4 items-center w-full cursor-pointer"
+                        onClick={() => {
+                          if (!nodeConnectionInfo) {
+                            return;
+                          }
+                          copyToClipboard(nodeConnectionInfo.pubkey, toast);
+                        }}
+                      >
+                        <div>Node</div>
+                        <div className="overflow-hidden text-ellipsis flex-1">
+                          {nodeConnectionInfo?.pubkey || "Loading..."}
                         </div>
-                      )}
-                      <Heart
-                        className="w-4 h-4"
-                        stroke={"hsl(var(--primary))"}
-                        strokeWidth={3}
-                        fill={
-                          nodeHealth === 100
-                            ? "hsl(var(--primary))"
-                            : "transparent"
-                        }
-                      />
-                    </CircleProgress>
-                  </TooltipTrigger>
-                  <TooltipContent>Node health: {nodeHealth}%</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </ExternalLink>
-          </div>
+                        {nodeConnectionInfo && (
+                          <CopyIcon className="shrink-0 w-4 h-4" />
+                        )}
+                      </div>
+                    </DropdownMenuItem>
+                  </DropdownMenuGroup>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuGroup>
+                    <DropdownMenuLabel>On-Chain</DropdownMenuLabel>
+                    <DropdownMenuItem>
+                      <Link
+                        to="/channels/onchain/deposit-bitcoin"
+                        className="w-full"
+                      >
+                        Deposit Bitcoin
+                      </Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem>
+                      <Link to="onchain/buy-bitcoin" className="w-full">
+                        Buy Bitcoin
+                      </Link>
+                    </DropdownMenuItem>
+                    {(balances?.onchain.spendable || 0) > ONCHAIN_DUST_SATS && (
+                      <DropdownMenuItem
+                        onClick={() => navigate("/wallet/withdraw")}
+                        className="w-full cursor-pointer"
+                      >
+                        Withdraw On-Chain Balance
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuGroup>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuGroup>
+                    <DropdownMenuLabel>Swaps</DropdownMenuLabel>
+                    <DropdownMenuItem
+                      onClick={() => setSwapInDialogOpen(true)}
+                      className="cursor-pointer"
+                    >
+                      <div className="mr-2 text-muted-foreground flex flex-row items-center">
+                        <LinkIcon className="w-4 h-4" />
+                        <ArrowRight className="w-4 h-4" />
+                        <ZapIcon className="w-4 h-4" />
+                      </div>
+                      Swap in
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setSwapOutDialogOpen(true)}
+                      className="cursor-pointer"
+                    >
+                      <div className="mr-2 text-muted-foreground flex flex-row items-center">
+                        <ZapIcon className="w-4 h-4" />
+                        <ArrowRight className="w-4 h-4" />
+                        <LinkIcon className="w-4 h-4" />
+                      </div>
+                      Swap out
+                    </DropdownMenuItem>
+                  </DropdownMenuGroup>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuGroup>
+                    <DropdownMenuLabel>Management</DropdownMenuLabel>
+                    <DropdownMenuItem>
+                      <Link className="w-full" to="/peers">
+                        Connected Peers
+                      </Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem>
+                      <Link className="w-full" to="/wallet/sign-message">
+                        Sign Message
+                      </Link>
+                    </DropdownMenuItem>
+                  </DropdownMenuGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              <Link to="/channels/incoming">
+                <Button>Open Channel</Button>
+              </Link>
+              <ExternalLink to="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/liquidity/node-health">
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <CircleProgress
+                        value={nodeHealth}
+                        className="w-9 h-9 relative"
+                      >
+                        {nodeHealth === 100 && (
+                          <div className="absolute w-full h-full opacity-20">
+                            <div className="absolute w-full h-full bg-primary animate-pulse" />
+                          </div>
+                        )}
+                        <Heart
+                          className="w-4 h-4"
+                          stroke={"hsl(var(--primary))"}
+                          strokeWidth={3}
+                          fill={
+                            nodeHealth === 100
+                              ? "hsl(var(--primary))"
+                              : "transparent"
+                          }
+                        />
+                      </CircleProgress>
+                    </TooltipTrigger>
+                    <TooltipContent>Node health: {nodeHealth}%</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </ExternalLink>
+            </div>
+          )
         }
       ></AppHeader>
 
       <HealthCheckAlert showOk={searchParams.has("healthcheck", "true")} />
-      {!!channels?.length && (
+
+      {hasChannelManagement && (
         <>
-          {/* If all channels have less than 20% incoming capacity, show a warning */}
-          {channels?.every(
-            (channel) =>
-              channel.remoteBalance <
-              (channel.localBalance + channel.remoteBalance) * 0.2
-          ) && (
-            <Alert>
-              <AlertTriangle className="h-4 w-4" />
-              <AlertTitle>Low receiving limit</AlertTitle>
-              <AlertDescription>
-                You likely won't be able to receive payments until you{" "}
-                <Link
-                  className="underline"
-                  to="#"
-                  onClick={() => setSwapOutDialogOpen(true)}
-                >
-                  swap out funds
-                </Link>{" "}
-                or{" "}
-                <Link className="underline" to="/channels/incoming">
-                  increase your receiving limits
-                </Link>
-                .
-              </AlertDescription>
-            </Alert>
+          {!!channels?.length && (
+            <>
+              {/* If all channels have less than 20% incoming capacity, show a warning */}
+              {channels?.every(
+                (channel) =>
+                  channel.remoteBalance <
+                  (channel.localBalance + channel.remoteBalance) * 0.2
+              ) && (
+                <Alert>
+                  <AlertTriangle className="h-4 w-4" />
+                  <AlertTitle>Low receiving limit</AlertTitle>
+                  <AlertDescription>
+                    You likely won't be able to receive payments until you{" "}
+                    <Link
+                      className="underline"
+                      to="#"
+                      onClick={() => setSwapOutDialogOpen(true)}
+                    >
+                      swap out funds
+                    </Link>{" "}
+                    or{" "}
+                    <Link className="underline" to="/channels/incoming">
+                      increase your receiving limits
+                    </Link>
+                    .
+                  </AlertDescription>
+                </Alert>
+              )}
+            </>
           )}
-        </>
-      )}
 
-      <div
-        className={cn("flex flex-col sm:flex-row flex-wrap gap-3 slashed-zero")}
-      >
-        <Card className="flex flex-1 sm:flex-[2] flex-col">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="font-semibold text-2xl">Lightning</CardTitle>
-            <ZapIcon className="h-6 w-6 text-muted-foreground" />
-          </CardHeader>
-
-          <CardContent className="flex flex-col sm:flex-row pl-0 flex-wrap">
-            <div className="flex flex-col flex-1">
-              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-1 pr-0">
-                <CardTitle className="text-sm font-medium">
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <div className="flex flex-row gap-1 items-center justify-start text-sm font-medium">
-                          Spending Balance
-                          <InfoIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
-                        </div>
-                      </TooltipTrigger>
-                      <TooltipContent className="w-[300px]">
-                        Your spending balance is the funds on your side of your
-                        channels, which you can use to make lightning payments.
-                        Your total lightning balance is{" "}
-                        {new Intl.NumberFormat().format(
-                          channels
-                            ?.map((channel) =>
-                              Math.floor(channel.localBalance / 1000)
-                            )
-                            .reduce((a, b) => a + b, 0) || 0
-                        )}{" "}
-                        sats which includes{" "}
-                        {new Intl.NumberFormat().format(
-                          Math.floor(
-                            channels
-                              ?.map((channel) =>
-                                Math.min(
-                                  Math.floor(channel.localBalance / 1000),
-                                  channel.unspendablePunishmentReserve
-                                )
-                              )
-                              .reduce((a, b) => a + b, 0) || 0
-                          )
-                        )}{" "}
-                        sats reserved in your channels which cannot be spent.
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
+          <div
+            className={cn(
+              "flex flex-col sm:flex-row flex-wrap gap-3 slashed-zero"
+            )}
+          >
+            <Card className="flex flex-1 sm:flex-[2] flex-col">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="font-semibold text-2xl">
+                  Lightning
                 </CardTitle>
+                <ZapIcon className="h-6 w-6 text-muted-foreground" />
               </CardHeader>
-              <CardContent className="flex-grow pb-0">
+
+              <CardContent className="flex flex-col sm:flex-row pl-0 flex-wrap">
+                <div className="flex flex-col flex-1">
+                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-1 pr-0">
+                    <CardTitle className="text-sm font-medium">
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <div className="flex flex-row gap-1 items-center justify-start text-sm font-medium">
+                              Spending Balance
+                              <InfoIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent className="w-[300px]">
+                            Your spending balance is the funds on your side of
+                            your channels, which you can use to make lightning
+                            payments. Your total lightning balance is{" "}
+                            {new Intl.NumberFormat().format(
+                              channels
+                                ?.map((channel) =>
+                                  Math.floor(channel.localBalance / 1000)
+                                )
+                                .reduce((a, b) => a + b, 0) || 0
+                            )}{" "}
+                            sats which includes{" "}
+                            {new Intl.NumberFormat().format(
+                              Math.floor(
+                                channels
+                                  ?.map((channel) =>
+                                    Math.min(
+                                      Math.floor(channel.localBalance / 1000),
+                                      channel.unspendablePunishmentReserve
+                                    )
+                                  )
+                                  .reduce((a, b) => a + b, 0) || 0
+                              )
+                            )}{" "}
+                            sats reserved in your channels which cannot be
+                            spent.
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="flex-grow pb-0">
+                    {!balances && (
+                      <div>
+                        <div className="animate-pulse d-inline ">
+                          <div className="h-2.5 bg-primary rounded-full w-12 my-2"></div>
+                        </div>
+                      </div>
+                    )}
+                    {balances && (
+                      <>
+                        <div className="text-xl font-medium balance sensitive mb-1">
+                          {new Intl.NumberFormat().format(
+                            Math.floor(balances.lightning.totalSpendable / 1000)
+                          )}{" "}
+                          sats
+                        </div>
+                        <FormattedFiatAmount
+                          amount={balances.lightning.totalSpendable / 1000}
+                        />
+                      </>
+                    )}
+                  </CardContent>
+                </div>
+                <div className="flex flex-col flex-1">
+                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-1 pr-0">
+                    <CardTitle className="text-sm font-medium">
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <div className="flex flex-row gap-1 items-center justify-start text-sm font-medium">
+                              Receive Limit
+                              <InfoIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent className="w-[300px]">
+                            Your receiving limit is the funds owned by your
+                            channel partner, which will be moved to your side
+                            when you receive lightning payments.
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="flex-grow pb-0">
+                    {balances && (
+                      <>
+                        <div className="text-xl font-medium balance sensitive mb-1">
+                          {new Intl.NumberFormat().format(
+                            Math.floor(
+                              balances.lightning.totalReceivable / 1000
+                            )
+                          )}{" "}
+                          sats
+                        </div>
+                        <FormattedFiatAmount
+                          amount={balances.lightning.totalReceivable / 1000}
+                        />
+                      </>
+                    )}
+                  </CardContent>
+                </div>
+              </CardContent>
+            </Card>
+            <Card className="flex flex-1 flex-col">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-2xl font-semibold">
+                  On-Chain
+                </CardTitle>
+                <LinkIcon className="h-6 w-6 text-muted-foreground" />
+              </CardHeader>
+              <CardContent className="flex-grow">
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-1 pl-0">
+                  <CardTitle className="text-sm font-medium">
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <div className="flex flex-row gap-1 items-center text-sm font-medium">
+                            Balance
+                            <InfoIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent className="w-[300px]">
+                          Your on-chain balance can be used to open new outgoing
+                          lightning channels and to ensure channels can be
+                          closed when required. When channels are closed, funds
+                          on your side of your channel will be returned to your
+                          on-chain balance.
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </CardTitle>
+                </CardHeader>
                 {!balances && (
                   <div>
                     <div className="animate-pulse d-inline ">
@@ -369,206 +472,128 @@ export default function Channels() {
                     </div>
                   </div>
                 )}
-                {balances && (
-                  <>
-                    <div className="text-xl font-medium balance sensitive mb-1">
-                      {new Intl.NumberFormat().format(
-                        Math.floor(balances.lightning.totalSpendable / 1000)
-                      )}{" "}
-                      sats
-                    </div>
-                    <FormattedFiatAmount
-                      amount={balances.lightning.totalSpendable / 1000}
-                    />
-                  </>
-                )}
-              </CardContent>
-            </div>
-            <div className="flex flex-col flex-1">
-              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-1 pr-0">
-                <CardTitle className="text-sm font-medium">
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <div className="flex flex-row gap-1 items-center justify-start text-sm font-medium">
-                          Receive Limit
-                          <InfoIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
-                        </div>
-                      </TooltipTrigger>
-                      <TooltipContent className="w-[300px]">
-                        Your receiving limit is the funds owned by your channel
-                        partner, which will be moved to your side when you
-                        receive lightning payments.
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="flex-grow pb-0">
-                {balances && (
-                  <>
-                    <div className="text-xl font-medium balance sensitive mb-1">
-                      {new Intl.NumberFormat().format(
-                        Math.floor(balances.lightning.totalReceivable / 1000)
-                      )}{" "}
-                      sats
-                    </div>
-                    <FormattedFiatAmount
-                      amount={balances.lightning.totalReceivable / 1000}
-                    />
-                  </>
-                )}
-              </CardContent>
-            </div>
-          </CardContent>
-        </Card>
-        <Card className="flex flex-1 flex-col">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-2xl font-semibold">On-Chain</CardTitle>
-            <LinkIcon className="h-6 w-6 text-muted-foreground" />
-          </CardHeader>
-          <CardContent className="flex-grow">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-1 pl-0">
-              <CardTitle className="text-sm font-medium">
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger>
-                      <div className="flex flex-row gap-1 items-center text-sm font-medium">
-                        Balance
-                        <InfoIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
+                <div>
+                  {balances && (
+                    <>
+                      <div className="mb-1">
+                        <span className="text-xl font-medium balance sensitive mb-1 mr-1">
+                          {new Intl.NumberFormat().format(
+                            Math.floor(balances.onchain.spendable)
+                          )}{" "}
+                          sats
+                        </span>
+                        {!!channels?.length &&
+                          balances.onchain.reserved +
+                            balances.onchain.spendable <
+                            25_000 && (
+                            <TooltipProvider>
+                              <Tooltip>
+                                <TooltipTrigger>
+                                  <AlertTriangle className="w-3 h-3 text-muted-foreground" />
+                                </TooltipTrigger>
+                                <TooltipContent className="w-[300px]">
+                                  You have insufficient funds in reserve to
+                                  close channels or bump on-chain transactions
+                                  and currently rely on the counterparty. It is
+                                  recommended to deposit at least 25,000 sats to
+                                  your on-chain balance.
+                                </TooltipContent>
+                              </Tooltip>
+                            </TooltipProvider>
+                          )}
                       </div>
-                    </TooltipTrigger>
-                    <TooltipContent className="w-[300px]">
-                      Your on-chain balance can be used to open new outgoing
-                      lightning channels and to ensure channels can be closed
-                      when required. When channels are closed, funds on your
-                      side of your channel will be returned to your on-chain
-                      balance.
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              </CardTitle>
-            </CardHeader>
-            {!balances && (
-              <div>
-                <div className="animate-pulse d-inline ">
-                  <div className="h-2.5 bg-primary rounded-full w-12 my-2"></div>
+                      <FormattedFiatAmount
+                        amount={balances.onchain.spendable}
+                        className="mb-1"
+                      />
+                      {balances &&
+                        balances.onchain.spendable !==
+                          balances.onchain.total && (
+                          <p className="text-xs text-muted-foreground animate-pulse">
+                            +
+                            {new Intl.NumberFormat().format(
+                              balances.onchain.total -
+                                balances.onchain.spendable
+                            )}{" "}
+                            sats incoming
+                          </p>
+                        )}
+                    </>
+                  )}
                 </div>
-              </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {balances &&
+            balances.onchain.pendingBalancesFromChannelClosures > 0 && (
+              <Alert>
+                <HourglassIcon className="h-4 w-4" />
+                <AlertTitle>Pending Closed Channels</AlertTitle>
+                <AlertDescription>
+                  You have{" "}
+                  {new Intl.NumberFormat().format(
+                    balances.onchain.pendingBalancesFromChannelClosures
+                  )}{" "}
+                  sats pending from closed channels with
+                  {[
+                    ...balances.onchain.pendingBalancesDetails,
+                    ...balances.onchain.pendingSweepBalancesDetails,
+                  ].map((details, index) => (
+                    <div key={details.channelId} className="inline">
+                      &nbsp;
+                      <ExternalLink
+                        to={`https://amboss.space/node/${details.nodeId}`}
+                        className="underline"
+                      >
+                        {nodes.find(
+                          (node) => node.public_key === details.nodeId
+                        )?.alias || "Unknown"}
+                        <ExternalLinkIcon className="ml-1 w-4 h-4 inline" />
+                      </ExternalLink>{" "}
+                      ({new Intl.NumberFormat().format(details.amount)}{" "}
+                      sats)&nbsp;
+                      <ExternalLink
+                        to={`https://mempool.space/tx/${details.fundingTxId}#flow=&vout=${details.fundingTxVout}`}
+                        className="underline"
+                      >
+                        funding tx
+                        <ExternalLinkIcon className="ml-1 w-4 h-4 inline" />
+                      </ExternalLink>
+                      {index <
+                        balances.onchain.pendingBalancesDetails.length - 1 &&
+                        ","}
+                    </div>
+                  ))}
+                  . Once spendable again these will become available in your
+                  on-chain balance. Funds from channels that were force closed
+                  may take up to 2 weeks to become available.{" "}
+                  <ExternalLink
+                    to="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/faq-alby-hub/why-was-my-lightning-channel-closed-and-what-to-do-next"
+                    className="underline"
+                  >
+                    Learn more
+                  </ExternalLink>
+                </AlertDescription>
+              </Alert>
             )}
-            <div>
-              {balances && (
-                <>
-                  <div className="mb-1">
-                    <span className="text-xl font-medium balance sensitive mb-1 mr-1">
-                      {new Intl.NumberFormat().format(
-                        Math.floor(balances.onchain.spendable)
-                      )}{" "}
-                      sats
-                    </span>
-                    {!!channels?.length &&
-                      balances.onchain.reserved + balances.onchain.spendable <
-                        25_000 && (
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger>
-                              <AlertTriangle className="w-3 h-3 text-muted-foreground" />
-                            </TooltipTrigger>
-                            <TooltipContent className="w-[300px]">
-                              You have insufficient funds in reserve to close
-                              channels or bump on-chain transactions and
-                              currently rely on the counterparty. It is
-                              recommended to deposit at least 25,000 sats to
-                              your on-chain balance.
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                      )}
-                  </div>
-                  <FormattedFiatAmount
-                    amount={balances.onchain.spendable}
-                    className="mb-1"
-                  />
-                  {balances &&
-                    balances.onchain.spendable !== balances.onchain.total && (
-                      <p className="text-xs text-muted-foreground animate-pulse">
-                        +
-                        {new Intl.NumberFormat().format(
-                          balances.onchain.total - balances.onchain.spendable
-                        )}{" "}
-                        sats incoming
-                      </p>
-                    )}
-                </>
-              )}
-            </div>
-          </CardContent>
-        </Card>
-      </div>
 
-      {balances && balances.onchain.pendingBalancesFromChannelClosures > 0 && (
-        <Alert>
-          <HourglassIcon className="h-4 w-4" />
-          <AlertTitle>Pending Closed Channels</AlertTitle>
-          <AlertDescription>
-            You have{" "}
-            {new Intl.NumberFormat().format(
-              balances.onchain.pendingBalancesFromChannelClosures
-            )}{" "}
-            sats pending from closed channels with
-            {[
-              ...balances.onchain.pendingBalancesDetails,
-              ...balances.onchain.pendingSweepBalancesDetails,
-            ].map((details, index) => (
-              <div key={details.channelId} className="inline">
-                &nbsp;
-                <ExternalLink
-                  to={`https://amboss.space/node/${details.nodeId}`}
-                  className="underline"
-                >
-                  {nodes.find((node) => node.public_key === details.nodeId)
-                    ?.alias || "Unknown"}
-                  <ExternalLinkIcon className="ml-1 w-4 h-4 inline" />
-                </ExternalLink>{" "}
-                ({new Intl.NumberFormat().format(details.amount)} sats)&nbsp;
-                <ExternalLink
-                  to={`https://mempool.space/tx/${details.fundingTxId}#flow=&vout=${details.fundingTxVout}`}
-                  className="underline"
-                >
-                  funding tx
-                  <ExternalLinkIcon className="ml-1 w-4 h-4 inline" />
-                </ExternalLink>
-                {index < balances.onchain.pendingBalancesDetails.length - 1 &&
-                  ","}
-              </div>
-            ))}
-            . Once spendable again these will become available in your on-chain
-            balance. Funds from channels that were force closed may take up to 2
-            weeks to become available.{" "}
-            <ExternalLink
-              to="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/faq-alby-hub/why-was-my-lightning-channel-closed-and-what-to-do-next"
-              className="underline"
-            >
-              Learn more
-            </ExternalLink>
-          </AlertDescription>
-        </Alert>
-      )}
+          {channels && channels.length === 0 && (
+            <EmptyState
+              icon={Unplug}
+              title="No Channels Available"
+              description="Connect to the Lightning Network by establishing your first channel and start transacting."
+              buttonText="Open Channel"
+              buttonLink="/channels/incoming"
+            />
+          )}
 
-      {channels && channels.length === 0 && (
-        <EmptyState
-          icon={Unplug}
-          title="No Channels Available"
-          description="Connect to the Lightning Network by establishing your first channel and start transacting."
-          buttonText="Open Channel"
-          buttonLink="/channels/incoming"
-        />
-      )}
-
-      {isDesktop ? (
-        <ChannelsTable channels={channels} nodes={nodes} />
-      ) : (
-        <ChannelsCards channels={channels} nodes={nodes} />
+          {isDesktop ? (
+            <ChannelsTable channels={channels} nodes={nodes} />
+          ) : (
+            <ChannelsCards channels={channels} nodes={nodes} />
+          )}
+        </>
       )}
     </>
   );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -167,7 +167,14 @@ export type HealthAlarmKind =
 
 export type HealthAlarm = {
   kind: HealthAlarmKind;
-  rawDetails: unknown;
+  rawDetails?: unknown;
+};
+export type AlbyInfoIncident = {
+  name: string;
+  started: string;
+  status: string;
+  impact: string;
+  url: string;
 };
 
 export type HealthResponse = {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -86,6 +86,7 @@ module.exports = {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
         "spin-slow": "spin 3s linear infinite",
+        highlight: "pulse 1s 2 cubic-bezier(0.4, 0, 0.6, 1)",
       },
       fontFamily: {
         sans: ["Inter var", ...defaultTheme.fontFamily.sans],

--- a/lnclient/phoenixd/phoenixd.go
+++ b/lnclient/phoenixd/phoenixd.go
@@ -70,6 +70,7 @@ type PhoenixService struct {
 	Address       string
 	Authorization string
 	pubkey        string
+	nodeInfo      *lnclient.NodeInfo
 }
 
 func NewPhoenixService(address string, authorization string) (result lnclient.LNClient, err error) {
@@ -81,10 +82,11 @@ func NewPhoenixService(address string, authorization string) (result lnclient.LN
 	}
 	phoenixService := &PhoenixService{Address: address, Authorization: authorizationBase64}
 
-	info, err := phoenixService.GetInfo(context.Background())
+	info, err := fetchNodeInfo(phoenixService)
 	if err != nil {
 		return nil, err
 	}
+	phoenixService.nodeInfo = info
 	phoenixService.pubkey = info.Pubkey
 
 	return phoenixService, nil
@@ -238,6 +240,10 @@ func (svc *PhoenixService) ListTransactions(ctx context.Context, from, until, li
 }
 
 func (svc *PhoenixService) GetInfo(ctx context.Context) (info *lnclient.NodeInfo, err error) {
+	return svc.nodeInfo, nil
+}
+
+func fetchNodeInfo(svc *PhoenixService) (info *lnclient.NodeInfo, err error) {
 	req, err := http.NewRequest(http.MethodGet, svc.Address+"/getinfo", nil)
 	if err != nil {
 		return nil, err
@@ -453,6 +459,11 @@ func (svc *PhoenixService) GetLogOutput(ctx context.Context, maxLen int) ([]byte
 }
 
 func (svc *PhoenixService) GetNodeStatus(ctx context.Context) (nodeStatus *lnclient.NodeStatus, err error) {
+	_, err = fetchNodeInfo(svc)
+	if err != nil {
+		return nil, err
+	}
+
 	return &lnclient.NodeStatus{
 		IsReady: true,
 	}, nil


### PR DESCRIPTION
Closes https://github.com/getAlby/hub/issues/1178

Rather than showing a toast when hovering over the healthcheck, it links to the node page. By default the node page will only show an alert if the healthcheck is failing, however if they click on the green healthcheck indicator, it'll show a success alert.

Now the alby services with incidents will show along with their status, and we link directly to the alby status page and a guide where the user can learn more.

![image](https://github.com/user-attachments/assets/277faf3a-74c3-475d-8920-2771004edf47)

![image](https://github.com/user-attachments/assets/ccafa93a-07bd-4dd3-a25b-17cf6cfcb037)

