### PR TITLE
fix: success screen crashes instead of redirecting

### DIFF
--- a/frontend/src/screens/wallet/send/PaymentSuccess.tsx
+++ b/frontend/src/screens/wallet/send/PaymentSuccess.tsx
@@ -1,4 +1,5 @@
 import { CircleCheck, CopyIcon } from "lucide-react";
+import { useEffect } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
 import { Button } from "src/components/ui/button";
@@ -16,8 +17,13 @@ export default function PaymentSuccess() {
   const navigate = useNavigate();
   const { toast } = useToast();
 
-  if (!state.preimage) {
-    navigate("/wallet/send");
+  useEffect(() => {
+    if (!state?.preimage) {
+      navigate("/wallet/send");
+    }
+  }, [state, navigate]);
+
+  if (!state?.preimage) {
     return null;
   }
 


### PR DESCRIPTION
## Description

Visiting `/wallet/send/success` page crashes instead of taking to `/wallet/send`. I ran into this on mobile, as often in mobile browsers, the tab refreshes on opening (and it is possible that the tab has last been in success screen)

