### PR TITLE
fix: wrong alby go link used in home screen

### DIFF
--- a/frontend/src/screens/Home.tsx
+++ b/frontend/src/screens/Home.tsx
@@ -133,7 +133,7 @@ function Home() {
             </Card>
           </Link>
 
-          <Link to="/appstore/alby-go">
+          <Link to="/internal-apps/alby-go">
             <Card>
               <CardHeader>
                 <div className="flex flex-row items-center">


### PR DESCRIPTION
Fixes #1208

Just had to change link