### PR TITLE
fix: retry start app after failure to avoid downtime in self-hosted LND environments

### DIFF
--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -53,9 +53,27 @@ func NewLNDService(ctx context.Context, eventPublisher events.EventPublisher, ln
 		logger.Logger.WithError(err).Error("Failed to create new LND client")
 		return nil, err
 	}
-	nodeInfo, err := fetchNodeInfo(ctx, lndClient)
+
+	var nodeInfo *lnclient.NodeInfo
+	maxRetries := 5
+	for i := range maxRetries {
+		nodeInfo, err = fetchNodeInfo(ctx, lndClient)
+		if err == nil {
+			break
+		}
+		if i < maxRetries-1 {
+			logger.Logger.WithFields(logrus.Fields{
+				"iteration": i,
+			}).WithError(err).Error("Failed to connect to LND, retrying in 10s")
+			time.Sleep(10 * time.Second)
+		} else {
+			logger.Logger.WithFields(logrus.Fields{
+				"iteration": i,
+			}).WithError(err).Error("Failed to connect to LND")
+		}
+	}
 	if err != nil {
-		logger.Logger.WithError(err).Error("Failed to fetch node info")
+		logger.Logger.WithError(err).Error("Failed to fetch node info after 5 attempts")
 		return nil, err
 	}
 
@@ -1197,7 +1215,6 @@ func (svc *LNDService) GetPubkey() string {
 func fetchNodeInfo(ctx context.Context, client *wrapper.LNDWrapper) (*lnclient.NodeInfo, error) {
 	resp, err := client.GetInfo(ctx, &lnrpc.GetInfoRequest{})
 	if err != nil {
-		logger.Logger.WithError(err).Error("Failed to fetch node info")
 		return nil, err
 	}
 	network := resp.Chains[0].Network

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -1211,6 +1211,7 @@ func (svc *LNDService) GetPubkey() string {
 func fetchNodeInfo(ctx context.Context, client *wrapper.LNDWrapper) (*lnclient.NodeInfo, error) {
 	resp, err := client.GetInfo(ctx, &lnrpc.GetInfoRequest{})
 	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to fetch node info")
 		return nil, err
 	}
 	network := resp.Chains[0].Network

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -56,24 +56,20 @@ func NewLNDService(ctx context.Context, eventPublisher events.EventPublisher, ln
 
 	var nodeInfo *lnclient.NodeInfo
 	maxRetries := 5
-	for i := range maxRetries {
+	for i := range maxRetries - 1 {
 		nodeInfo, err = fetchNodeInfo(ctx, lndClient)
 		if err == nil {
 			break
 		}
-		if i < maxRetries-1 {
-			logger.Logger.WithFields(logrus.Fields{
-				"iteration": i,
-			}).WithError(err).Error("Failed to connect to LND, retrying in 10s")
-			time.Sleep(10 * time.Second)
-		} else {
-			logger.Logger.WithFields(logrus.Fields{
-				"iteration": i,
-			}).WithError(err).Error("Failed to connect to LND")
-		}
+		logger.Logger.WithFields(logrus.Fields{
+			"iteration": i,
+		}).WithError(err).Error("Failed to connect to LND, retrying in 10s")
+		time.Sleep(10 * time.Second)
 	}
+
+	nodeInfo, err = fetchNodeInfo(ctx, lndClient)
 	if err != nil {
-		logger.Logger.WithError(err).Error("Failed to fetch node info after 5 attempts")
+		logger.Logger.WithError(err).Error("Failed to connect to LND on final attempt, not attempting further retries")
 		return nil, err
 	}
 

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -56,7 +56,7 @@ func NewLNDService(ctx context.Context, eventPublisher events.EventPublisher, ln
 
 	var nodeInfo *lnclient.NodeInfo
 	maxRetries := 5
-	for i := range maxRetries - 1 {
+	for i := range maxRetries {
 		nodeInfo, err = fetchNodeInfo(ctx, lndClient)
 		if err == nil {
 			break
@@ -67,7 +67,6 @@ func NewLNDService(ctx context.Context, eventPublisher events.EventPublisher, ln
 		time.Sleep(10 * time.Second)
 	}
 
-	nodeInfo, err = fetchNodeInfo(ctx, lndClient)
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to connect to LND on final attempt, not attempting further retries")
 		return nil, err


### PR DESCRIPTION
Fixes the issue which causes auto unlock to fail in Umbrel/Start 9 on reboot since the `StartApp` call is done while LND is initializing