### PR TITLE
feat: add funding txid and amount to LDK channel closed event

### DIFF
--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -266,9 +266,10 @@ func (svc *LNDService) subscribeChannelEvents(ctx context.Context) {
 					svc.eventPublisher.Publish(&events.Event{
 						Event: "nwc_channel_closed",
 						Properties: map[string]interface{}{
-							"counterparty_node_id": counterpartyNodeId,
-							"reason":               closureReason,
-							"node_type":            config.LNDBackendType,
+							"counterparty_node_id":  counterpartyNodeId,
+							"counterparty_node_url": "https://amboss.space/node/" + counterpartyNodeId,
+							"reason":                closureReason,
+							"node_type":             config.LNDBackendType,
 						},
 					})
 				}


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/1197 (LDK only)

Adds new properties to the `nwc_channel_closed` event for both LDK and LND:
```
counterparty_node_url
```

Adds new properties to the `nwc_channel_closed` event to LDK only:
```
pending_balance
funding_tx_id
funding_tx_vout
funding_tx_url
```

CC @MoritzKa (to review the new event properties which we could show in the email)