### PR TITLE
fix: always show swap alert on close channel dialog

### DIFF
--- a/frontend/src/components/CloseChannelDialogContent.tsx
+++ b/frontend/src/components/CloseChannelDialogContent.tsx
@@ -114,7 +114,7 @@ export function CloseChannelDialogContent({ alias, channel }: Props) {
               Are you sure you want to close the channel with {alias}?
             </AlertDialogTitle>
             <AlertDialogDescription className="text-left">
-              <SwapAlert className="mb-4" />
+              <SwapAlert minChannels={0} className="mb-4" />
               <Alert className="mb-4">
                 <AlertCircleIcon className="h-4 w-4" />
                 <AlertDescription>

--- a/frontend/src/components/channels/ChannelDropdownMenu.tsx
+++ b/frontend/src/components/channels/ChannelDropdownMenu.tsx
@@ -5,6 +5,7 @@ import {
   Trash2,
 } from "lucide-react";
 import React from "react";
+import { useSearchParams } from "react-router-dom";
 import { CloseChannelDialogContent } from "src/components/CloseChannelDialogContent";
 import ExternalLink from "src/components/ExternalLink";
 import { RoutingFeeDialogContent } from "src/components/RoutingFeeDialogContent";
@@ -30,11 +31,19 @@ export function ChannelDropdownMenu({
   alias,
   channel,
 }: ChannelDropdownMenuProps) {
+  const [searchParams] = useSearchParams();
   const [dialog, setDialog] = React.useState<"closeChannel" | "routingFee">();
+
+  React.useEffect(() => {
+    // when opening the swap dialog, close existing dialog
+    if (searchParams.has("swap", "true")) {
+      setDialog(undefined);
+    }
+  }, [searchParams]);
 
   return (
     <AlertDialog
-      onOpenChange={() => {
+      onOpenChange={(open) => {
         if (!open) {
           setDialog(undefined);
         }

--- a/frontend/src/components/channels/SwapAlert.tsx
+++ b/frontend/src/components/channels/SwapAlert.tsx
@@ -6,15 +6,16 @@ import { useChannels } from "src/hooks/useChannels";
 
 type SwapAlertProps = {
   className?: string;
+  minChannels?: number;
 };
-export function SwapAlert({ className }: SwapAlertProps) {
+export function SwapAlert({ className, minChannels = 2 }: SwapAlertProps) {
   const { data: channels } = useChannels();
   const { data: balances } = useBalances();
 
   if (!channels || !balances) {
     return null;
   }
-  if (channels.length < 2) {
+  if (minChannels && channels.length < minChannels) {
     return null;
   }
 

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -73,17 +73,11 @@ export default function Channels() {
   const [nodes, setNodes] = React.useState<Node[]>([]);
   const [swapOutDialogOpen, setSwapOutDialogOpen] = React.useState(false);
   const [swapInDialogOpen, setSwapInDialogOpen] = React.useState(false);
-  const [hasOpenedSwapDialog, setOpenedSwapDialog] = React.useState(false);
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   React.useEffect(() => {
-    if (
-      !hasOpenedSwapDialog &&
-      balances &&
-      channels &&
-      searchParams.has("swap", "true")
-    ) {
-      setOpenedSwapDialog(true);
+    if (balances && channels && searchParams.has("swap", "true")) {
+      setSearchParams({});
       if (
         balances.lightning.totalSpendable > balances.lightning.totalReceivable
       ) {
@@ -92,7 +86,7 @@ export default function Channels() {
         setSwapInDialogOpen(true);
       }
     }
-  }, [balances, channels, hasOpenedSwapDialog, searchParams]);
+  }, [balances, channels, searchParams, setSearchParams]);
 
   const { toast } = useToast();
   const isDesktop = useIsDesktop();


### PR DESCRIPTION
Even if the user has 1 channel there's no need to close it when they could swap instead