### PR TITLE
fix: show health alert if vss is enabled but subscription was cancelled

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1082,6 +1082,17 @@ func (api *api) Health(ctx context.Context) (*HealthResponse, error) {
 		alarms = append(alarms, NewHealthAlarm(HealthAlarmKindNostrRelayOffline, nil))
 	}
 
+	ldkVssEnabled, _ := api.cfg.Get("LdkVssEnabled", "")
+	if ldkVssEnabled == "true" {
+		albyMe, err := api.albyOAuthSvc.GetMe(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if albyMe.Subscription.PlanCode == "" {
+			alarms = append(alarms, NewHealthAlarm(HealthAlarmKindVssNoSubscription, nil))
+		}
+	}
+
 	lnClient := api.svc.GetLNClient()
 
 	if lnClient != nil {

--- a/api/models.go
+++ b/api/models.go
@@ -387,9 +387,10 @@ type HealthAlarmKind string
 
 const (
 	HealthAlarmKindAlbyService       HealthAlarmKind = "alby_service"
-	HealthAlarmKindNodeNotReady                      = "node_not_ready"
-	HealthAlarmKindChannelsOffline                   = "channels_offline"
-	HealthAlarmKindNostrRelayOffline                 = "nostr_relay_offline"
+	HealthAlarmKindNodeNotReady      HealthAlarmKind = "node_not_ready"
+	HealthAlarmKindChannelsOffline   HealthAlarmKind = "channels_offline"
+	HealthAlarmKindNostrRelayOffline HealthAlarmKind = "nostr_relay_offline"
+	HealthAlarmKindVssNoSubscription HealthAlarmKind = "vss_no_subscription"
 )
 
 type HealthAlarm struct {

--- a/frontend/src/components/channels/HealthcheckAlert.tsx
+++ b/frontend/src/components/channels/HealthcheckAlert.tsx
@@ -39,6 +39,8 @@ export function HealthCheckAlert({ showOk }: HealthCheckAlertProps) {
           return "Node is not ready";
         case "nostr_relay_offline":
           return "Could not connect to relay";
+        case "vss_no_subscription":
+          return "Your lightning channel data is stored encrypted by Alby's Versioned Storage Service which is a paid feature. Restart your subscription or send your funds to another wallet as soon as possible.";
       }
     } catch (error) {
       console.error("failed to parse alarm details", alarm.kind, error);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -163,7 +163,8 @@ export type HealthAlarmKind =
   | "alby_service"
   | "node_not_ready"
   | "channels_offline"
-  | "nostr_relay_offline";
+  | "nostr_relay_offline"
+  | "vss_no_subscription";
 
 export type HealthAlarm = {
   kind: HealthAlarmKind;

--- a/service/start.go
+++ b/service/start.go
@@ -449,7 +449,18 @@ func (svc *service) requestVssToken(ctx context.Context) (string, error) {
 		vssToken, err = svc.albyOAuthSvc.GetVssAuthToken(ctx, vssNodeIdentifier)
 		if err != nil {
 			logger.Logger.WithError(err).Error("Failed to fetch VSS JWT token")
+
+			existingVssToken, _ := svc.cfg.Get("VssToken", "")
+			if existingVssToken != "" {
+				logger.Logger.Warn("Using stored VSS JWT token")
+				return existingVssToken, nil
+			}
+
 			return "", err
+		}
+		err = svc.cfg.SetUpdate("VssToken", vssToken, "")
+		if err != nil {
+			logger.Logger.WithError(err).Error("Failed to save VSS JWT token to user config")
 		}
 	}
 	return vssToken, nil


### PR DESCRIPTION
VSS is a paid feature but Alby Hub does not handle if this endpoint is only accessible by subscribers.

![image](https://github.com/user-attachments/assets/edec8e09-b1a9-435c-9ee5-f619d36d4fed)
