### PR TITLE
fix: better handling if alby api is inaccessible to allow basic functionality

### DIFF
--- a/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
@@ -66,7 +66,8 @@ function NewChannelInternal({
   network: Network;
   channels: Channel[];
 }) {
-  const { data: _channelPeerSuggestions } = useChannelPeerSuggestions();
+  const { data: _channelPeerSuggestions, error: channelPeerSuggestionsError } =
+    useChannelPeerSuggestions();
   const navigate = useNavigate();
 
   const { toast } = useToast();
@@ -85,6 +86,16 @@ function NewChannelInternal({
   const [selectedPeer, setSelectedPeer] = React.useState<
     RecommendedChannelPeer | undefined
   >();
+
+  React.useEffect(() => {
+    if (channelPeerSuggestionsError) {
+      toast({
+        variant: "destructive",
+        title: "Failed to load channel suggestions",
+      });
+      navigate("/channels/outgoing");
+    }
+  }, [channelPeerSuggestionsError, navigate, toast]);
 
   const channelPeerSuggestions = React.useMemo(() => {
     return _channelPeerSuggestions

--- a/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
@@ -100,7 +100,7 @@ function NewChannelInternal({ network }: { network: Network }) {
           ),
           customOption,
         ]
-      : undefined;
+      : [customOption];
   }, [_channelPeerSuggestions, network]);
 
   function setPublic(isPublic: boolean) {

--- a/frontend/src/screens/internal-apps/UncleJim.tsx
+++ b/frontend/src/screens/internal-apps/UncleJim.tsx
@@ -42,7 +42,7 @@ export function UncleJim() {
   const { toast } = useToast();
   const [isLoading, setLoading] = React.useState(false);
   const { data: info } = useInfo();
-  const { data: albyMe } = useAlbyMe();
+  const { data: albyMe, error: albyMeError } = useAlbyMe();
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -91,7 +91,7 @@ export function UncleJim() {
     albyMe?.subscription.plan_code ||
     (onboardedApps && onboardedApps?.length < 3);
 
-  if (!info || (info.albyAccountConnected && !albyMe)) {
+  if (!info || (info.albyAccountConnected && !albyMe && !albyMeError)) {
     // make sure to not render the incorrect component
     return <Loading />;
   }

--- a/frontend/src/screens/wallet/Receive.tsx
+++ b/frontend/src/screens/wallet/Receive.tsx
@@ -12,16 +12,23 @@ import { copyToClipboard } from "src/lib/clipboard";
 
 export default function Receive() {
   const { data: info } = useInfo();
-  const { data: me } = useAlbyMe();
+  const { data: me, error: meError } = useAlbyMe();
   const { toast } = useToast();
   const navigate = useNavigate();
 
   // TODO: remove this once we have a CTA to connect an Alby Account to use a lightning address
   React.useEffect(() => {
-    if (info && !info.albyAccountConnected) {
+    if (info && (!info.albyAccountConnected || meError)) {
+      if (meError) {
+        toast({
+          variant: "destructive",
+          title: "Failed to load lightning address",
+        });
+      }
+
       navigate("/wallet/receive/invoice");
     }
-  }, [info, navigate]);
+  }, [info, meError, navigate, toast]);
 
   if (!info || (info.albyAccountConnected && !me)) {
     return <Loading />;


### PR DESCRIPTION
This PR improves handling if the Alby API is currently not accessible, by:
- redirecting to the receive invoice page from the receive page (rather than waiting forever to display the user's lightning address)
- when clicking "open new channel" if we cannot load suggestions, redirect to create an outbound channel, and always allow using the custom option while outgoing suggestions are being loaded
- allow basic access to friends and family app (however only non-pro access - user will still have issue if they have > 3 apps)

To test, add the following lines to `/etc/hosts` which will disable access to Alby APIs:

```
127.0.0.1 getalby.com
127.0.0.1 api.getalby.com
```