### PR TITLE
fix: anchor reserve warning not displaying on withdraw on-chain funds page

### DIFF
--- a/frontend/src/components/MempoolAlert.tsx
+++ b/frontend/src/components/MempoolAlert.tsx
@@ -3,7 +3,7 @@ import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
 import { ExternalLinkButton } from "src/components/ui/button";
 import { useMempoolApi } from "src/hooks/useMempoolApi";
 
-export function MempoolAlert() {
+export function MempoolAlert({ className }: { className?: string }) {
   const { data: recommendedFees } = useMempoolApi<{ fastestFee: number }>(
     "/v1/fees/recommended",
     true
@@ -26,7 +26,7 @@ export function MempoolAlert() {
     return null;
   }
   return (
-    <Alert>
+    <Alert className={className}>
       <TriangleAlertIcon className="h-4 w-4" />
       <AlertTitle>
         Mempool Fees are currently{" "}


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/1235

also adds a mempool alert shown if the fees are currently high

![image](https://github.com/user-attachments/assets/e252a465-c393-4c2e-8113-7b12997f739b)

![image](https://github.com/user-attachments/assets/71a7ef88-9af3-40c7-9413-0541b021cf65)

![image](https://github.com/user-attachments/assets/fe382bb3-edb6-4b71-b9e1-60ad74eec048)

![image](https://github.com/user-attachments/assets/c64b56a7-38a5-4cab-8b32-9df3cec703be)
