### PR TITLE
chore: use debian:12-slim base image for smaller final container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN chmod +x copy_dylibs.sh
 RUN ./copy_dylibs.sh $(echo "$TARGETPLATFORM" | cut -d'/' -f2)
 
 # Start a new, final image to reduce size.
-FROM debian as final
+FROM debian:12-slim as final
 
 ENV LD_LIBRARY_PATH=/usr/lib/nwc
 #


### PR DESCRIPTION
Using `debian:12-slim` instead of `debian` reduces the final container image size while maintaining all required functionality. This helps optimize resource usage and improves pull/push times.