### PR TITLE
fix: sync passwordinput with external value change

### DIFF
--- a/frontend/src/components/password/PasswordInput.tsx
+++ b/frontend/src/components/password/PasswordInput.tsx
@@ -16,21 +16,14 @@ export default function PasswordInput({
   value,
   ...restProps
 }: PasswordInputProps) {
-  const [password, setPassword] = React.useState(value);
   const [passwordVisible, setPasswordVisible] = React.useState(false);
-
-  React.useEffect(() => {
-    if (onChange) {
-      onChange(password);
-    }
-  }, [password, onChange]);
 
   return (
     <Input
       type={passwordVisible ? "text" : "password"}
-      value={password}
+      value={value}
       required
-      onChange={(e) => setPassword(e.target.value)}
+      onChange={(e) => onChange && onChange(e.target.value)}
       placeholder={placeholder}
       {...restProps}
       endAdornment={

--- a/frontend/src/screens/Start.tsx
+++ b/frontend/src/screens/Start.tsx
@@ -89,7 +89,11 @@ export default function Start() {
                   value={unlockPassword}
                 />
               </div>
-              <LoadingButton type="submit" loading={loading}>
+              <LoadingButton
+                type="submit"
+                loading={loading}
+                disabled={!unlockPassword}
+              >
                 {buttonText}
               </LoadingButton>
               {loading && (


### PR DESCRIPTION
## Description

When a Start attempt fails (for some node reason let's say) and you try again, you get this weird "invalid password" error even though you haven't changed anything.

It was happening because on receiving an error, the unlockPassword is set to `""` but it is not reflected in the internal state of `PasswordInput` component which makes it render the password without clearing it. This PR syncs it so the component state is updated when value changes externally.