### PR TITLE
chore: bump Go version to 1.24

### DIFF
--- a/.github/workflows/wails.yml
+++ b/.github/workflows/wails.yml
@@ -76,7 +76,7 @@ jobs:
           node-version: "20.x"
 
       - name: Install Wails
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.9.2
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.10.1
         shell: bash
 
       - name: Install Linux Wails deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /build
 COPY frontend ./frontend
 RUN cd frontend && yarn install --network-timeout 3000000 && yarn build:http
 
-FROM golang:1.23.6 as builder
+FROM golang:1.24 as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getAlby/hub
 
-go 1.23.6
+go 1.24
 
 require (
 	github.com/adrg/xdg v0.5.3

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,6 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
-github.com/getAlby/ldk-node-go v0.0.0-20250317054222-37346892e729 h1:mfRbKeU2PhlunwiwOBTCPOh4h6ZxOfpIZD1/0DlFjaI=
-github.com/getAlby/ldk-node-go v0.0.0-20250317054222-37346892e729/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getAlby/ldk-node-go v0.0.0-20250409032721-a0b2d497fc2c h1:16rFwWZ9W3Ru0nUUgcZoyRxkykJjZx0okhTXscLhRRk=
 github.com/getAlby/ldk-node-go v0.0.0-20250409032721-a0b2d497fc2c/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
Closes https://github.com/getAlby/hub/issues/1256