### PR TITLE
fix: update workflows to use ubuntu 24.04

### DIFF
--- a/.github/workflows/http.yml
+++ b/.github/workflows/http.yml
@@ -31,17 +31,17 @@ jobs:
             {
               arch: x86_64,
               alby_arch: x86_64-unknown-linux-gnu,
-              os: ubuntu-20.04,
+              os: ubuntu-24.04,
             },
             {
               arch: armv6,
               alby_arch: arm-unknown-linux-gnueabihf,
-              os: ubuntu-20.04,
+              os: ubuntu-24.04,
             },
             {
               arch: aarch64,
               alby_arch: aarch64-unknown-linux-gnu,
-              os: ubuntu-20.04,
+              os: ubuntu-24.04,
             },
             { arch: darwin/universal, os: macos-13 },
           ]

--- a/.github/workflows/http.yml
+++ b/.github/workflows/http.yml
@@ -31,17 +31,17 @@ jobs:
             {
               arch: x86_64,
               alby_arch: x86_64-unknown-linux-gnu,
-              os: ubuntu-24.04,
+              os: ubuntu-22.04,
             },
             {
               arch: armv6,
               alby_arch: arm-unknown-linux-gnueabihf,
-              os: ubuntu-24.04,
+              os: ubuntu-22.04,
             },
             {
               arch: aarch64,
               alby_arch: aarch64-unknown-linux-gnu,
-              os: ubuntu-24.04,
+              os: ubuntu-22.04,
             },
             { arch: darwin/universal, os: macos-13 },
           ]

--- a/.github/workflows/wails.yml
+++ b/.github/workflows/wails.yml
@@ -31,6 +31,7 @@ jobs:
       matrix:
         build:
           [
+            { platform: linux/amd64, os: ubuntu-22.04 },
             { platform: linux/amd64, os: ubuntu-24.04 },
             { platform: windows/amd64, os: windows-2019 },
             { platform: darwin/universal, os: macos-13 },

--- a/.github/workflows/wails.yml
+++ b/.github/workflows/wails.yml
@@ -31,7 +31,6 @@ jobs:
       matrix:
         build:
           [
-            { platform: linux/amd64, os: ubuntu-20.04 },
             { platform: linux/amd64, os: ubuntu-24.04 },
             { platform: windows/amd64, os: windows-2019 },
             { platform: darwin/universal, os: macos-13 },


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/11101