### PR TITLE
feat: improve querying performance

### DIFF
--- a/api/transactions.go
+++ b/api/transactions.go
@@ -39,7 +39,13 @@ func (api *api) ListTransactions(ctx context.Context, appId *uint, limit uint64,
 	if api.svc.GetLNClient() == nil {
 		return nil, errors.New("LNClient not started")
 	}
-	transactions, totalCount, err := api.svc.GetTransactionsService().ListTransactions(ctx, 0, 0, limit, offset, true, false, nil, api.svc.GetLNClient(), appId, true)
+
+	forceFilterByAppId := false
+	if appId != nil {
+		forceFilterByAppId = true
+	}
+
+	transactions, totalCount, err := api.svc.GetTransactionsService().ListTransactions(ctx, 0, 0, limit, offset, true, false, nil, api.svc.GetLNClient(), appId, forceFilterByAppId)
 	if err != nil {
 		return nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -152,7 +152,7 @@ func (cfg *config) Get(key string, encryptionKey string) (string, error) {
 
 func (cfg *config) get(key string, encryptionKey string, gormDB *gorm.DB) (string, error) {
 	var userConfig db.UserConfig
-	err := gormDB.Where(&db.UserConfig{Key: key}).Limit(1).Find(&userConfig).Error
+	err := gormDB.Where("key = ?", key).First(&userConfig).Error
 	if err != nil {
 		return "", fmt.Errorf("failed to get configuration value: %w", gormDB.Error)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -152,7 +152,7 @@ func (cfg *config) Get(key string, encryptionKey string) (string, error) {
 
 func (cfg *config) get(key string, encryptionKey string, gormDB *gorm.DB) (string, error) {
 	var userConfig db.UserConfig
-	err := gormDB.Where("key = ?", key).First(&userConfig).Error
+	err := gormDB.Where(&db.UserConfig{Key: key}).Limit(1).Find(&userConfig).Error
 	if err != nil {
 		return "", fmt.Errorf("failed to get configuration value: %w", gormDB.Error)
 	}

--- a/db/migrations/202504231037_add_indexes.go
+++ b/db/migrations/202504231037_add_indexes.go
@@ -14,7 +14,6 @@ var _202504231037_add_indexes = &gormigrate.Migration{
 		if err := db.Transaction(func(tx *gorm.DB) error {
 
 			if err := tx.Exec(`
-DROP INDEX IF EXISTS idx_transactions_app_id;
 DROP INDEX IF EXISTS idx_transactions_request_event_id;
 DROP INDEX IF EXISTS idx_transactions_created_at;
 DROP INDEX IF EXISTS idx_transactions_settled_at;

--- a/db/migrations/202504231037_add_indexes.go
+++ b/db/migrations/202504231037_add_indexes.go
@@ -1,0 +1,45 @@
+package migrations
+
+import (
+	_ "embed"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+var _202504231037_add_indexes = &gormigrate.Migration{
+	ID: "202504231037_add_indexes",
+	Migrate: func(db *gorm.DB) error {
+
+		if err := db.Transaction(func(tx *gorm.DB) error {
+
+			if err := tx.Exec(`
+DROP INDEX IF EXISTS idx_transactions_app_id;
+DROP INDEX IF EXISTS idx_transactions_request_event_id;
+DROP INDEX IF EXISTS idx_transactions_created_at;
+DROP INDEX IF EXISTS idx_transactions_settled_at;
+DROP INDEX IF EXISTS idx_transactions_app_id_type_state_created_at_settled_at_payment_hash;
+		`).Error; err != nil {
+				return err
+			}
+
+			if err := tx.Exec(`
+CREATE INDEX idx_transactions_updated_at ON transactions(updated_at);
+CREATE INDEX idx_transactions_app_id_updated_at ON transactions(app_id, updated_at);
+CREATE INDEX idx_transactions_state_type_updated_at ON transactions(state, type, updated_at);
+CREATE INDEX idx_transactions_payment_hash_settled_at_created_at ON transactions(payment_hash, settled_at, created_at);
+			`).Error; err != nil {
+				return err
+			}
+
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		return nil
+	},
+	Rollback: func(tx *gorm.DB) error {
+		return nil
+	},
+}

--- a/db/migrations/202504231037_add_indexes.go
+++ b/db/migrations/202504231037_add_indexes.go
@@ -24,9 +24,9 @@ DROP INDEX IF EXISTS idx_transactions_app_id_type_state_created_at_settled_at_pa
 			}
 
 			if err := tx.Exec(`
-CREATE INDEX idx_transactions_updated_at ON transactions(updated_at);
-CREATE INDEX idx_transactions_app_id_updated_at ON transactions(app_id, updated_at);
+CREATE INDEX idx_transactions_state_type ON transactions(state, type);
 CREATE INDEX idx_transactions_state_type_updated_at ON transactions(state, type, updated_at);
+CREATE INDEX idx_transactions_app_id_state_type_updated_at ON transactions(app_id, state, type, updated_at);
 CREATE INDEX idx_transactions_payment_hash_settled_at_created_at ON transactions(payment_hash, settled_at, created_at);
 			`).Error; err != nil {
 				return err

--- a/db/migrations/migrate.go
+++ b/db/migrations/migrate.go
@@ -28,6 +28,7 @@ func Migrate(gormDB *gorm.DB) error {
 		_202408291715_app_metadata,
 		_202410141503_add_wallet_pubkey,
 		_202412212345_fix_types,
+		_202504231037_add_indexes,
 	})
 
 	return m.Migrate()

--- a/nip47/event_handler.go
+++ b/nip47/event_handler.go
@@ -120,8 +120,10 @@ func (svc *nip47Service) HandleEvent(ctx context.Context, relay nostrmodels.Rela
 			"encryption":          encryption,
 		}).WithError(err).Error("Failed to initialize cipher")
 
-		requestEvent.State = db.REQUEST_EVENT_STATE_HANDLER_ERROR
-		err = svc.db.Save(&requestEvent).Error
+		err = svc.db.
+			Model(&requestEvent).
+			Update("state", db.REQUEST_EVENT_STATE_HANDLER_ERROR).
+			Error
 		if err != nil {
 			logger.Logger.WithFields(logrus.Fields{
 				"appPubkey": event.PubKey,
@@ -161,8 +163,10 @@ func (svc *nip47Service) HandleEvent(ctx context.Context, relay nostrmodels.Rela
 		return
 	}
 
-	requestEvent.AppId = &app.ID
-	err = svc.db.Save(&requestEvent).Error
+	err = svc.db.
+		Model(&requestEvent).
+		Update("app_id", app.ID).
+		Error
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
 			"appPubkey": event.PubKey,
@@ -183,8 +187,10 @@ func (svc *nip47Service) HandleEvent(ctx context.Context, relay nostrmodels.Rela
 		}
 		svc.publishResponseEvent(ctx, relay, &requestEvent, resp, &app)
 
-		requestEvent.State = db.REQUEST_EVENT_STATE_HANDLER_ERROR
-		err = svc.db.Save(&requestEvent).Error
+		err = svc.db.
+			Model(&requestEvent).
+			Update("state", db.REQUEST_EVENT_STATE_HANDLER_ERROR).
+			Error
 		if err != nil {
 			logger.Logger.WithFields(logrus.Fields{
 				"appPubkey": event.PubKey,
@@ -203,8 +209,10 @@ func (svc *nip47Service) HandleEvent(ctx context.Context, relay nostrmodels.Rela
 			"appId":               app.ID,
 		}).WithError(err).Error("Failed to decrypt content")
 
-		requestEvent.State = db.REQUEST_EVENT_STATE_HANDLER_ERROR
-		err = svc.db.Save(&requestEvent).Error
+		err = svc.db.
+			Model(&requestEvent).
+			Update("state", db.REQUEST_EVENT_STATE_HANDLER_ERROR).
+			Error
 		if err != nil {
 			logger.Logger.WithFields(logrus.Fields{
 				"appPubkey": event.PubKey,
@@ -251,8 +259,10 @@ func (svc *nip47Service) HandleEvent(ctx context.Context, relay nostrmodels.Rela
 			"eventKind":           event.Kind,
 		}).WithError(err).Error("Failed to process event")
 
-		requestEvent.State = db.REQUEST_EVENT_STATE_HANDLER_ERROR
-		err = svc.db.Save(&requestEvent).Error
+		err = svc.db.
+			Model(&requestEvent).
+			Update("state", db.REQUEST_EVENT_STATE_HANDLER_ERROR).
+			Error
 		if err != nil {
 			logger.Logger.WithFields(logrus.Fields{
 				"appPubkey": event.PubKey,
@@ -262,13 +272,15 @@ func (svc *nip47Service) HandleEvent(ctx context.Context, relay nostrmodels.Rela
 		return
 	}
 
-	requestEvent.Method = nip47Request.Method
-	requestEvent.ContentData = payload
-	svc.db.Save(&requestEvent) // we ignore potential DB errors here as this only saves the method and content data
-
+	// we ignore potential DB errors here as this only saves the method and content data
+	svc.db.Model(&requestEvent).Updates(map[string]interface{}{
+		"method":       nip47Request.Method,
+		"content_data": payload,
+	})
 	// TODO: replace with a channel
 	// TODO: update all previous occurrences of svc.publishResponseEvent to also use the channel
 	publishResponse := func(nip47Response *models.Response, tags nostr.Tags) {
+		var state string
 		resp, err := svc.CreateResponse(event, nip47Response, tags, nip47Cipher, appWalletPrivKey)
 		if err != nil {
 			logger.Logger.WithFields(logrus.Fields{
@@ -276,7 +288,7 @@ func (svc *nip47Service) HandleEvent(ctx context.Context, relay nostrmodels.Rela
 				"eventKind":           event.Kind,
 				"appId":               app.ID,
 			}).WithError(err).Error("Failed to create response")
-			requestEvent.State = db.REQUEST_EVENT_STATE_HANDLER_ERROR
+			state = db.REQUEST_EVENT_STATE_HANDLER_ERROR
 		} else {
 			err = svc.publishResponseEvent(ctx, relay, &requestEvent, resp, &app)
 			if err != nil {
@@ -286,18 +298,21 @@ func (svc *nip47Service) HandleEvent(ctx context.Context, relay nostrmodels.Rela
 					"eventKind":            event.Kind,
 					"appId":                app.ID,
 				}).WithError(err).Error("Failed to publish event")
-				requestEvent.State = db.REQUEST_EVENT_STATE_HANDLER_ERROR
+				state = db.REQUEST_EVENT_STATE_HANDLER_ERROR
 			} else {
-				requestEvent.State = db.REQUEST_EVENT_STATE_HANDLER_EXECUTED
 				logger.Logger.WithFields(logrus.Fields{
 					"requestEventNostrId":  event.ID,
 					"responseEventNostrId": resp.ID,
 					"eventKind":            event.Kind,
 					"appId":                app.ID,
 				}).Debug("Published response")
+				state = db.REQUEST_EVENT_STATE_HANDLER_EXECUTED
 			}
 		}
-		err = svc.db.Save(&requestEvent).Error
+		err = svc.db.
+			Model(&requestEvent).
+			Update("state", state).
+			Error
 		if err != nil {
 			logger.Logger.WithFields(logrus.Fields{
 				"appPubkey": event.PubKey,
@@ -471,9 +486,10 @@ func (svc *nip47Service) publishResponseEvent(ctx context.Context, relay nostrmo
 		return err
 	}
 
+	updateColumns := make(map[string]interface{})
 	err = relay.Publish(ctx, *resp)
 	if err != nil {
-		responseEvent.State = db.RESPONSE_EVENT_STATE_PUBLISH_FAILED
+		updateColumns["state"] = db.RESPONSE_EVENT_STATE_PUBLISH_FAILED
 		logger.Logger.WithFields(logrus.Fields{
 			"requestEventId":       requestEvent.ID,
 			"requestNostrEventId":  requestEvent.NostrId,
@@ -482,8 +498,8 @@ func (svc *nip47Service) publishResponseEvent(ctx context.Context, relay nostrmo
 			"responseNostrEventId": resp.ID,
 		}).WithError(err).Error("Failed to publish reply")
 	} else {
-		responseEvent.State = db.RESPONSE_EVENT_STATE_PUBLISH_CONFIRMED
-		responseEvent.RepliedAt = time.Now()
+		updateColumns["state"] = db.RESPONSE_EVENT_STATE_PUBLISH_CONFIRMED
+		updateColumns["replied_at"] = time.Now()
 		logger.Logger.WithFields(logrus.Fields{
 			"requestEventId":       requestEvent.ID,
 			"requestNostrEventId":  requestEvent.NostrId,
@@ -493,7 +509,10 @@ func (svc *nip47Service) publishResponseEvent(ctx context.Context, relay nostrmo
 		}).Info("Published reply")
 	}
 
-	err = svc.db.Save(&responseEvent).Error
+	err = svc.db.
+		Model(&responseEvent).
+		Updates(updateColumns).
+		Error
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
 			"requestEventId":       requestEvent.ID,

--- a/transactions/transactions_service.go
+++ b/transactions/transactions_service.go
@@ -579,11 +579,9 @@ func (svc *transactionsService) ListTransactions(ctx context.Context, from, unti
 	if !unpaidOutgoing && !unpaidIncoming {
 		tx = tx.Where("state = ?", constants.TRANSACTION_STATE_SETTLED)
 	} else if unpaidOutgoing && !unpaidIncoming {
-		tx = tx.Where(tx.Where("state = ?", constants.TRANSACTION_STATE_SETTLED).
-			Or("type = ?", constants.TRANSACTION_TYPE_OUTGOING))
+		tx = tx.Where("state = ? OR type = ?", constants.TRANSACTION_STATE_SETTLED, constants.TRANSACTION_TYPE_OUTGOING)
 	} else if unpaidIncoming && !unpaidOutgoing {
-		tx = tx.Where(tx.Where("state = ?", constants.TRANSACTION_STATE_SETTLED).
-			Or("type = ?", constants.TRANSACTION_TYPE_INCOMING))
+		tx = tx.Where("state = ? OR type = ?", constants.TRANSACTION_STATE_SETTLED, constants.TRANSACTION_TYPE_INCOMING)
 	}
 
 	if transactionType != nil {

--- a/transactions/transactions_service.go
+++ b/transactions/transactions_service.go
@@ -597,8 +597,6 @@ func (svc *transactionsService) ListTransactions(ctx context.Context, from, unti
 		tx = tx.Where("updated_at <= ?", time.Unix(int64(until), 0))
 	}
 
-	tx = tx.Order("updated_at desc")
-
 	var totalCount64 int64
 	result := tx.Model(&db.Transaction{}).Count(&totalCount64)
 	if result.Error != nil {
@@ -606,6 +604,8 @@ func (svc *transactionsService) ListTransactions(ctx context.Context, from, unti
 		return nil, 0, result.Error
 	}
 	totalCount = uint64(totalCount64)
+
+	tx = tx.Order("updated_at desc")
 
 	if limit > 0 {
 		tx = tx.Limit(int(limit))


### PR DESCRIPTION
Fixes #1263

Leaves out a few things mentioned in the issue:
- Persisting a request event and response event (updates are covered though)
- Fetching user config by a particular key (key is already indexed and are very less, not sure why this is happening)
- Listing apps from the http API, the ideal solution is to have the permissions within the apps table, we should do a migration for that)

## Indexes removed

- `idx_transactions_app_id` (we never filter only on app_id, added composite indexes to cover all cases)
- `idx_transactions_request_event_id` (same as above)
- `idx_transactions_created_at` (same as above)
- `idx_transactions_settled_at` (same as above)
- `idx_transactions_app_id_type_state_created_at_settled_at_payment_hash` (we should always use most differing column first, so it can use the index when required, and payment_hash is at the end, also we never filter based on created and settled at dates, so we can remove it)

## Indexes added

- `idx_transactions_state_type` (used while listing txs)
- `idx_transactions_state_type_updated_at` (used while listing txs)
- `idx_transactions_app_id_state_type_updated_at` (used while listing txs)
- `idx_transactions_payment_hash_settled_at_created_at` (for lookup transaction)

### List Transactions - Possible queries

- We always chain on `state` and `type`
- `updated_at` is not used much, unless it's via NWC controller
- Also pushed `updated_at desc` ordering to do it after counting to save some time
- Conditionally `app_id` (I took out code to find `isIsolated` outside to reduce multiple requests to db at once)

So for all these possibilities, I added `idx_transactions_state_type`, `idx_transactions_state_type_updated_at` and `idx_transactions_app_id_state_type_updated_at` (`idx_transactions_app_id_type_state` already exists)

### Lookup Transactions - Possible queries

- We don't use `type` at all - both internally and via NWC, we should remove the param itself in a separate issue
- We do a find query on `payment_hash` by ordering by `settled_at` and `created_at`
- Conditionally `app_id` (I took out code to find `isIsolated` outside to reduce multiple requests to db at once)

And this time app_id doesn't make much difference so I only added `idx_transactions_payment_hash_settled_at_created_at`