### PR TITLE
fix: use md breakpoint for sidebar trigger

### DIFF
--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -13,8 +13,8 @@ function AppHeader({ title, description = "", contentRight }: Props) {
   return (
     <>
       <header className="flex flex-row items-center border-b border-border pb-4 gap-2">
-        <SidebarTrigger className="-ml-1 sm:hidden" />
-        <Separator orientation="vertical" className="mr-2 h-4 sm:hidden" />
+        <SidebarTrigger className="-ml-1 md:hidden" />
+        <Separator orientation="vertical" className="mr-2 h-4 md:hidden" />
         <div className="flex flex-col flex-1">
           <div className="flex justify-between items-center">
             <div className="flex-1">


### PR DESCRIPTION
Because mobile breakpoint is `768px`

https://github.com/getAlby/hub/blob/3ccdb1e16196bd62ba8463ba400fc0338fce3b6a/frontend/src/hooks/use-mobile.tsx#L3