### PR TITLE
fix: filter transactions by state when processing the payment_sent event in the transactions service

### DIFF
--- a/transactions/transactions_service.go
+++ b/transactions/transactions_service.go
@@ -741,6 +741,7 @@ func (svc *transactionsService) ConsumeEvent(ctx context.Context, event *events.
 		err := svc.db.Transaction(func(tx *gorm.DB) error {
 			result := tx.Limit(1).Find(&dbTransaction, &db.Transaction{
 				Type:        constants.TRANSACTION_TYPE_OUTGOING,
+				State:       constants.TRANSACTION_STATE_PENDING,
 				PaymentHash: lnClientTransaction.PaymentHash,
 			})
 


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/1272