### PR TITLE
fix: overflow due to long descriptions

### DIFF
--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -144,7 +144,7 @@ function TransactionItem({ tx }: Props) {
                 </span>
               </p>
             </div>
-            <p className="text-sm md:text-base text-muted-foreground break-all w-full truncate">
+            <p className="text-sm md:text-base text-muted-foreground break-all line-clamp-1">
               {tx.description}
             </p>
           </div>

--- a/frontend/src/screens/wallet/send/ConfirmPayment.tsx
+++ b/frontend/src/screens/wallet/send/ConfirmPayment.tsx
@@ -83,7 +83,7 @@ export default function ConfirmPayment() {
           <FormattedFiatAmount amount={amount || invoice.satoshi} />
         </div>
         {invoice.description && (
-          <div className="mt-2 max-w-lg break-words">
+          <div className="mt-2 break-all">
             <Label>Description</Label>
             <p className="text-muted-foreground">{invoice.description}</p>
           </div>

--- a/frontend/src/screens/wallet/send/ConfirmPayment.tsx
+++ b/frontend/src/screens/wallet/send/ConfirmPayment.tsx
@@ -83,7 +83,7 @@ export default function ConfirmPayment() {
           <FormattedFiatAmount amount={amount || invoice.satoshi} />
         </div>
         {invoice.description && (
-          <div className="mt-2">
+          <div className="mt-2 max-w-lg break-words">
             <Label>Description</Label>
             <p className="text-muted-foreground">{invoice.description}</p>
           </div>


### PR DESCRIPTION
before: 
![image](https://github.com/user-attachments/assets/4034016c-6c65-442a-8d39-c4d7ca2e9566)
![image](https://github.com/user-attachments/assets/c94bed00-d8de-4603-ae00-da2e2ecbb6a0)

after: 

![image](https://github.com/user-attachments/assets/19f90c7f-7320-4fd6-88ca-ec4f1c283861)
![image](https://github.com/user-attachments/assets/a2204361-8d88-42ad-ac75-1a438ce679bf)
