### PR TITLE
fix: use full version of go library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getAlby/hub
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/adrg/xdg v0.5.3


### PR DESCRIPTION
Fixes https://stackoverflow.com/questions/78519711/toolchain-not-available-error-prevents-me-from-using-any-go-commands