### PR TITLE
feat: add update banner

### DIFF
--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -1,4 +1,3 @@
-import { compare } from "compare-versions";
 import {
   BoxIcon,
   ChevronsUpDown,
@@ -11,8 +10,6 @@ import {
   Plug2Icon,
   PlugZapIcon,
   Settings,
-  ShieldAlertIcon,
-  ShieldCheckIcon,
   Sparkles,
   SquareStack,
   WalletIcon,
@@ -44,15 +41,8 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "src/components/ui/sidebar";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "src/components/ui/tooltip";
 import { UpgradeDialog } from "src/components/UpgradeDialog";
 import UserAvatar from "src/components/UserAvatar";
-import { useAlbyInfo } from "src/hooks/useAlbyInfo";
 import { useAlbyMe } from "src/hooks/useAlbyMe";
 import { useHealthCheck } from "src/hooks/useHealthCheck";
 import { useInfo } from "src/hooks/useInfo";
@@ -135,7 +125,6 @@ export function AppSidebar() {
             <AlbyHubLogo className="text-sidebar-foreground h-12" />
           </Link>
           <div className="flex gap-3 items-center">
-            <AppVersion />
             <HealthIndicator />
           </div>
         </div>
@@ -325,67 +314,6 @@ export function NavSecondary({
         </SidebarMenu>
       </SidebarGroupContent>
     </SidebarGroup>
-  );
-}
-
-function AppVersion() {
-  const { data: albyInfo } = useAlbyInfo();
-  const { data: info } = useInfo();
-  // briefly delay display of version to fix bug on mobile
-  // where update tooltip is always shown when sidebar is expanded
-  const [isVisible, setVisible] = React.useState(false);
-
-  React.useEffect(() => {
-    const timeout = setTimeout(() => setVisible(true), 1000);
-    return () => {
-      clearTimeout(timeout);
-      setVisible(false);
-    };
-  }, []);
-
-  if (!info || !albyInfo || !isVisible) {
-    return null;
-  }
-
-  const upToDate =
-    info.version &&
-    info.version.startsWith("v") &&
-    compare(info.version.substring(1), albyInfo.hub.latestVersion, ">=");
-
-  return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger>
-          <ExternalLink
-            to={`https://getalby.com/update/hub?version=${info.version}`}
-            className="font-semibold text-xl"
-          >
-            <span className="text-xs flex items-center text-muted-foreground">
-              {info.version && <>{info.version}&nbsp;</>}
-              {upToDate ? (
-                <ShieldCheckIcon className="w-4 h-4" />
-              ) : (
-                <ShieldAlertIcon className="w-4 h-4" />
-              )}
-            </span>
-          </ExternalLink>
-        </TooltipTrigger>
-        <TooltipContent>
-          {upToDate ? (
-            <p>Alby Hub is up to date!</p>
-          ) : (
-            <div>
-              <p className="font-semibold">
-                Alby Hub {albyInfo.hub.latestVersion} available!
-              </p>
-              <p className="mt-2 max-w-xs whitespace-pre-wrap">
-                {albyInfo.hub.latestReleaseNotes}
-              </p>
-            </div>
-          )}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
   );
 }
 

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -118,7 +118,10 @@ export function AppSidebar() {
   };
 
   return (
-    <Sidebar collapsible="offcanvas">
+    <Sidebar
+      className="top-[--header-height] !h-[calc(100svh-var(--header-height))]"
+      collapsible="offcanvas"
+    >
       <SidebarHeader>
         <div className="p-2 flex flex-row items-center justify-between">
           <Link to="/home" onClick={() => setOpenMobile(false)}>

--- a/frontend/src/components/UpdateBanner.tsx
+++ b/frontend/src/components/UpdateBanner.tsx
@@ -1,50 +1,32 @@
-import { compare } from "compare-versions";
 import { XIcon } from "lucide-react";
-import React from "react";
-
 import ExternalLink from "src/components/ExternalLink";
+
 import { useAlbyInfo } from "src/hooks/useAlbyInfo";
 import { useInfo } from "src/hooks/useInfo";
 
-export function UpdateBanner() {
+export function UpdateBanner({ onDismiss }: { onDismiss: () => void }) {
   const { data: info } = useInfo();
   const { data: albyInfo } = useAlbyInfo();
-  const [isVisible, setIsVisible] = React.useState(false);
 
-  React.useEffect(() => {
-    if (!info || !albyInfo) {
-      setIsVisible(false);
-      return;
-    }
-
-    const upToDate =
-      Boolean(info.version) &&
-      info.version.startsWith("v") &&
-      compare(info.version.substring(1), albyInfo.hub.latestVersion, ">=");
-
-    setIsVisible(!upToDate);
-  }, [info, albyInfo]);
-
-  const dismissBanner = () => {
-    setIsVisible(false);
-  };
-
-  if (!info || !albyInfo || !isVisible) {
+  if (!info || !albyInfo) {
     return null;
   }
 
   return (
-    <div className="fixed w-full bg-foreground text-background z-20 px-8 md:px-12 py-2 text-sm md:text-center flex items-center justify-center">
+    <div className="fixed w-full bg-foreground text-background z-20 py-2 text-sm flex items-center justify-center">
       <ExternalLink
         to={`https://getalby.com/update/hub?version=${info?.version}`}
+        className="flex items-center max-w-[80%]"
       >
-        <span className="font-semibold">Update Available</span>
-        {" • "}
-        <span>{albyInfo.hub.latestReleaseNotes.substring(0, 120) + "..."}</span>
+        <p className="line-clamp-2 md:block whitespace-normal md:whitespace-nowrap overflow-hidden text-ellipsis">
+          <span className="font-semibold mr-2">Update Available</span>
+          <span>•</span>
+          <span className="ml-2">{albyInfo.hub.latestReleaseNotes}</span>
+        </p>
       </ExternalLink>
       <XIcon
         className="absolute right-4 cursor-pointer w-4 text-background"
-        onClick={dismissBanner}
+        onClick={onDismiss}
       />
     </div>
   );

--- a/frontend/src/components/UpdateBanner.tsx
+++ b/frontend/src/components/UpdateBanner.tsx
@@ -16,9 +16,9 @@ export function UpdateBanner({ onDismiss }: { onDismiss: () => void }) {
     <div className="fixed w-full bg-foreground text-background z-20 py-2 text-sm flex items-center justify-center">
       <ExternalLink
         to={`https://getalby.com/update/hub?version=${info?.version}`}
-        className="flex items-center max-w-[80%]"
+        className="w-full px-12 md:px-24"
       >
-        <p className="line-clamp-2 md:block whitespace-normal md:whitespace-nowrap overflow-hidden text-ellipsis">
+        <p className="line-clamp-2 md:block whitespace-normal md:whitespace-nowrap overflow-hidden text-ellipsis text-center">
           <span className="font-semibold mr-2">Update Available</span>
           <span>•</span>
           <span className="ml-2">{albyInfo.hub.latestReleaseNotes}</span>

--- a/frontend/src/components/UpdateBanner.tsx
+++ b/frontend/src/components/UpdateBanner.tsx
@@ -1,0 +1,51 @@
+import { compare } from "compare-versions";
+import { XIcon } from "lucide-react";
+import React from "react";
+
+import ExternalLink from "src/components/ExternalLink";
+import { useAlbyInfo } from "src/hooks/useAlbyInfo";
+import { useInfo } from "src/hooks/useInfo";
+
+export function UpdateBanner() {
+  const { data: info } = useInfo();
+  const { data: albyInfo } = useAlbyInfo();
+  const [isVisible, setIsVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!info || !albyInfo) {
+      setIsVisible(false);
+      return;
+    }
+
+    const upToDate =
+      Boolean(info.version) &&
+      info.version.startsWith("v") &&
+      compare(info.version.substring(1), albyInfo.hub.latestVersion, ">=");
+
+    setIsVisible(!upToDate);
+  }, [info, albyInfo]);
+
+  const dismissBanner = () => {
+    setIsVisible(false);
+  };
+
+  if (!info || !albyInfo || !isVisible) {
+    return null;
+  }
+
+  return (
+    <div className="fixed w-full bg-foreground text-background z-20 px-8 md:px-12 py-2 text-sm md:text-center flex items-center justify-center">
+      <ExternalLink
+        to={`https://getalby.com/update/hub?version=${info?.version}`}
+      >
+        <span className="font-semibold">Update Available</span>
+        {" • "}
+        <span>{albyInfo.hub.latestReleaseNotes.substring(0, 120) + "..."}</span>
+      </ExternalLink>
+      <XIcon
+        className="absolute right-4 cursor-pointer w-4 text-background"
+        onClick={dismissBanner}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/layouts/AppLayout.tsx
+++ b/frontend/src/components/layouts/AppLayout.tsx
@@ -2,6 +2,7 @@ import { Outlet } from "react-router-dom";
 
 import { AppSidebar } from "src/components/AppSidebar";
 import { SidebarInset, SidebarProvider } from "src/components/ui/sidebar";
+import { UpdateBanner } from "src/components/UpdateBanner";
 import { useInfo } from "src/hooks/useInfo";
 import { useNotifyReceivedPayments } from "src/hooks/useNotifyReceivedPayments";
 import { useRemoveSuccessfulChannelOrder } from "src/hooks/useRemoveSuccessfulChannelOrder";
@@ -19,6 +20,7 @@ export default function AppLayout() {
   return (
     <>
       <div className="font-sans min-h-screen w-full flex flex-col">
+        <UpdateBanner />
         <SidebarProvider>
           <AppSidebar />
           <SidebarInset>

--- a/frontend/src/components/layouts/AppLayout.tsx
+++ b/frontend/src/components/layouts/AppLayout.tsx
@@ -3,12 +3,15 @@ import { Outlet } from "react-router-dom";
 import { AppSidebar } from "src/components/AppSidebar";
 import { SidebarInset, SidebarProvider } from "src/components/ui/sidebar";
 import { UpdateBanner } from "src/components/UpdateBanner";
+import { useBanner } from "src/hooks/useBanner";
 import { useInfo } from "src/hooks/useInfo";
 import { useNotifyReceivedPayments } from "src/hooks/useNotifyReceivedPayments";
 import { useRemoveSuccessfulChannelOrder } from "src/hooks/useRemoveSuccessfulChannelOrder";
+import { cn } from "src/lib/utils";
 
 export default function AppLayout() {
   const { data: info } = useInfo();
+  const { showBanner, dismissBanner } = useBanner();
 
   useRemoveSuccessfulChannelOrder();
   useNotifyReceivedPayments();
@@ -19,15 +22,29 @@ export default function AppLayout() {
 
   return (
     <>
-      <div className="font-sans min-h-screen w-full flex flex-col">
-        <UpdateBanner />
-        <SidebarProvider>
-          <AppSidebar />
-          <SidebarInset>
-            <div className="flex flex-1 flex-col gap-4 p-4">
-              <Outlet />
-            </div>
-          </SidebarInset>
+      <div
+        className={cn(
+          "font-sans min-h-screen w-full flex flex-col",
+          showBanner
+            ? "[--header-height:calc(theme(spacing.9))]"
+            : "[--header-height:0]"
+        )}
+      >
+        <SidebarProvider className="flex flex-col">
+          {showBanner && <UpdateBanner onDismiss={dismissBanner} />}
+          <div className="flex flex-1">
+            <AppSidebar />
+            <SidebarInset>
+              <div
+                className={cn(
+                  "flex flex-1 flex-col gap-4 p-4",
+                  showBanner && "mt-14 md:mt-9"
+                )}
+              >
+                <Outlet />
+              </div>
+            </SidebarInset>
+          </div>
         </SidebarProvider>
       </div>
     </>

--- a/frontend/src/components/layouts/AppLayout.tsx
+++ b/frontend/src/components/layouts/AppLayout.tsx
@@ -26,7 +26,7 @@ export default function AppLayout() {
         className={cn(
           "font-sans min-h-screen w-full flex flex-col",
           showBanner
-            ? "[--header-height:calc(theme(spacing.9))]"
+            ? "[--header-height:calc(theme(spacing.9))]" // Banner height is 36px when visible (sidebar hidden on <md width)
             : "[--header-height:0]"
         )}
       >
@@ -38,7 +38,7 @@ export default function AppLayout() {
               <div
                 className={cn(
                   "flex flex-1 flex-col gap-4 p-4",
-                  showBanner && "mt-14 md:mt-9"
+                  showBanner && "mt-14 md:mt-9" // Banner height is 36px with 1 line (>=md width) and 56px with 2 lines (<md width)
                 )}
               >
                 <Outlet />

--- a/frontend/src/components/layouts/SettingsLayout.tsx
+++ b/frontend/src/components/layouts/SettingsLayout.tsx
@@ -95,8 +95,8 @@ export default function SettingsLayout() {
         }
       />
 
-      <div className="flex flex-col space-y-8 lg:flex-row lg:space-x-4 lg:space-y-0">
-        <aside className="flex flex-col justify-between lg:w-1/5 max-h-screen">
+      <div className="flex flex-col space-y-8 lg:flex-row lg:space-x-4 lg:space-y-0 h-full">
+        <aside className="flex flex-col justify-between lg:w-1/5">
           <nav className="flex flex-wrap lg:flex-col lg:space-y-1">
             <MenuItem to="/settings">General</MenuItem>
             {info?.autoUnlockPasswordSupported && (
@@ -118,6 +118,9 @@ export default function SettingsLayout() {
             <MenuItem to="/settings/developer">Developer</MenuItem>
             <MenuItem to="/settings/debug-tools">Debug Tools</MenuItem>
           </nav>
+          <span className="font-medium slashed-zero text-muted-foreground text-sm">
+            {info?.version}
+          </span>
         </aside>
         <Separator orientation="vertical" className="hidden lg:block" />
         <div className="flex-1 lg:max-w-2xl">

--- a/frontend/src/components/layouts/SettingsLayout.tsx
+++ b/frontend/src/components/layouts/SettingsLayout.tsx
@@ -63,35 +63,40 @@ export default function SettingsLayout() {
         title="Settings"
         breadcrumb={false}
         contentRight={
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <LoadingButton
-                variant="destructive"
-                size="icon"
-                loading={shuttingDown}
-              >
-                {!shuttingDown && <PowerIcon className="w-4 h-4" />}
-              </LoadingButton>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>
-                  Do you want to turn off your Alby Hub?
-                </AlertDialogTitle>
-                <AlertDialogDescription>
-                  This will turn off your Alby Hub and make your node offline.
-                  You won't be able to send or receive bitcoin until you unlock
-                  it.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction onClick={shutdown}>
-                  Continue
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+          <div className="flex items-center gap-4">
+            <div className="font-medium slashed-zero text-muted-foreground text-sm">
+              {info?.version}
+            </div>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <LoadingButton
+                  variant="destructive"
+                  size="icon"
+                  loading={shuttingDown}
+                >
+                  {!shuttingDown && <PowerIcon className="w-4 h-4" />}
+                </LoadingButton>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    Do you want to turn off your Alby Hub?
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will turn off your Alby Hub and make your node offline.
+                    You won't be able to send or receive bitcoin until you
+                    unlock it.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={shutdown}>
+                    Continue
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
         }
       />
 
@@ -118,9 +123,6 @@ export default function SettingsLayout() {
             <MenuItem to="/settings/developer">Developer</MenuItem>
             <MenuItem to="/settings/debug-tools">Debug Tools</MenuItem>
           </nav>
-          <span className="font-medium slashed-zero text-muted-foreground text-sm">
-            {info?.version}
-          </span>
         </aside>
         <Separator orientation="vertical" className="hidden lg:block" />
         <div className="flex-1 lg:max-w-2xl">

--- a/frontend/src/hooks/useBanner.tsx
+++ b/frontend/src/hooks/useBanner.tsx
@@ -1,0 +1,30 @@
+import { compare } from "compare-versions";
+import React from "react";
+import { useAlbyInfo } from "src/hooks/useAlbyInfo";
+import { useInfo } from "src/hooks/useInfo";
+
+export function useBanner() {
+  const { data: info } = useInfo();
+  const { data: albyInfo } = useAlbyInfo();
+  const [showBanner, setShowBanner] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!info || !albyInfo) {
+      setShowBanner(false);
+      return;
+    }
+
+    const upToDate =
+      Boolean(info.version) &&
+      info.version.startsWith("v") &&
+      compare(info.version.substring(1), albyInfo.hub.latestVersion, ">=");
+
+    setShowBanner(!upToDate);
+  }, [info, albyInfo]);
+
+  const dismissBanner = () => {
+    setShowBanner(false);
+  };
+
+  return { showBanner, dismissBanner };
+}


### PR DESCRIPTION
Fixes #1250 

## Description

- Took [this official example](https://ui.shadcn.com/view/styles/new-york/sidebar-16) as inspo for shifting the sidebar
- Added a `useBanner` hook in which we can change logic if we would like to display other banners (with some conditional logic in `UpdateBanner.tsx`
- Version Shield Icon is removed
- Version will now be displayed in settings

## Screenshots
<table>
<tr>
<td><img src="https://github.com/user-attachments/assets/b2709f0a-9e50-4627-895e-79927674ce4a"/></td>
<td><img src="https://github.com/user-attachments/assets/7bed363d-7598-40b8-96e6-20a6ddc7556b"/></td>
</tr>
</table>
