### PR TITLE
chore: do not expose swaps ui for backends other than ldk, lnd

### DIFF
--- a/frontend/src/components/layouts/SettingsLayout.tsx
+++ b/frontend/src/components/layouts/SettingsLayout.tsx
@@ -104,7 +104,9 @@ export default function SettingsLayout() {
         <aside className="flex flex-col justify-between lg:w-1/5">
           <nav className="flex flex-wrap lg:flex-col lg:space-y-1">
             <MenuItem to="/settings">General</MenuItem>
-            <MenuItem to="/settings/swaps">Swaps</MenuItem>
+            {(info?.backendType === "LDK" || info?.backendType === "LND") && (
+              <MenuItem to="/settings/swaps">Swaps</MenuItem>
+            )}
             {info?.autoUnlockPasswordSupported && (
               <MenuItem to="/settings/auto-unlock">Auto Unlock</MenuItem>
             )}


### PR DESCRIPTION
Because we are not sure how other backends (Phoenix and Cashu) handle hold invoices, better to not risk their funds.