### PR TITLE
chore: filter apps from aotd widget

### DIFF
--- a/frontend/src/components/home/widgets/AppOfTheDayWidget.tsx
+++ b/frontend/src/components/home/widgets/AppOfTheDayWidget.tsx
@@ -17,11 +17,13 @@ export function AppOfTheDayWidget() {
     return x - Math.floor(x);
   }
 
+  // filter out apps which already have a widget
+  const excludedAppIds = ["alby-go", "zapplanner"];
+  const apps = suggestedApps.filter((a) => !excludedAppIds.includes(a.id));
+
   const daysSinceEpoch = Math.floor(Date.now() / (1000 * 60 * 60 * 24));
-  const todayIndex = Math.floor(
-    seededRandom(daysSinceEpoch) * suggestedApps.length
-  );
-  const app = suggestedApps[todayIndex];
+  const todayIndex = Math.floor(seededRandom(daysSinceEpoch) * apps.length);
+  const app = apps[todayIndex];
 
   return (
     <Card>


### PR DESCRIPTION
It is possible that sometimes apps which already have a standalone widget are featured again in App Of The Day widget, doesn't look that good.

<img width="100%" alt="Screenshot 2025-05-16 at 1 42 59 PM" src="https://github.com/user-attachments/assets/28755cbd-77ac-4029-8d51-649495e906e7" />
