### PR TITLE
fix: make input full width for zaplanner and messageboard dialogs

### DIFF
--- a/frontend/src/components/home/widgets/LightningMessageboardWidget.tsx
+++ b/frontend/src/components/home/widgets/LightningMessageboardWidget.tsx
@@ -246,27 +246,29 @@ export function LightningMessageboardWidget() {
                 <Label htmlFor="comment" className="text-right">
                   Your Name
                 </Label>
-                <Input
-                  id="sender-name"
-                  value={senderName}
-                  onChange={(e) => setSenderName(e.target.value)}
-                  maxLength={20}
-                  className="col-span-3"
-                  autoFocus
-                />
+                <div className="col-span-3">
+                  <Input
+                    id="sender-name"
+                    value={senderName}
+                    onChange={(e) => setSenderName(e.target.value)}
+                    maxLength={20}
+                    autoFocus
+                  />
+                </div>
               </div>
 
               <div className="grid grid-cols-4 items-center gap-4">
                 <Label htmlFor="amount" className="text-right">
                   Amount (sats)
                 </Label>
-                <Input
-                  id="amount"
-                  required
-                  value={amount}
-                  onChange={(e) => setAmount(e.target.value)}
-                  className="col-span-2"
-                />
+                <div className="col-span-2">
+                  <Input
+                    id="amount"
+                    required
+                    value={amount}
+                    onChange={(e) => setAmount(e.target.value)}
+                  />
+                </div>
                 <Button
                   type="button"
                   variant="secondary"

--- a/frontend/src/screens/internal-apps/ZapPlanner.tsx
+++ b/frontend/src/screens/internal-apps/ZapPlanner.tsx
@@ -237,38 +237,41 @@ export function ZapPlanner() {
                       <Label htmlFor="name" className="text-right">
                         Recipient Name
                       </Label>
-                      <Input
-                        id="name"
-                        value={recipientName}
-                        required
-                        onChange={(e) => setRecipientName(e.target.value)}
-                        className="col-span-3"
-                      />
+                      <div className="col-span-3">
+                        <Input
+                          id="name"
+                          value={recipientName}
+                          required
+                          onChange={(e) => setRecipientName(e.target.value)}
+                        />
+                      </div>
                     </div>
                     <div className="grid grid-cols-4 items-center gap-4">
                       <Label htmlFor="name" className="text-right">
                         Recipient Lightning Address
                       </Label>
-                      <Input
-                        id="receiver"
-                        required
-                        value={recipientLightningAddress}
-                        onChange={(e) =>
-                          setRecipientLightningAddress(e.target.value)
-                        }
-                        className="col-span-3"
-                      />
+                      <div className="col-span-3">
+                        <Input
+                          id="receiver"
+                          required
+                          value={recipientLightningAddress}
+                          onChange={(e) =>
+                            setRecipientLightningAddress(e.target.value)
+                          }
+                        />
+                      </div>
                     </div>
                     <div className="grid grid-cols-4 items-center gap-4">
                       <Label htmlFor="amount" className="text-right">
                         Amount / month (sats)
                       </Label>
-                      <Input
-                        id="amount"
-                        value={amount}
-                        onChange={(e) => setAmount(e.target.value)}
-                        className="col-span-3"
-                      />
+                      <div className="col-span-3">
+                        <Input
+                          id="amount"
+                          value={amount}
+                          onChange={(e) => setAmount(e.target.value)}
+                        />
+                      </div>
                     </div>
                     <div className="grid grid-cols-4 gap-4">
                       <Label htmlFor="comment" className="text-right pt-2">
@@ -286,13 +289,14 @@ export function ZapPlanner() {
                       <Label htmlFor="comment" className="text-right">
                         Your Name
                       </Label>
-                      <Input
-                        id="sender-name"
-                        value={senderName}
-                        onChange={(e) => setSenderName(e.target.value)}
-                        placeholder={`Let ${recipientName || "them"} know it was from you`}
-                        className="col-span-3"
-                      />
+                      <div className="col-span-3">
+                        <Input
+                          id="sender-name"
+                          value={senderName}
+                          onChange={(e) => setSenderName(e.target.value)}
+                          placeholder={`Let ${recipientName || "them"} know it was from you`}
+                        />
+                      </div>
                     </div>
                   </div>
                   <DialogFooter>


### PR DESCRIPTION
 its because of this instances directly give col-span-3 to the <input> tag but after introduction to end adornment for input we wrap input in a div
we should always use
```
<div class="col-span-3">
<input... />
</div>
```
we do it at most of the places expect two screens which i fixed below. also checked all the input instances should be okay now