### PR TITLE
fix: set default vss url to allow enabling vss on self-hosted hubs

### DIFF
--- a/config/models.go
+++ b/config/models.go
@@ -31,7 +31,7 @@ type AppConfig struct {
 	LDKEsploraServer         string `envconfig:"LDK_ESPLORA_SERVER" default:"https://electrs.getalbypro.com"` // TODO: remove LDK prefix
 	LDKGossipSource          string `envconfig:"LDK_GOSSIP_SOURCE"`
 	LDKLogLevel              string `envconfig:"LDK_LOG_LEVEL" default:"3"`
-	LDKVssUrl                string `envconfig:"LDK_VSS_URL"`
+	LDKVssUrl                string `envconfig:"LDK_VSS_URL" default:"https://vss.getalbypro.com/vss"`
 	LDKListeningAddresses    string `envconfig:"LDK_LISTENING_ADDRESSES" default:"0.0.0.0:9735,[::]:9735"`
 	LDKTransientNetworkGraph bool   `envconfig:"LDK_TRANSIENT_NETWORK_GRAPH" default:"false"`
 	MempoolApi               string `envconfig:"MEMPOOL_API" default:"https://mempool.space/api"`


### PR DESCRIPTION
This change will not affect existing users who have already started their node in the past. Any existing pro users will need to manually enable it in Settings -> Backup.