### PR TITLE
chore: do not show error log when swaps are not configured

### DIFF
--- a/swaps/swaps_service.go
+++ b/swaps/swaps_service.go
@@ -75,7 +75,8 @@ func (svc *swapsService) EnableAutoSwaps(ctx context.Context, lnClient lnclient.
 
 	if swapDestination == "" || balanceThresholdStr == "" || amountStr == "" {
 		cancelFn()
-		return errors.New("auto swap not configured")
+		logger.Logger.Info("Auto swaps not configured")
+		return nil
 	}
 
 	parsedBalanceThreshold, err := strconv.ParseUint(balanceThresholdStr, 10, 64)


### PR DESCRIPTION
We currently show an error log like this:
```
{"error":"auto swap not configured","level":"error","msg":"Couldn't enable auto swaps","time":"2025-05-23T21:21:21+07:00"}
```