### PR TITLE
fix: pass token to LNServer to indicate 0-conf support

### DIFF
--- a/api/lsp.go
+++ b/api/lsp.go
@@ -245,6 +245,12 @@ func (api *api) requestLSPS1Invoice(ctx context.Context, request *LSPOrderReques
 		token = "AlbyHub/" + version.Tag
 	}
 
+	// set a non-empty token to notify LNServer that we support 0-conf
+	// (Pre-v1.17.2 does not support 0-conf)
+	if request.LSPUrl == "https://www.lnserver.com/lsp/wave" {
+		token = "AlbyHub/" + version.Tag
+	}
+
 	newLSPS1ChannelRequest := lsps1ChannelRequest{
 		PublicKey:                    pubkey,
 		LSPBalanceSat:                strconv.FormatUint(request.Amount, 10),


### PR DESCRIPTION
LNServer is adding 0-conf support, but we must ensure it's only enabled for hubs with 1.17.2 or later, otherwise the channel opening will fail, since LNServer is not a trusted 0 conf peer.