### PR TITLE
feat: mark active zero-conf channels as unconfirmed if they haven't been confirmed within an hour

### DIFF
--- a/frontend/src/components/channels/ChannelsCards.tsx
+++ b/frontend/src/components/channels/ChannelsCards.tsx
@@ -18,14 +18,23 @@ import {
   TooltipTrigger,
 } from "src/components/ui/tooltip";
 import { formatAmount } from "src/lib/utils.ts";
-import { Channel, Node } from "src/types";
+import {
+  Channel,
+  LongUnconfirmedZeroConfChannel,
+  MempoolNode,
+} from "src/types";
 
 type ChannelsCardsProps = {
   channels?: Channel[];
-  nodes?: Node[];
+  nodes?: MempoolNode[];
+  longUnconfirmedZeroConfChannels: LongUnconfirmedZeroConfChannel[];
 };
 
-export function ChannelsCards({ channels, nodes }: ChannelsCardsProps) {
+export function ChannelsCards({
+  channels,
+  nodes,
+  longUnconfirmedZeroConfChannels,
+}: ChannelsCardsProps) {
   if (!channels?.length) {
     return null;
   }
@@ -48,6 +57,9 @@ export function ChannelsCards({ channels, nodes }: ChannelsCardsProps) {
             );
             const alias = node?.alias || "Unknown";
             const capacity = channel.localBalance + channel.remoteBalance;
+            const unconfirmedChannel = longUnconfirmedZeroConfChannels.find(
+              (uc) => uc.id === channel.id
+            );
 
             return (
               <>
@@ -69,7 +81,16 @@ export function ChannelsCards({ channels, nodes }: ChannelsCardsProps) {
                         Status
                       </p>
                       {channel.status == "online" ? (
-                        <Badge variant="positive">Online</Badge>
+                        unconfirmedChannel ? (
+                          <Badge
+                            variant="outline"
+                            title={unconfirmedChannel.message}
+                          >
+                            Unconfirmed
+                          </Badge>
+                        ) : (
+                          <Badge variant="positive">Online</Badge>
+                        )
                       ) : channel.status == "opening" ? (
                         <Badge variant="outline">Opening</Badge>
                       ) : (

--- a/frontend/src/components/channels/ChannelsTable.tsx
+++ b/frontend/src/components/channels/ChannelsTable.tsx
@@ -24,15 +24,24 @@ import {
   TooltipTrigger,
 } from "src/components/ui/tooltip.tsx";
 import { formatAmount } from "src/lib/utils.ts";
-import { Channel, Node } from "src/types";
+import {
+  Channel,
+  LongUnconfirmedZeroConfChannel,
+  MempoolNode,
+} from "src/types";
 import { ChannelDropdownMenu } from "./ChannelDropdownMenu";
 
 type ChannelsTableProps = {
   channels?: Channel[];
-  nodes?: Node[];
+  nodes?: MempoolNode[];
+  longUnconfirmedZeroConfChannels: LongUnconfirmedZeroConfChannel[];
 };
 
-export function ChannelsTable({ channels, nodes }: ChannelsTableProps) {
+export function ChannelsTable({
+  channels,
+  nodes,
+  longUnconfirmedZeroConfChannels,
+}: ChannelsTableProps) {
   if (channels && !channels.length) {
     return null;
   }
@@ -134,6 +143,10 @@ export function ChannelsTable({ channels, nodes }: ChannelsTableProps) {
                     const capacity =
                       channel.localBalance + channel.remoteBalance;
 
+                    const unconfirmedChannel =
+                      longUnconfirmedZeroConfChannels.find(
+                        (uc) => uc.id === channel.id
+                      );
                     return (
                       <TableRow key={channel.id} className="channel">
                         <TableCell>
@@ -146,7 +159,16 @@ export function ChannelsTable({ channels, nodes }: ChannelsTableProps) {
                         </TableCell>
                         <TableCell>
                           {channel.status == "online" ? (
-                            <Badge variant="positive">Online</Badge>
+                            unconfirmedChannel ? (
+                              <Badge
+                                variant="outline"
+                                title={unconfirmedChannel.message}
+                              >
+                                Unconfirmed
+                              </Badge>
+                            ) : (
+                              <Badge variant="positive">Online</Badge>
+                            )
                           ) : channel.status == "opening" ? (
                             <Badge variant="outline">Opening</Badge>
                           ) : (

--- a/frontend/src/screens/channels/CurrentChannelOrder.tsx
+++ b/frontend/src/screens/channels/CurrentChannelOrder.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import {
   ConnectPeerRequest,
+  MempoolNode,
   NewChannelOrder,
-  Node,
   OpenChannelRequest,
   OpenChannelResponse,
   PayInvoiceResponse,
@@ -391,7 +391,9 @@ function PayBitcoinChannelOrderWithSpendableFunds({
     throw new Error("incorrect payment method");
   }
   const { data: peers } = usePeers();
-  const [nodeDetails, setNodeDetails] = React.useState<Node | undefined>();
+  const [nodeDetails, setNodeDetails] = React.useState<
+    MempoolNode | undefined
+  >();
   const [hasLoadedNodeDetails, setLoadedNodeDetails] = React.useState(false);
 
   const { toast } = useToast();
@@ -403,7 +405,7 @@ function PayBitcoinChannelOrderWithSpendableFunds({
       return;
     }
     try {
-      const data = await request<Node>(
+      const data = await request<MempoolNode>(
         `/api/mempool?endpoint=/v1/lightning/nodes/${pubkey}`
       );
       setNodeDetails(data);

--- a/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
@@ -39,9 +39,9 @@ import { usePeers } from "src/hooks/usePeers";
 import { cn, formatAmount } from "src/lib/utils";
 import useChannelOrderStore from "src/state/ChannelOrderStore";
 import {
+  MempoolNode,
   Network,
   NewChannelOrder,
-  Node,
   OnchainOrder,
   RecommendedChannelPeer,
 } from "src/types";
@@ -435,7 +435,9 @@ type NewChannelOnchainProps = {
 };
 
 function NewChannelOnchain(props: NewChannelOnchainProps) {
-  const [nodeDetails, setNodeDetails] = React.useState<Node | undefined>();
+  const [nodeDetails, setNodeDetails] = React.useState<
+    MempoolNode | undefined
+  >();
   const { data: peers } = usePeers();
 
   if (props.order.paymentMethod !== "onchain") {
@@ -470,7 +472,7 @@ function NewChannelOnchain(props: NewChannelOnchainProps) {
       return;
     }
     try {
-      const data = await request<Node>(
+      const data = await request<MempoolNode>(
         `/api/mempool?endpoint=/v1/lightning/nodes/${pubkey}`
       );
 

--- a/frontend/src/screens/peers/Peers.tsx
+++ b/frontend/src/screens/peers/Peers.tsx
@@ -24,7 +24,7 @@ import { useToast } from "src/components/ui/use-toast";
 import { useChannels } from "src/hooks/useChannels";
 import { usePeers } from "src/hooks/usePeers.ts";
 import { useSyncWallet } from "src/hooks/useSyncWallet.ts";
-import { Node, Peer } from "src/types";
+import { MempoolNode, Peer } from "src/types";
 import { request } from "src/utils/request";
 
 export default function Peers() {
@@ -32,7 +32,7 @@ export default function Peers() {
   const { data: peers } = usePeers();
   const { data: channels } = useChannels();
   const { toast } = useToast();
-  const [nodes, setNodes] = React.useState<Node[]>([]);
+  const [nodes, setNodes] = React.useState<MempoolNode[]>([]);
   const [peerToDisconnect, setPeerToDisconnect] = React.useState<Peer>();
 
   // TODO: move to NWC backend
@@ -41,9 +41,9 @@ export default function Peers() {
       return [];
     }
     const nodes = await Promise.all(
-      peers?.map(async (peer): Promise<Node | undefined> => {
+      peers?.map(async (peer): Promise<MempoolNode | undefined> => {
         try {
-          const response = await request<Node>(
+          const response = await request<MempoolNode>(
             `/api/mempool?endpoint=/v1/lightning/nodes/${peer.nodeId}`
           );
           return response;
@@ -53,7 +53,7 @@ export default function Peers() {
         }
       })
     );
-    setNodes(nodes.filter((node) => !!node) as Node[]);
+    setNodes(nodes.filter((node) => !!node) as MempoolNode[]);
   }, [peers]);
 
   React.useEffect(() => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -335,13 +335,36 @@ export type OnchainBalanceResponse = {
 };
 
 // from https://mempool.space/docs/api/rest#get-node-stats
-export type Node = {
+export type MempoolNode = {
   alias: string;
   public_key: string;
   color: string;
   active_channel_count: number;
   sockets: string;
 };
+
+// from https://mempool.space/docs/api/rest#get-transaction
+export type MempoolTransaction = {
+  txid: string;
+  //version: 1,
+  //locktime: 0,
+  // vin: [],
+  //vout: [],
+  size: number;
+  weight: number;
+  fee: number;
+  status:
+    | {
+        confirmed: true;
+        block_height: number;
+        block_hash: string;
+        block_time: number;
+      }
+    | { confirmed: false };
+};
+
+export type LongUnconfirmedZeroConfChannel = { id: string; message: string };
+
 export type SetupNodeInfo = Partial<{
   backendType: BackendType;
 


### PR DESCRIPTION
Closes https://github.com/getAlby/hub/issues/1335

For active, 0-conf channels with 0 confirmations, we do a couple calls to mempool.space to figure out how long the channel has been unconfirmed. If the opening transaction is not in the mempool or has been there longer than an hour, we will show "Unconfirmed" instead of "Online".

![image](https://github.com/user-attachments/assets/8e50779f-0636-4334-b6c0-20536f61e5a5)
![image](https://github.com/user-attachments/assets/c1795f35-7114-4430-89b1-bb1a0e2b0900)
