### PR TITLE
chore: convert tailwind config to esm

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,7 +1,8 @@
-const defaultTheme = require("tailwindcss/defaultTheme");
+import * as tailwindAnimate from "tailwindcss-animate";
+import defaultTheme from "tailwindcss/defaultTheme";
 
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   darkMode: ["selector"],
   content: [
     "./pages/**/*.{ts,tsx}",
@@ -103,5 +104,5 @@ module.exports = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindAnimate],
 };


### PR DESCRIPTION
## Description

This makes it work in both node v20 and v22

Previously it failed on v22 saying:
```
file:///.../hub/frontend/tailwind.config.js:1
const defaultTheme = require("tailwindcss/defaultTheme");
                     ^

ReferenceError: require is not define
```