### PR TITLE
feat: Regenerate JWT Secret on password change

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -269,6 +269,19 @@ func (cfg *config) ChangeUnlockPassword(currentUnlockPassword string, newUnlockP
 		return err
 	}
 
+	newSecret, err := randomHex(32)
+	if err != nil {
+		logger.Logger.WithError(err).Error("failed to generate new JWT secret")
+	} else {
+		err = cfg.SetUpdate("JWTSecret", newSecret, "")
+		if err != nil {
+			logger.Logger.WithError(err).Error("failed to save new JWT secret")
+		} else {
+			cfg.JWTSecret = newSecret
+			logger.Logger.Info("Successfully regenerated JWT secret after password change")
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
fixes: #1376 
The `ChangeUnlockPassword` function in `config/config.go` has been updated to:
- Generate a new random JWT secret.
- Store this new secret in the database.
- Update the active JWT secret in the config.