### PR TITLE
chore: adjust link alby account budget values

### DIFF
--- a/frontend/src/components/BudgetAmountSelect.tsx
+++ b/frontend/src/components/BudgetAmountSelect.tsx
@@ -2,16 +2,18 @@ import React from "react";
 import { Input } from "src/components/ui/input";
 import { Label } from "src/components/ui/label";
 import { cn } from "src/lib/utils";
-import { budgetOptions } from "src/types";
+import { budgetOptions as defaultBudgetOptions } from "src/types";
 
 function BudgetAmountSelect({
   value,
   onChange,
   minAmount,
+  budgetOptions = defaultBudgetOptions,
 }: {
   value: number;
   onChange: (value: number) => void;
   minAmount?: number;
+  budgetOptions?: typeof defaultBudgetOptions;
 }) {
   const [customBudget, setCustomBudget] = React.useState(
     value ? !Object.values(budgetOptions).includes(value) : false

--- a/frontend/src/components/connections/AlbyConnectionCard.tsx
+++ b/frontend/src/components/connections/AlbyConnectionCard.tsx
@@ -51,9 +51,9 @@ function AlbyConnectionCard({ connection }: { connection?: App }) {
   const { loading, linkStatus, loadingLinkStatus, linkAccount } =
     useLinkAccount();
 
-  const [maxAmount, setMaxAmount] = useState(1_000_000);
+  const [maxAmount, setMaxAmount] = useState(150_000);
   const [budgetRenewal, setBudgetRenewal] =
-    useState<BudgetRenewalType>("monthly");
+    useState<BudgetRenewalType>("weekly");
 
   function onSubmit(e: FormEvent) {
     e.preventDefault();
@@ -130,6 +130,11 @@ function AlbyConnectionCard({ connection }: { connection?: App }) {
                           minAmount={
                             25000 /* the minimum should be a bit more than the Alby monthly fee */
                           }
+                          budgetOptions={{
+                            "150k": 150_000,
+                            "500k": 500_000,
+                            "1M": 1_000_000,
+                          }}
                         />
                       </div>
                       <DialogFooter>


### PR DESCRIPTION
Closes https://github.com/getAlby/hub/issues/1375

![image](https://github.com/user-attachments/assets/6278df5e-3cfa-4b61-af11-cd1e3437a4cb)

Note: if the user chooses custom, the lowest they can input is 25k.