### PR TITLE
feat: add app id override to make invoice

### DIFF
--- a/nip47/controllers/make_invoice_controller.go
+++ b/nip47/controllers/make_invoice_controller.go
@@ -30,13 +30,14 @@ func (controller *nip47Controller) HandleMakeInvoiceEvent(ctx context.Context, n
 	}
 
 	logger.Logger.WithFields(logrus.Fields{
+		"app_id":           appId,
 		"request_event_id": requestEventId,
 		"amount":           makeInvoiceParams.Amount,
 		"description":      makeInvoiceParams.Description,
 		"description_hash": makeInvoiceParams.DescriptionHash,
 		"expiry":           makeInvoiceParams.Expiry,
 		"metadata":         makeInvoiceParams.Metadata,
-	}).Info("Making invoice")
+	}).Debug("Handling make_invoice request")
 
 	expiry := makeInvoiceParams.Expiry
 

--- a/transactions/transactions_service.go
+++ b/transactions/transactions_service.go
@@ -139,6 +139,16 @@ func NewTransactionsService(db *gorm.DB, eventPublisher events.EventPublisher) *
 }
 
 func (svc *transactionsService) MakeInvoice(ctx context.Context, amount uint64, description string, descriptionHash string, expiry uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error) {
+	logger.Logger.WithFields(logrus.Fields{
+		"app_id":           appId,
+		"request_event_id": requestEventId,
+		"amount":           amount,
+		"description":      description,
+		"description_hash": descriptionHash,
+		"expiry":           expiry,
+		"metadata":         metadata,
+	}).Debug("Making invoice")
+
 	var metadataBytes []byte
 	if metadata != nil {
 		var err error
@@ -150,6 +160,16 @@ func (svc *transactionsService) MakeInvoice(ctx context.Context, amount uint64, 
 		if len(metadataBytes) > constants.INVOICE_METADATA_MAX_LENGTH {
 			return nil, fmt.Errorf("encoded invoice metadata provided is too large. Limit: %d Received: %d", constants.INVOICE_METADATA_MAX_LENGTH, len(metadataBytes))
 		}
+	}
+
+	if metadata["app_id"] != nil {
+		overwriteAppIdType, ok := metadata["app_id"].(float64)
+		if !ok {
+			return nil, errors.New("failed to overwrite app ID")
+		}
+		overwriteAppId := uint(overwriteAppIdType)
+		logger.Logger.WithField("app_id", overwriteAppId).Info("Making invoice with overwritten app ID")
+		appId = &overwriteAppId
 	}
 
 	lnClientTransaction, err := lnClient.MakeInvoice(ctx, int64(amount), description, descriptionHash, int64(expiry))
@@ -345,6 +365,17 @@ func (svc *transactionsService) SendPaymentSync(ctx context.Context, payReq stri
 		}).WithError(err).Error("Failed to create DB transaction")
 		return nil, err
 	}
+
+	logger.Logger.WithFields(logrus.Fields{
+		"app_id":           appId,
+		"request_event_id": requestEventId,
+		"amount":           paymentAmount,
+		"description":      paymentRequest.Description,
+		"description_hash": paymentRequest.DescriptionHash,
+		"expiry":           paymentRequest.Expiry,
+		"self_payment":     selfPayment,
+		"metadata":         metadata,
+	}).Debug("Initiating payment")
 
 	var response *lnclient.PayInvoiceResponse
 	if selfPayment {


### PR DESCRIPTION
Closes https://github.com/getAlby/hub/issues/1382

Simply pass `metadata: {app_id: 2}` and the invoice will be for app 2 instead, no matter what app initiated the request.

Does not do the lightning address part (see https://github.com/getAlby/hub/issues/1387)