### PR TITLE
fix: always pass in fee and handle mempool errors

### DIFF
--- a/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
+++ b/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
@@ -3,7 +3,7 @@ import {
   ChevronDown,
   CopyIcon,
   ExternalLinkIcon,
-  TriangleAlertIcon,
+  InfoIcon,
 } from "lucide-react";
 import React from "react";
 import AppHeader from "src/components/AppHeader";
@@ -57,6 +57,12 @@ export default function WithdrawOnchainFunds() {
   const [confirmDialogOpen, setConfirmDialogOpen] = React.useState(false);
 
   React.useEffect(() => {
+    if (mempoolError) {
+      setShowAdvanced(true);
+    }
+  }, [mempoolError]);
+
+  React.useEffect(() => {
     if (recommendedFees?.fastestFee) {
       setFeeRate(recommendedFees.fastestFee.toString());
     }
@@ -69,9 +75,11 @@ export default function WithdrawOnchainFunds() {
   const redeemFunds = React.useCallback(async () => {
     setLoading(true);
     try {
-      await new Promise((resolve) => setTimeout(resolve, 100));
       if (!onchainAddress) {
         throw new Error("No onchain address");
+      }
+      if (!feeRate) {
+        throw new Error("No fee rate set");
       }
     } catch (error) {
       console.error(error);
@@ -96,7 +104,7 @@ export default function WithdrawOnchainFunds() {
             toAddress: onchainAddress,
             amount: +amount,
             sendAll,
-            ...(feeRate && { feeRate: +feeRate }),
+            feeRate: +feeRate,
           }),
         }
       );
@@ -260,6 +268,12 @@ export default function WithdrawOnchainFunds() {
               {showAdvanced && (
                 <div className="">
                   <Label htmlFor="fee-rate">Fee Rate (Sat/vB)</Label>
+                  {mempoolError && (
+                    <div className="text-muted-foreground text-xs flex gap-1 items-center">
+                      <AlertTriangleIcon className="h-3 w-3" />
+                      Failed to fetch fee estimates. Try refreshing the page.
+                    </div>
+                  )}
                   <Input
                     id="fee-rate"
                     type="number"
@@ -326,9 +340,10 @@ export default function WithdrawOnchainFunds() {
             >
               <Button className="w-full">Withdraw</Button>
               {feeRate && (
-                <div className="mt-2 text-muted-foreground text-sm flex items-center">
-                  <TriangleAlertIcon className="h-4 w-4 mr-1" />
-                  Onchain payment will be made with {feeRate} sat/vB fee
+                <div className="mt-2 text-muted-foreground text-sm flex gap-1 items-center justify-center">
+                  <InfoIcon className="h-4 w-4" />
+                  On-chain payment will be made with{" "}
+                  <span className="font-semibold">{feeRate} sat/vB</span> fee
                 </div>
               )}
 
@@ -353,6 +368,15 @@ export default function WithdrawOnchainFunds() {
                           )}
                         </span>
                       </p>
+                      {feeRate && (
+                        <p className="mt-4">
+                          Fee Rate:{" "}
+                          <span className="font-bold slashed-zero">
+                            {feeRate}
+                          </span>{" "}
+                          sat/vB
+                        </p>
+                      )}
                     </div>
                   </AlertDialogDescription>
                 </AlertDialogHeader>


### PR DESCRIPTION
## Description

In LND, withdrawing with `TargetConf` set to 1 can make it use very high fees >20-30 sat per vB as it uses mean/median instead of mode (roughly). To avoid that, we set the fees in the frontend itself.

This also adds code to avoid the withdraw page from crashing if the mempool api returns an error, in that case, the user can still input a feeRate or else it will use the `TargetConf: 1`

## Screenshot

<img width="100%" alt="Screenshot 2025-06-11 at 6 25 09 PM" src="https://github.com/user-attachments/assets/b1209b9b-404b-4bf9-8e6c-14cb97566f1d" />
