### PR TITLE
Chore: add albyhub region cookie to developer page

### DIFF
--- a/alby/models.go
+++ b/alby/models.go
@@ -72,7 +72,8 @@ type AlbyInfo struct {
 }
 
 type AlbyMeHub struct {
-	Name string `json:"name"`
+	Name   string                 `json:"name"`
+	Config map[string]interface{} `json:"config"`
 }
 
 type AlbyMeSubscription struct {

--- a/frontend/src/screens/settings/DeveloperSettings.tsx
+++ b/frontend/src/screens/settings/DeveloperSettings.tsx
@@ -174,7 +174,43 @@ export default function DeveloperSettings() {
                     </span>{" "}
                   </li>
                 )}
+                <li>
+                  <span className="font-mono font-semibold">
+                    AlbyHub-Region: YOUR_COOKIE_VALUE
+                  </span>{" "}
+                  (if you are using Alby Cloud)
+                </li>
               </ol>
+              <p className="mt-2 text-sm text-muted-foreground">
+                To find the{" "}
+                <span className="font-mono font-semibold">AlbyHub-Region</span>{" "}
+                cookie value:
+              </p>
+              <ul className="list-disc list-inside text-sm text-muted-foreground ml-4">
+                <li>
+                  Open Developer Tools in your browser (e.g., press F12 or
+                  right-click and select 'Inspect').
+                </li>
+                <li>
+                  Navigate to the 'Application' tab (in Chrome-based browsers)
+                  or 'Storage' tab (in Firefox).
+                </li>
+                <li>
+                  Under the 'Cookies' section in the sidebar, find and select
+                  the domain for Alby Hub (e.g.,{" "}
+                  <span className="font-mono font-semibold">
+                    {new URL(window.location.origin).hostname}
+                  </span>
+                  ).
+                </li>
+                <li>
+                  Look for the cookie named{" "}
+                  <span className="font-mono font-semibold">
+                    AlbyHub-Region
+                  </span>{" "}
+                  in the list and copy its value.
+                </li>
+              </ul>
             </div>
             <p className="text-xs">
               This token grants full access to your hub. Please keep it secure.

--- a/frontend/src/screens/settings/DeveloperSettings.tsx
+++ b/frontend/src/screens/settings/DeveloperSettings.tsx
@@ -174,44 +174,16 @@ export default function DeveloperSettings() {
                     </span>{" "}
                   </li>
                 )}
-                <li>
-                  <span className="font-mono font-semibold">
-                    AlbyHub-Region: YOUR_COOKIE_VALUE
-                  </span>{" "}
-                  (if you are using Alby Cloud)
-                </li>
+                {albyMe?.hub.name && (
+                  <li>
+                    <span className="font-mono font-semibold">
+                      AlbyHub-Region: {albyMe.hub.config?.region || "lax"}
+                    </span>
+                  </li>
+                )}
               </ol>
-              <p className="mt-2 text-sm text-muted-foreground">
-                To find the{" "}
-                <span className="font-mono font-semibold">AlbyHub-Region</span>{" "}
-                cookie value:
-              </p>
-              <ul className="list-disc list-inside text-sm text-muted-foreground ml-4">
-                <li>
-                  Open Developer Tools in your browser (e.g., press F12 or
-                  right-click and select 'Inspect').
-                </li>
-                <li>
-                  Navigate to the 'Application' tab (in Chrome-based browsers)
-                  or 'Storage' tab (in Firefox).
-                </li>
-                <li>
-                  Under the 'Cookies' section in the sidebar, find and select
-                  the domain for Alby Hub (e.g.,{" "}
-                  <span className="font-mono font-semibold">
-                    {new URL(window.location.origin).hostname}
-                  </span>
-                  ).
-                </li>
-                <li>
-                  Look for the cookie named{" "}
-                  <span className="font-mono font-semibold">
-                    AlbyHub-Region
-                  </span>{" "}
-                  in the list and copy its value.
-                </li>
-              </ul>
             </div>
+
             <p className="text-xs">
               This token grants full access to your hub. Please keep it secure.
               If you suspect that the token has been compromised, immediately

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -434,6 +434,9 @@ export type AlbyMe = {
   shared_node: boolean;
   hub: {
     name?: string;
+    config?: {
+      region?: string;
+    };
   };
   subscription: {
     plan_code: string;


### PR DESCRIPTION
This cookie is required to correctly forward requests to Alby Cloud when it is deployed on the non-default region.

Fixes https://github.com/getAlby/hub/issues/1410