### PR TITLE
feat: add download button for latest SCB file in backup page

### DIFF
--- a/api/models.go
+++ b/api/models.go
@@ -67,6 +67,7 @@ type API interface {
 	GetCustomNodeCommands() (*CustomNodeCommandsResponse, error)
 	ExecuteCustomNodeCommand(ctx context.Context, command string) (interface{}, error)
 	SendEvent(event string)
+	GetLatestSCB() ([]byte, error)
 }
 
 type App struct {

--- a/http/http_service.go
+++ b/http/http_service.go
@@ -165,6 +165,7 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	restrictedApiGroup.POST("/settings/swaps", httpSvc.enableAutoSwapsHandler)
 	restrictedApiGroup.DELETE("/settings/swaps", httpSvc.disableAutoSwapsHandler)
 	restrictedApiGroup.POST("/node/alias", httpSvc.setNodeAliasHandler)
+	restrictedApiGroup.GET("/scb", httpSvc.downloadSCBHandler)
 
 	httpSvc.albyHttpSvc.RegisterSharedRoutes(restrictedApiGroup, e)
 }
@@ -1254,4 +1255,18 @@ func (httpSvc *HttpService) setNodeAliasHandler(c echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusNoContent)
+}
+
+func (httpSvc *HttpService) downloadSCBHandler(c echo.Context) error {
+	scbData, err := httpSvc.api.GetLatestSCB()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Message: fmt.Sprintf("Failed to get SCB file: %v", err),
+		})
+	}
+	c.Response().Header().Set("Content-Type", "application/json")
+	c.Response().Header().Set("Content-Disposition", "attachment; filename=static-channel-backup.json")
+	c.Response().WriteHeader(http.StatusOK)
+	c.Response().Write(scbData)
+	return nil
 }

--- a/wails/wails_handlers.go
+++ b/wails/wails_handlers.go
@@ -1084,6 +1084,20 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 
 			return WailsRequestRouterResponse{Body: nil, Error: ""}
 		}
+	case "/api/scb":
+		scbData, err := app.api.GetLatestSCB()
+		if err != nil {
+			logger.Logger.WithFields(logrus.Fields{
+				"route":  route,
+				"method": method,
+				"body":   body,
+			}).WithError(err).Error("Failed to get SCB file")
+			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
+		}
+		return WailsRequestRouterResponse{Body: map[string]interface{}{
+			"data":     string(scbData),
+			"filename": "static-channel-backup.json",
+		}, Error: ""}
 	}
 
 	if strings.HasPrefix(route, "/api/log/") {


### PR DESCRIPTION
#1037

- Add GetLatestSCB() API method to find the most recent SCB file
- Add /api/scb endpoint for HTTP and Wails modes
- Add DownloadSCBButton component to the backup page
- Only show the button for LDK backend type
- Include proper loading states and error handling
- Support both HTTP and Wails download modes