### PR TITLE
feat: specify max channel saturation power of half from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ _To configure via env, the following parameters must be provided:_
 - `LDK_VSS_URL`: Use VSS (encrypted remote storage) rather than local sqlite store for lightning and bitcoin data. Currently this feature only works for brand new Alby Hub instances that are connected to Alby Accounts with an active subscription plan.
 - `LDK_LISTENING_ADDRESSES`: configure listening addresses, required for public channels, and ideally reachable if you would like others to be able to initiate peering with your node.
 - `LDK_MAX_CHANNEL_SATURATION`: Sets the maximum portion of a channel's total capacity that may be used for sending a payment, expressed as a power of 1/2. See `max_channel_saturation_power_of_half` in [LDK docs](https://docs.rs/lightning/latest/lightning/routing/router/struct.PaymentParameters.html#structfield.max_channel_saturation_power_of_half).
+- `LDK_MAX_PATH_COUNT`: Maximum number of paths that may be used by MPP payments.
 
 #### LDK Network Configuration
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ _To configure via env, the following parameters must be provided:_
 - `LDK_ESPLORA_SERVER`: By default the optimized Alby esplora is used. You can configure your own esplora server (note: the public blockstream one is slow and can cause onchain syncing and issues with opening channels)
 - `LDK_VSS_URL`: Use VSS (encrypted remote storage) rather than local sqlite store for lightning and bitcoin data. Currently this feature only works for brand new Alby Hub instances that are connected to Alby Accounts with an active subscription plan.
 - `LDK_LISTENING_ADDRESSES`: configure listening addresses, required for public channels, and ideally reachable if you would like others to be able to initiate peering with your node.
+- `LDK_MAX_CHANNEL_SATURATION`: Sets the maximum portion of a channel's total capacity that may be used for sending a payment, expressed as a power of 1/2. See `max_channel_saturation_power_of_half` in [LDK docs](https://docs.rs/lightning/latest/lightning/routing/router/struct.PaymentParameters.html#structfield.max_channel_saturation_power_of_half).
 
 #### LDK Network Configuration
 

--- a/config/models.go
+++ b/config/models.go
@@ -15,40 +15,41 @@ const (
 )
 
 type AppConfig struct {
-	Relay                    string `envconfig:"RELAY" default:"wss://relay.getalby.com/v1"`
-	LNBackendType            string `envconfig:"LN_BACKEND_TYPE"`
-	LNDAddress               string `envconfig:"LND_ADDRESS"`
-	LNDCertFile              string `envconfig:"LND_CERT_FILE"`
-	LNDMacaroonFile          string `envconfig:"LND_MACAROON_FILE"`
-	Workdir                  string `envconfig:"WORK_DIR"`
-	Port                     string `envconfig:"PORT" default:"8080"`
-	DatabaseUri              string `envconfig:"DATABASE_URI" default:"nwc.db"`
-	JWTSecret                string `envconfig:"JWT_SECRET"`
-	LogLevel                 string `envconfig:"LOG_LEVEL" default:"4"`
-	LogToFile                bool   `envconfig:"LOG_TO_FILE" default:"true"`
-	Network                  string `envconfig:"NETWORK"`
-	LDKNetwork               string `envconfig:"LDK_NETWORK"`
-	LDKEsploraServer         string `envconfig:"LDK_ESPLORA_SERVER" default:"https://electrs.getalbypro.com"` // TODO: remove LDK prefix
-	LDKGossipSource          string `envconfig:"LDK_GOSSIP_SOURCE"`
-	LDKLogLevel              string `envconfig:"LDK_LOG_LEVEL" default:"3"`
-	LDKVssUrl                string `envconfig:"LDK_VSS_URL" default:"https://vss.getalbypro.com/vss"`
-	LDKListeningAddresses    string `envconfig:"LDK_LISTENING_ADDRESSES" default:"0.0.0.0:9735,[::]:9735"`
-	LDKTransientNetworkGraph bool   `envconfig:"LDK_TRANSIENT_NETWORK_GRAPH" default:"false"`
-	MempoolApi               string `envconfig:"MEMPOOL_API" default:"https://mempool.space/api"`
-	AlbyClientId             string `envconfig:"ALBY_OAUTH_CLIENT_ID" default:"J2PbXS1yOf"`
-	AlbyClientSecret         string `envconfig:"ALBY_OAUTH_CLIENT_SECRET" default:"rABK2n16IWjLTZ9M1uKU"`
-	BaseUrl                  string `envconfig:"BASE_URL"`
-	FrontendUrl              string `envconfig:"FRONTEND_URL"`
-	LogEvents                bool   `envconfig:"LOG_EVENTS" default:"true"`
-	AutoLinkAlbyAccount      bool   `envconfig:"AUTO_LINK_ALBY_ACCOUNT" default:"true"`
-	PhoenixdAddress          string `envconfig:"PHOENIXD_ADDRESS"`
-	PhoenixdAuthorization    string `envconfig:"PHOENIXD_AUTHORIZATION"`
-	GoProfilerAddr           string `envconfig:"GO_PROFILER_ADDR"`
-	DdProfilerEnabled        bool   `envconfig:"DD_PROFILER_ENABLED" default:"false"`
-	EnableAdvancedSetup      bool   `envconfig:"ENABLE_ADVANCED_SETUP" default:"true"`
-	AutoUnlockPassword       string `envconfig:"AUTO_UNLOCK_PASSWORD"`
-	LogDBQueries             bool   `envconfig:"LOG_DB_QUERIES" default:"false"`
-	BoltzApi                 string `envconfig:"BOLTZ_API" default:"https://api.boltz.exchange"`
+	Relay                              string `envconfig:"RELAY" default:"wss://relay.getalby.com/v1"`
+	LNBackendType                      string `envconfig:"LN_BACKEND_TYPE"`
+	LNDAddress                         string `envconfig:"LND_ADDRESS"`
+	LNDCertFile                        string `envconfig:"LND_CERT_FILE"`
+	LNDMacaroonFile                    string `envconfig:"LND_MACAROON_FILE"`
+	Workdir                            string `envconfig:"WORK_DIR"`
+	Port                               string `envconfig:"PORT" default:"8080"`
+	DatabaseUri                        string `envconfig:"DATABASE_URI" default:"nwc.db"`
+	JWTSecret                          string `envconfig:"JWT_SECRET"`
+	LogLevel                           string `envconfig:"LOG_LEVEL" default:"4"`
+	LogToFile                          bool   `envconfig:"LOG_TO_FILE" default:"true"`
+	Network                            string `envconfig:"NETWORK"`
+	LDKNetwork                         string `envconfig:"LDK_NETWORK"`
+	LDKEsploraServer                   string `envconfig:"LDK_ESPLORA_SERVER" default:"https://electrs.getalbypro.com"` // TODO: remove LDK prefix
+	LDKGossipSource                    string `envconfig:"LDK_GOSSIP_SOURCE"`
+	LDKLogLevel                        string `envconfig:"LDK_LOG_LEVEL" default:"3"`
+	LDKMaxChannelSaturationPowerOfHalf string `envconfig:"LDK_MAX_CHANNEL_SATURATION" default:"2"`
+	LDKVssUrl                          string `envconfig:"LDK_VSS_URL" default:"https://vss.getalbypro.com/vss"`
+	LDKListeningAddresses              string `envconfig:"LDK_LISTENING_ADDRESSES" default:"0.0.0.0:9735,[::]:9735"`
+	LDKTransientNetworkGraph           bool   `envconfig:"LDK_TRANSIENT_NETWORK_GRAPH" default:"false"`
+	MempoolApi                         string `envconfig:"MEMPOOL_API" default:"https://mempool.space/api"`
+	AlbyClientId                       string `envconfig:"ALBY_OAUTH_CLIENT_ID" default:"J2PbXS1yOf"`
+	AlbyClientSecret                   string `envconfig:"ALBY_OAUTH_CLIENT_SECRET" default:"rABK2n16IWjLTZ9M1uKU"`
+	BaseUrl                            string `envconfig:"BASE_URL"`
+	FrontendUrl                        string `envconfig:"FRONTEND_URL"`
+	LogEvents                          bool   `envconfig:"LOG_EVENTS" default:"true"`
+	AutoLinkAlbyAccount                bool   `envconfig:"AUTO_LINK_ALBY_ACCOUNT" default:"true"`
+	PhoenixdAddress                    string `envconfig:"PHOENIXD_ADDRESS"`
+	PhoenixdAuthorization              string `envconfig:"PHOENIXD_AUTHORIZATION"`
+	GoProfilerAddr                     string `envconfig:"GO_PROFILER_ADDR"`
+	DdProfilerEnabled                  bool   `envconfig:"DD_PROFILER_ENABLED" default:"false"`
+	EnableAdvancedSetup                bool   `envconfig:"ENABLE_ADVANCED_SETUP" default:"true"`
+	AutoUnlockPassword                 string `envconfig:"AUTO_UNLOCK_PASSWORD"`
+	LogDBQueries                       bool   `envconfig:"LOG_DB_QUERIES" default:"false"`
+	BoltzApi                           string `envconfig:"BOLTZ_API" default:"https://api.boltz.exchange"`
 }
 
 func (c *AppConfig) IsDefaultClientId() bool {

--- a/config/models.go
+++ b/config/models.go
@@ -31,8 +31,8 @@ type AppConfig struct {
 	LDKEsploraServer                   string `envconfig:"LDK_ESPLORA_SERVER" default:"https://electrs.getalbypro.com"` // TODO: remove LDK prefix
 	LDKGossipSource                    string `envconfig:"LDK_GOSSIP_SOURCE"`
 	LDKLogLevel                        string `envconfig:"LDK_LOG_LEVEL" default:"3"`
-	LDKMaxChannelSaturationPowerOfHalf string `envconfig:"LDK_MAX_CHANNEL_SATURATION" default:"2"`
-	LDKMaxPathCount                    string `envconfig:"LDK_MAX_PATH_COUNT" default:"10"`
+	LDKMaxChannelSaturationPowerOfHalf uint8  `envconfig:"LDK_MAX_CHANNEL_SATURATION" default:"2"`
+	LDKMaxPathCount                    uint8  `envconfig:"LDK_MAX_PATH_COUNT" default:"10"`
 	LDKVssUrl                          string `envconfig:"LDK_VSS_URL" default:"https://vss.getalbypro.com/vss"`
 	LDKListeningAddresses              string `envconfig:"LDK_LISTENING_ADDRESSES" default:"0.0.0.0:9735,[::]:9735"`
 	LDKTransientNetworkGraph           bool   `envconfig:"LDK_TRANSIENT_NETWORK_GRAPH" default:"false"`

--- a/config/models.go
+++ b/config/models.go
@@ -32,6 +32,7 @@ type AppConfig struct {
 	LDKGossipSource                    string `envconfig:"LDK_GOSSIP_SOURCE"`
 	LDKLogLevel                        string `envconfig:"LDK_LOG_LEVEL" default:"3"`
 	LDKMaxChannelSaturationPowerOfHalf string `envconfig:"LDK_MAX_CHANNEL_SATURATION" default:"2"`
+	LDKMaxPathCount                    string `envconfig:"LDK_MAX_PATH_COUNT" default:"10"`
 	LDKVssUrl                          string `envconfig:"LDK_VSS_URL" default:"https://vss.getalbypro.com/vss"`
 	LDKListeningAddresses              string `envconfig:"LDK_LISTENING_ADDRESSES" default:"0.0.0.0:9735,[::]:9735"`
 	LDKTransientNetworkGraph           bool   `envconfig:"LDK_TRANSIENT_NETWORK_GRAPH" default:"false"`

--- a/config/models.go
+++ b/config/models.go
@@ -32,7 +32,7 @@ type AppConfig struct {
 	LDKGossipSource                    string `envconfig:"LDK_GOSSIP_SOURCE"`
 	LDKLogLevel                        string `envconfig:"LDK_LOG_LEVEL" default:"3"`
 	LDKMaxChannelSaturationPowerOfHalf uint8  `envconfig:"LDK_MAX_CHANNEL_SATURATION" default:"2"`
-	LDKMaxPathCount                    uint8  `envconfig:"LDK_MAX_PATH_COUNT" default:"10"`
+	LDKMaxPathCount                    uint8  `envconfig:"LDK_MAX_PATH_COUNT" default:"5"`
 	LDKVssUrl                          string `envconfig:"LDK_VSS_URL" default:"https://vss.getalbypro.com/vss"`
 	LDKListeningAddresses              string `envconfig:"LDK_LISTENING_ADDRESSES" default:"0.0.0.0:9735,[::]:9735"`
 	LDKTransientNetworkGraph           bool   `envconfig:"LDK_TRANSIENT_NETWORK_GRAPH" default:"false"`

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -502,11 +502,17 @@ func (ls *LDKService) SendPaymentSync(ctx context.Context, invoice string, amoun
 	defer ls.ldkEventBroadcaster.CancelSubscription(ldkEventSubscription)
 
 	saturationPowerInt, _ := strconv.Atoi(ls.cfg.GetEnv().LDKMaxChannelSaturationPowerOfHalf)
+	maxPathCountInt, _ := strconv.Atoi(ls.cfg.GetEnv().LDKMaxChannelSaturationPowerOfHalf)
+
 	saturationPower := uint8(saturationPowerInt)
+	maxPathCount := uint8(maxPathCountInt)
+
 	maxTotalRoutingFeeMsat := getMaxTotalRoutingFeeLimit(paymentAmountMsat)
+
 	sendingParams := &ldk_node.SendingParameters{
 		MaxTotalRoutingFeeMsat:          &maxTotalRoutingFeeMsat,
 		MaxChannelSaturationPowerOfHalf: &saturationPower,
+		MaxPathCount:                    &maxPathCount,
 	}
 
 	invoiceObj, err := checkLDKErr(ldk_node.Bolt11InvoiceFromStr(invoice))
@@ -610,11 +616,17 @@ func (ls *LDKService) SendKeysend(ctx context.Context, amount uint64, destinatio
 	defer ls.ldkEventBroadcaster.CancelSubscription(ldkEventSubscription)
 
 	saturationPowerInt, _ := strconv.Atoi(ls.cfg.GetEnv().LDKMaxChannelSaturationPowerOfHalf)
+	maxPathCountInt, _ := strconv.Atoi(ls.cfg.GetEnv().LDKMaxChannelSaturationPowerOfHalf)
+
 	saturationPower := uint8(saturationPowerInt)
+	maxPathCount := uint8(maxPathCountInt)
+
 	maxTotalRoutingFeeMsat := getMaxTotalRoutingFeeLimit(amount)
+
 	sendingParams := &ldk_node.SendingParameters{
 		MaxTotalRoutingFeeMsat:          &maxTotalRoutingFeeMsat,
 		MaxChannelSaturationPowerOfHalf: &saturationPower,
+		MaxPathCount:                    &maxPathCount,
 	}
 
 	paymentHash, err := checkLDKErr(ls.node.SpontaneousPayment().SendWithTlvsAndPreimage(amount, destination, sendingParams, customTlvs, &preimage))

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -111,7 +111,10 @@ func NewLDKService(ctx context.Context, cfg config.Config, eventPublisher events
 	}
 
 	ldkConfig.ListeningAddresses = &listeningAddresses
-	logLevel, _ := strconv.Atoi(cfg.GetEnv().LDKLogLevel)
+	logLevel, err := strconv.Atoi(cfg.GetEnv().LDKLogLevel)
+	if err != nil {
+		logLevel = int(ldk_node.LogLevelDebug)
+	}
 	// LogLevelGossip is added due to bug in go bindings which uses an enum that starts at 1 instead of 0
 	ldkLogger := NewLDKLogger(ldk_node.LogLevel(logLevel) + ldk_node.LogLevelGossip)
 	ldkConfig.TransientNetworkGraph = cfg.GetEnv().LDKTransientNetworkGraph
@@ -501,12 +504,8 @@ func (ls *LDKService) SendPaymentSync(ctx context.Context, invoice string, amoun
 	ldkEventSubscription := ls.ldkEventBroadcaster.Subscribe()
 	defer ls.ldkEventBroadcaster.CancelSubscription(ldkEventSubscription)
 
-	saturationPowerInt, _ := strconv.Atoi(ls.cfg.GetEnv().LDKMaxChannelSaturationPowerOfHalf)
-	maxPathCountInt, _ := strconv.Atoi(ls.cfg.GetEnv().LDKMaxChannelSaturationPowerOfHalf)
-
-	saturationPower := uint8(saturationPowerInt)
-	maxPathCount := uint8(maxPathCountInt)
-
+	saturationPower := ls.cfg.GetEnv().LDKMaxChannelSaturationPowerOfHalf
+	maxPathCount := ls.cfg.GetEnv().LDKMaxPathCount
 	maxTotalRoutingFeeMsat := getMaxTotalRoutingFeeLimit(paymentAmountMsat)
 
 	sendingParams := &ldk_node.SendingParameters{
@@ -615,12 +614,8 @@ func (ls *LDKService) SendKeysend(ctx context.Context, amount uint64, destinatio
 	ldkEventSubscription := ls.ldkEventBroadcaster.Subscribe()
 	defer ls.ldkEventBroadcaster.CancelSubscription(ldkEventSubscription)
 
-	saturationPowerInt, _ := strconv.Atoi(ls.cfg.GetEnv().LDKMaxChannelSaturationPowerOfHalf)
-	maxPathCountInt, _ := strconv.Atoi(ls.cfg.GetEnv().LDKMaxChannelSaturationPowerOfHalf)
-
-	saturationPower := uint8(saturationPowerInt)
-	maxPathCount := uint8(maxPathCountInt)
-
+	saturationPower := ls.cfg.GetEnv().LDKMaxChannelSaturationPowerOfHalf
+	maxPathCount := ls.cfg.GetEnv().LDKMaxPathCount
 	maxTotalRoutingFeeMsat := getMaxTotalRoutingFeeLimit(amount)
 
 	sendingParams := &ldk_node.SendingParameters{

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -501,10 +501,12 @@ func (ls *LDKService) SendPaymentSync(ctx context.Context, invoice string, amoun
 	ldkEventSubscription := ls.ldkEventBroadcaster.Subscribe()
 	defer ls.ldkEventBroadcaster.CancelSubscription(ldkEventSubscription)
 
-	var paymentHash string
+	saturationPowerInt, _ := strconv.Atoi(ls.cfg.GetEnv().LDKMaxChannelSaturationPowerOfHalf)
+	saturationPower := uint8(saturationPowerInt)
 	maxTotalRoutingFeeMsat := getMaxTotalRoutingFeeLimit(paymentAmountMsat)
 	sendingParams := &ldk_node.SendingParameters{
-		MaxTotalRoutingFeeMsat: &maxTotalRoutingFeeMsat,
+		MaxTotalRoutingFeeMsat:          &maxTotalRoutingFeeMsat,
+		MaxChannelSaturationPowerOfHalf: &saturationPower,
 	}
 
 	invoiceObj, err := checkLDKErr(ldk_node.Bolt11InvoiceFromStr(invoice))
@@ -513,6 +515,7 @@ func (ls *LDKService) SendPaymentSync(ctx context.Context, invoice string, amoun
 		return nil, err
 	}
 
+	var paymentHash string
 	if amount == nil {
 		paymentHash, err = checkLDKErr(ls.node.Bolt11Payment().Send(invoiceObj, sendingParams))
 	} else {
@@ -606,9 +609,12 @@ func (ls *LDKService) SendKeysend(ctx context.Context, amount uint64, destinatio
 	ldkEventSubscription := ls.ldkEventBroadcaster.Subscribe()
 	defer ls.ldkEventBroadcaster.CancelSubscription(ldkEventSubscription)
 
+	saturationPowerInt, _ := strconv.Atoi(ls.cfg.GetEnv().LDKMaxChannelSaturationPowerOfHalf)
+	saturationPower := uint8(saturationPowerInt)
 	maxTotalRoutingFeeMsat := getMaxTotalRoutingFeeLimit(amount)
 	sendingParams := &ldk_node.SendingParameters{
-		MaxTotalRoutingFeeMsat: &maxTotalRoutingFeeMsat,
+		MaxTotalRoutingFeeMsat:          &maxTotalRoutingFeeMsat,
+		MaxChannelSaturationPowerOfHalf: &saturationPower,
 	}
 
 	paymentHash, err := checkLDKErr(ls.node.SpontaneousPayment().SendWithTlvsAndPreimage(amount, destination, sendingParams, customTlvs, &preimage))

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -113,6 +113,7 @@ func NewLDKService(ctx context.Context, cfg config.Config, eventPublisher events
 	ldkConfig.ListeningAddresses = &listeningAddresses
 	logLevel, err := strconv.Atoi(cfg.GetEnv().LDKLogLevel)
 	if err != nil {
+		// If parsing log level fails we default to 3, which is then bumped below
 		logLevel = int(ldk_node.LogLevelDebug)
 	}
 	// LogLevelGossip is added due to bug in go bindings which uses an enum that starts at 1 instead of 0


### PR DESCRIPTION
Fixes #1425

Adds an env var `LDK_MAX_CHANNEL_SATURATION` which is defaulted to `2` (same as LDK)