### PR TITLE
fix: use custom mempool url

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,2 +1,4 @@
 # set a custom messageboard wallet (should be a sub-wallet with only make invoice and list transactions permissions)
 #VITE_LIGHTNING_MESSAGEBOARD_NWC_URL="nostr+walletconnect://5f8e7c098137ccca853327be44a9b2e956cf79a8e2336e27a4f27b3fb55325b6?relay=wss://relay.getalby.com/v1&secret=ace5c4b9e08138a2ef91b4ccf1379952c77c651866b29f5872b5165134417894"
+
+#VITE_MEMPOOL_URL=https://mempool.space

--- a/frontend/src/components/CloseChannelDialogContent.tsx
+++ b/frontend/src/components/CloseChannelDialogContent.tsx
@@ -13,6 +13,7 @@ import { Button } from "src/components/ui/button";
 import { Label } from "src/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "src/components/ui/radio-group";
 import { useToast } from "src/components/ui/use-toast";
+import { MEMPOOL_URL } from "src/constants";
 import { useBalances } from "src/hooks/useBalances";
 import { useChannels } from "src/hooks/useChannels";
 import { copyToClipboard } from "src/lib/clipboard";
@@ -241,7 +242,7 @@ export function CloseChannelDialogContent({ alias, channel }: Props) {
                 />
               </div>
               <ExternalLink
-                to={`https://mempool.space/tx/${fundingTxId}`}
+                to={`${MEMPOOL_URL}/tx/${fundingTxId}`}
                 className="underline flex items-center mt-2"
               >
                 View on Mempool

--- a/frontend/src/components/MempoolAlert.tsx
+++ b/frontend/src/components/MempoolAlert.tsx
@@ -1,6 +1,7 @@
 import { TriangleAlertIcon } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
 import { ExternalLinkButton } from "src/components/ui/button";
+import { MEMPOOL_URL } from "src/constants";
 import { useMempoolApi } from "src/hooks/useMempoolApi";
 
 export function MempoolAlert({ className }: { className?: string }) {
@@ -41,11 +42,7 @@ export function MempoolAlert({ className }: { className?: string }) {
           >
             Learn more
           </ExternalLinkButton>
-          <ExternalLinkButton
-            to="https://mempool.space"
-            size={"sm"}
-            variant="secondary"
-          >
+          <ExternalLinkButton to={MEMPOOL_URL} size={"sm"} variant="secondary">
             View fees on mempool
           </ExternalLinkButton>
         </div>

--- a/frontend/src/components/channels/ChannelDropdownMenu.tsx
+++ b/frontend/src/components/channels/ChannelDropdownMenu.tsx
@@ -20,6 +20,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "src/components/ui/dropdown-menu.tsx";
+import { MEMPOOL_URL } from "src/constants";
 import { Channel } from "src/types";
 
 type ChannelDropdownMenuProps = {
@@ -58,7 +59,7 @@ export function ChannelDropdownMenu({
         <DropdownMenuContent align="end">
           <DropdownMenuItem className="flex flex-row items-center gap-2 cursor-pointer">
             <ExternalLink
-              to={`https://mempool.space/tx/${channel.fundingTxId}#flow=&vout=${channel.fundingTxVout}`}
+              to={`${MEMPOOL_URL}/tx/${channel.fundingTxId}#flow=&vout=${channel.fundingTxVout}`}
               className="w-full flex flex-row items-center gap-2"
             >
               <ExternalLinkIcon className="w-4 h-4" />

--- a/frontend/src/components/channels/OnchainTransactionsTable.tsx
+++ b/frontend/src/components/channels/OnchainTransactionsTable.tsx
@@ -8,6 +8,7 @@ import {
   CardTitle,
 } from "src/components/ui/card";
 import { Table, TableBody, TableCell, TableRow } from "src/components/ui/table";
+import { MEMPOOL_URL } from "src/constants";
 import { useOnchainTransactions } from "src/hooks/useOnchainTransactions";
 import { cn } from "src/lib/utils";
 
@@ -33,10 +34,7 @@ export function OnchainTransactionsTable() {
                   key={tx.txId}
                   className="cursor-pointer"
                   onClick={() => {
-                    window.open(
-                      `https://mempool.space/tx/${tx.txId}`,
-                      "_blank"
-                    );
+                    window.open(`${MEMPOOL_URL}/tx/${tx.txId}`, "_blank");
                   }}
                 >
                   <TableCell className="flex items-center gap-2">

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -19,3 +19,6 @@ export const SUPPORT_ALBY_CONNECTION_NAME = `ZapPlanner - Alby Hub`;
 export const SUPPORT_ALBY_LIGHTNING_ADDRESS = "hub@getalby.com";
 
 export const SUBWALLET_APPSTORE_APP_ID = "uncle-jim";
+
+export const MEMPOOL_URL =
+  import.meta.env.VITE_MEMPOOL_URL || "https://mempool.space";

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -55,7 +55,7 @@ import {
 } from "src/components/ui/tooltip.tsx";
 import { useToast } from "src/components/ui/use-toast.ts";
 import { UpgradeDialog } from "src/components/UpgradeDialog";
-import { ONCHAIN_DUST_SATS } from "src/constants.ts";
+import { MEMPOOL_URL, ONCHAIN_DUST_SATS } from "src/constants.ts";
 import { useAlbyMe } from "src/hooks/useAlbyMe";
 import { useBalances } from "src/hooks/useBalances.ts";
 import { useChannels } from "src/hooks/useChannels";
@@ -631,7 +631,7 @@ export default function Channels() {
                       ({new Intl.NumberFormat().format(details.amount)}{" "}
                       sats)&nbsp;
                       <ExternalLink
-                        to={`https://mempool.space/tx/${details.fundingTxId}#flow=&vout=${details.fundingTxVout}`}
+                        to={`${MEMPOOL_URL}/tx/${details.fundingTxId}#flow=&vout=${details.fundingTxVout}`}
                         className="underline"
                       >
                         funding tx

--- a/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
+++ b/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
@@ -26,7 +26,7 @@ import { Input } from "src/components/ui/input";
 import { Label } from "src/components/ui/label";
 import { LoadingButton } from "src/components/ui/loading-button";
 import { useToast } from "src/components/ui/use-toast";
-import { ONCHAIN_DUST_SATS } from "src/constants";
+import { MEMPOOL_URL, ONCHAIN_DUST_SATS } from "src/constants";
 import { useBalances } from "src/hooks/useBalances";
 import { useChannels } from "src/hooks/useChannels";
 import { useInfo } from "src/hooks/useInfo";
@@ -144,7 +144,7 @@ export default function WithdrawOnchainFunds() {
           />
         </div>
         <ExternalLink
-          to={`https://mempool.space/tx/${transactionId}`}
+          to={`${MEMPOOL_URL}/tx/${transactionId}`}
           className="underline flex items-center mt-2"
         >
           View on Mempool
@@ -309,10 +309,7 @@ export default function WithdrawOnchainFunds() {
                       >
                         High priority: {recommendedFees.fastestFee}
                       </Button>{" "}
-                      <ExternalLink
-                        to="https://mempool.space"
-                        className="underline ml-2"
-                      >
+                      <ExternalLink to={MEMPOOL_URL} className="underline ml-2">
                         mempool.space
                       </ExternalLink>
                     </p>


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/1412

This allows users to set a custom mempool URL for the frontend. But I'm thinking if we can change the backend env var from `MEMPOOL_API` to `MEMPOOL_URL` and use it everywhere (not sure how to pass it to frontend though + it would also be a breaking change)