### PR TITLE
docs: use local update script for pi hubs

### DIFF
--- a/scripts/pi-aarch64/README.md
+++ b/scripts/pi-aarch64/README.md
@@ -6,15 +6,13 @@ You should have some basic Linux understanding to install and operate it.
 Have a look at our [installation guide](https://github.com/getAlby/hub/tree/master/scripts/pi-arm) for more details and inspiration.
 
 SSH into your Pi and run:
+
 ```shell
 /bin/bash -c "$(curl -fsSL https://getalby.com/install/hub/pi-aarch64-install.sh)"
 ```
 
 ### Updating a running instance
 
-SSH into your Pi and run:
-```shell
-/bin/bash -c "$(curl -fsSL https://getalby.com/install/hub/pi-aarch64-update.sh)"
-```
+SSH into your Pi and cd into `/opt/albyhub`
 
-And see install.sh and update.sh for details.
+Run `./update.sh`

--- a/scripts/pi-arm/README.md
+++ b/scripts/pi-arm/README.md
@@ -11,10 +11,6 @@ SSH into your Pi and run:
 
 ### Updating a running instance
 
-SSH into your Pi and run:
+SSH into your Pi and cd into `/opt/albyhub`
 
-```shell
-/bin/bash -c "$(curl -fsSL https://getalby.com/install/hub/pi-zero-update.sh)"
-```
-
-And see install.sh and update.sh for details.
+Run `./update.sh`


### PR DESCRIPTION
We don't want to recommend downloading the update script every time as it renders the verify step useless.

See https://github.com/getAlby/hub/pull/1220#issuecomment-2997162063