### PR TITLE
chore: increase lnd wait time before retrying

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -25,6 +25,15 @@ func main() {
 	signal.Notify(osSignalChannel, os.Interrupt, syscall.SIGTERM)
 
 	ctx, cancel := context.WithCancel(context.Background())
+
+	var signal os.Signal
+	go func() {
+		// wait for exit signal
+		signal = <-osSignalChannel
+		logger.Logger.WithField("signal", signal).Info("Received OS signal")
+		cancel()
+	}()
+
 	svc, err := service.NewService(ctx)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to create service")
@@ -42,14 +51,6 @@ func main() {
 			logger.Logger.WithError(err).Error("echo server failed to start")
 			cancel()
 		}
-	}()
-
-	var signal os.Signal
-	go func() {
-		// wait for exit signal
-		signal = <-osSignalChannel
-		logger.Logger.WithField("signal", signal).Info("Received OS signal")
-		cancel()
 	}()
 
 	//handle graceful shutdown

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -60,7 +60,7 @@ func NewLNDService(ctx context.Context, eventPublisher events.EventPublisher, ln
 	}
 
 	var nodeInfo *lnclient.NodeInfo
-	maxRetries := 5
+	maxRetries := 60
 	for i := range maxRetries {
 		nodeInfo, err = fetchNodeInfo(ctx, lndClient)
 		if err == nil {
@@ -68,10 +68,10 @@ func NewLNDService(ctx context.Context, eventPublisher events.EventPublisher, ln
 		}
 		logger.Logger.WithFields(logrus.Fields{
 			"iteration": i,
-		}).WithError(err).Error("Failed to connect to LND, retrying in 30s")
+		}).WithError(err).Error("Failed to connect to LND, retrying in 10s")
 
 		select {
-		case <-time.After(30 * time.Second):
+		case <-time.After(10 * time.Second):
 		case <-ctx.Done():
 			logger.Logger.WithError(ctx.Err()).Error("Context cancelled during LND connection retries")
 			return nil, ctx.Err()

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -68,8 +68,14 @@ func NewLNDService(ctx context.Context, eventPublisher events.EventPublisher, ln
 		}
 		logger.Logger.WithFields(logrus.Fields{
 			"iteration": i,
-		}).WithError(err).Error("Failed to connect to LND, retrying in 10s")
-		time.Sleep(10 * time.Second)
+		}).WithError(err).Error("Failed to connect to LND, retrying in 30s")
+
+		select {
+		case <-time.After(30 * time.Second):
+		case <-ctx.Done():
+			logger.Logger.WithError(ctx.Err()).Error("Context cancelled during LND connection retries")
+			return nil, ctx.Err()
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/1437 by increasing wait time to 30s (should it be 1 minute?) cc @rolznz

And also addresses the issue where hitting `Ctrl+C` doesn't stop the app immediately because the os signal goroutine is registered after service creation.