### PR TITLE
feat: show alerts if send amount is larger than next spendable mpp

### DIFF
--- a/frontend/src/components/SpendingAlert.tsx
+++ b/frontend/src/components/SpendingAlert.tsx
@@ -1,17 +1,21 @@
 import { AlertTriangleIcon } from "lucide-react";
-import { Link } from "react-router-dom";
 import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
 
-export function SpendingAlert({ className }: { className?: string }) {
+export function SpendingAlert({
+  className,
+  maxSpendable,
+}: {
+  className?: string;
+  maxSpendable: number;
+}) {
   return (
     <Alert className={className}>
       <AlertTriangleIcon className="h-4 w-4" />
-      <AlertTitle>Low spending capacity</AlertTitle>
+      <AlertTitle>Channel Liquidity Too Low</AlertTitle>
       <AlertDescription>
-        You won't be able to send payments until you{" "}
-        <Link className="underline" to="/channels/outgoing">
-          increase your spending capacity.
-        </Link>
+        Your payment will likely fail because your maximum spendable amount for
+        the next payment is currently{" "}
+        {new Intl.NumberFormat().format(Math.floor(maxSpendable / 1000))} sats.
       </AlertDescription>
     </Alert>
   );

--- a/frontend/src/components/SpendingAlert.tsx
+++ b/frontend/src/components/SpendingAlert.tsx
@@ -11,9 +11,9 @@ export function SpendingAlert({
   return (
     <Alert className={className}>
       <AlertTriangleIcon className="h-4 w-4" />
-      <AlertTitle>Channel Liquidity Too Low</AlertTitle>
+      <AlertTitle>Maximum Spendable Balance Too Low</AlertTitle>
       <AlertDescription>
-        Your payment will likely fail because your maximum spendable amount for
+        Your payment will likely fail because your maximum spendable balance for
         the next payment is currently{" "}
         {new Intl.NumberFormat().format(Math.floor(maxSpendable / 1000))} sats.
       </AlertDescription>

--- a/frontend/src/components/SpendingAlert.tsx
+++ b/frontend/src/components/SpendingAlert.tsx
@@ -1,0 +1,18 @@
+import { AlertTriangleIcon } from "lucide-react";
+import { Link } from "react-router-dom";
+import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
+
+export function SpendingAlert({ className }: { className?: string }) {
+  return (
+    <Alert className={className}>
+      <AlertTriangleIcon className="h-4 w-4" />
+      <AlertTitle>Low spending capacity</AlertTitle>
+      <AlertDescription>
+        You won't be able to send payments until you{" "}
+        <Link className="underline" to="/channels/outgoing">
+          increase your spending capacity.
+        </Link>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/frontend/src/screens/wallet/send/ConfirmPayment.tsx
+++ b/frontend/src/screens/wallet/send/ConfirmPayment.tsx
@@ -78,12 +78,14 @@ export default function ConfirmPayment() {
     return <Loading />;
   }
 
-  const maxSpendable =
+  const maxSpendable = Math.max(
     balances.lightning.nextMaxSpendableMPP -
-    Math.max(
-      0.01 * balances.lightning.nextMaxSpendableMPP,
-      10000
-    ); /* fee reserve */
+      Math.max(
+        0.01 * balances.lightning.nextMaxSpendableMPP,
+        10000 /* fee reserve */
+      ),
+    0
+  );
 
   return (
     <form onSubmit={onSubmit} className="grid gap-4">

--- a/frontend/src/screens/wallet/send/ConfirmPayment.tsx
+++ b/frontend/src/screens/wallet/send/ConfirmPayment.tsx
@@ -78,17 +78,17 @@ export default function ConfirmPayment() {
     return <Loading />;
   }
 
+  const maxSpendable =
+    balances.lightning.nextMaxSpendableMPP -
+    Math.max(
+      0.01 * balances.lightning.nextMaxSpendableMPP,
+      10000
+    ); /* fee reserve */
+
   return (
     <form onSubmit={onSubmit} className="grid gap-4">
-      {hasChannelManagement &&
-        (amount || 0) * 1000 >=
-          balances.lightning.nextMaxSpendableMPP -
-            Math.max(
-              0.01 * balances.lightning.nextMaxSpendableMPP,
-              10000
-            ) /* fee reserve */ && <SpendingAlert />}
-      <div>
-        <p className="font-medium text-lg mb-2">Payment Details</p>
+      <div className="grid gap-2">
+        <p className="font-medium text-lg">Payment Details</p>
         <div>
           <Label>Amount</Label>
           <p className="text-xl font-bold slashed-zero">
@@ -97,12 +97,16 @@ export default function ConfirmPayment() {
           <FormattedFiatAmount amount={amount || invoice.satoshi} />
         </div>
         {invoice.description && (
-          <div className="mt-2 break-all">
+          <div className="break-all">
             <Label>Description</Label>
             <p className="text-muted-foreground">{invoice.description}</p>
           </div>
         )}
       </div>
+      {hasChannelManagement &&
+        (amount || invoice.satoshi || 0) * 1000 >= maxSpendable && (
+          <SpendingAlert maxSpendable={maxSpendable} />
+        )}
       <div className="flex gap-4">
         <LoadingButton loading={isLoading} type="submit" autoFocus>
           Confirm Payment

--- a/frontend/src/screens/wallet/send/LnurlPay.tsx
+++ b/frontend/src/screens/wallet/send/LnurlPay.tsx
@@ -70,26 +70,26 @@ export default function LnurlPay() {
     return <Loading />;
   }
 
+  const maxSpendable =
+    balances.lightning.nextMaxSpendableMPP -
+    Math.max(
+      0.01 * balances.lightning.nextMaxSpendableMPP,
+      10000
+    ); /* fee reserve */
+
   return (
     <form onSubmit={onSubmit} className="grid gap-4">
-      {hasChannelManagement &&
-        parseInt(amount || "0") * 1000 >=
-          balances.lightning.nextMaxSpendableMPP -
-            Math.max(
-              0.01 * balances.lightning.nextMaxSpendableMPP,
-              10000
-            ) /* fee reserve */ && <SpendingAlert />}
-      <div>
-        <p className="font-medium text-lg mb-2">{lnAddress.address}</p>
+      <div className="grid gap-2">
+        <p className="font-medium text-lg">{lnAddress.address}</p>
         {lnAddress.lnurlpData?.description && (
-          <div className="mb-2">
+          <div>
             <Label>Description</Label>
             <p className="text-muted-foreground">
               {lnAddress.lnurlpData.description}
             </p>
           </div>
         )}
-        <div className="mb-2">
+        <div>
           <Label htmlFor="amount">Amount</Label>
           <Input
             id="amount"
@@ -105,7 +105,7 @@ export default function LnurlPay() {
           />
         </div>
         {!!lnAddress.lnurlpData?.commentAllowed && (
-          <div className="mb-2">
+          <div>
             <Label htmlFor="comment">Comment</Label>
             <Input
               id="comment"
@@ -119,6 +119,10 @@ export default function LnurlPay() {
           </div>
         )}
       </div>
+      {hasChannelManagement &&
+        parseInt(amount || "0") * 1000 >= maxSpendable && (
+          <SpendingAlert maxSpendable={maxSpendable} />
+        )}
       <div className="flex gap-4">
         <LoadingButton loading={isLoading} type="submit">
           Continue

--- a/frontend/src/screens/wallet/send/LnurlPay.tsx
+++ b/frontend/src/screens/wallet/send/LnurlPay.tsx
@@ -2,21 +2,18 @@ import { LightningAddress } from "@getalby/lightning-tools";
 import React from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import Loading from "src/components/Loading";
-import { SpendingAlert } from "src/components/SpendingAlert";
 import { Button } from "src/components/ui/button";
 import { Input } from "src/components/ui/input";
 import { Label } from "src/components/ui/label";
 import { LoadingButton } from "src/components/ui/loading-button";
 import { useToast } from "src/components/ui/use-toast";
 import { useBalances } from "src/hooks/useBalances";
-import { useInfo } from "src/hooks/useInfo";
 import { TransactionMetadata } from "src/types";
 
 export default function LnurlPay() {
   const { state } = useLocation();
   const navigate = useNavigate();
   const { toast } = useToast();
-  const { hasChannelManagement } = useInfo();
   const { data: balances } = useBalances();
 
   const lnAddress = state?.args?.lnAddress as LightningAddress;
@@ -70,13 +67,6 @@ export default function LnurlPay() {
     return <Loading />;
   }
 
-  const maxSpendable =
-    balances.lightning.nextMaxSpendableMPP -
-    Math.max(
-      0.01 * balances.lightning.nextMaxSpendableMPP,
-      10000
-    ); /* fee reserve */
-
   return (
     <form onSubmit={onSubmit} className="grid gap-4">
       <div className="grid gap-2">
@@ -119,10 +109,6 @@ export default function LnurlPay() {
           </div>
         )}
       </div>
-      {hasChannelManagement &&
-        parseInt(amount || "0") * 1000 >= maxSpendable && (
-          <SpendingAlert maxSpendable={maxSpendable} />
-        )}
       <div className="flex gap-4">
         <LoadingButton loading={isLoading} type="submit">
           Continue


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/1435

Adds a SpendingAlert component and shows it whenever input/invoice amount is more than `nextMaxSpendableMPP - fee reserve`

## Screenshot
<img width="1470" alt="Screenshot 2025-07-02 at 6 37 04 PM" src="https://github.com/user-attachments/assets/960e6c16-c634-4bd4-bc4b-c481428b350a" />

