### PR TITLE
Add spending recommendations

### DIFF
--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -375,7 +375,11 @@ export default function Channels() {
                   <AlertTriangleIcon className="h-4 w-4" />
                   <AlertTitle>Low receiving limit</AlertTitle>
                   <AlertDescription>
-                    You likely won't be able to receive payments until you spend or{" "}
+                    You likely won't be able to receive payments until you{" "}
+                    <Link className="underline" to="/wallet/send">
+                      spend
+                    </Link>
+                    ,{" "}
                     <Link
                       className="underline"
                       to="#"

--- a/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
@@ -111,9 +111,17 @@ export default function ReceiveInvoice() {
               0.8 * balances.lightning.totalReceivable && (
               <Alert>
                 <AlertTriangleIcon className="h-4 w-4" />
-                <AlertTitle>Low receiving capacity</AlertTitle>
+                <AlertTitle>Low receiving limit</AlertTitle>
                 <AlertDescription>
-                  You likely won't be able to receive payments until you spend or{" "}
+                  You likely won't be able to receive payments until you{" "}
+                  <Link className="underline" to="/wallet/send">
+                    spend
+                  </Link>
+                  ,{" "}
+                  <Link className="underline" to="/channels?swap=true">
+                    swap out funds
+                  </Link>
+                  , or{" "}
                   <Link className="underline" to="/channels/incoming">
                     increase your receiving capacity.
                   </Link>


### PR DESCRIPTION
Users can also increase their receiving capacity by spending funds.

Should we align both notifications? One of them also mentions swaps as a way to increase receiving capacity. We could mention that on [frontend/src/screens/wallet/receive/ReceiveInvoice.tsx](https://github.com/getAlby/hub/blob/66a1be6d162f6ffb22f801a10f4c023ae6a93059/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx#L116) too.