### PR TITLE
fix: improve readability of alerts in dark themes

### DIFF
--- a/frontend/src/themes/alby.css
+++ b/frontend/src/themes/alby.css
@@ -56,7 +56,7 @@
   --accent-foreground: 0 0% 98%;
 
   --destructive: 0 84% 60%;
-  --destructive-foreground: 0 0% 98%;
+  --destructive-foreground: 0 62.8% 30.6%;
 
   --warning: 33 90% 96%;
   --warning-foreground: 21 90% 48%;

--- a/frontend/src/themes/bitcoin.css
+++ b/frontend/src/themes/bitcoin.css
@@ -59,7 +59,7 @@
   --accent-foreground: 0 0% 98%;
 
   --destructive: 0 84% 60%;
-  --destructive-foreground: 0 0% 98%;
+  --destructive-foreground: 0 62.8% 30.6%;
 
   --border: 40 5% 12%;
   --input: 45 4% 18%;

--- a/frontend/src/themes/default.css
+++ b/frontend/src/themes/default.css
@@ -50,8 +50,8 @@
   --muted-foreground: 240 5% 64.9%;
   --accent: 240 3.7% 15.9%;
   --accent-foreground: 0 0% 98%;
-  --destructive: 0 62.8% 30.6%;
-  --destructive-foreground: 0 0% 98%;
+  --destructive: 0 84% 60%;
+  --destructive-foreground: 0 62.8% 30.6%;
   --border: 240 3.7% 15.9%;
   --input: 240 3.7% 15.9%;
   --ring: 240 4.9% 83.9%;

--- a/frontend/src/themes/nostr.css
+++ b/frontend/src/themes/nostr.css
@@ -59,7 +59,7 @@
   --accent-foreground: 0 0% 98%;
 
   --destructive: 0 84% 60%;
-  --destructive-foreground: 0 0% 98%;
+  --destructive-foreground: 0 62.8% 30.6%;
 
   --border: 300 2% 12%;
   --input: 270 2% 18%;


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/63819e88-2ac1-4aeb-b0fa-78cbe0ea24ed)


After:
![image](https://github.com/user-attachments/assets/0c6c0b99-0415-4fc5-bfb5-c562843ed7de)
