### PR TITLE
feat: remove excess events

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -307,13 +307,22 @@ func (svc *service) removeExcessEvents() {
 		return
 	}
 	deleteEventsBelowId := events[numEventsToDelete].ID
+
 	logger.Logger.WithFields(logrus.Fields{
 		"amount":   numEventsToDelete,
 		"below_id": deleteEventsBelowId,
-	}).Info("Removing excess events")
+	}).Debug("Removing excess events")
 
 	err = svc.db.Exec("delete from request_events where id < ?", deleteEventsBelowId).Error
 	if err != nil {
-		logger.Logger.WithError(err).Error("Failed to delete excess request events")
+		logger.Logger.WithError(err).WithFields(logrus.Fields{
+			"amount":   numEventsToDelete,
+			"below_id": deleteEventsBelowId,
+		}).Error("Failed to delete excess request events")
+		return
 	}
+	logger.Logger.WithFields(logrus.Fields{
+		"amount":   numEventsToDelete,
+		"below_id": deleteEventsBelowId,
+	}).Info("Removed excess events")
 }


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/87

Tested by dropping the max events to 5 and changing the interval to 30 seconds
```
sqlite> select id from request_events;
2777
2778
2779
2780
2781
2782
sqlite> select id from request_events;
2778
2779
2780
2781
2782
```

> {"amount":1,"below_id":2778,"file":"service/service.go:313","func":"github.com/getAlby/hub/service.(*service).removeExcessEvents","level":"info","msg":"Removing excess events","time":"2025-07-10T13:41:45+07:00"}