### PR TITLE
fix: remove event deletion from migration

### DIFF
--- a/db/migrations/202508041712_delete_non_cascade_deleted_records.go
+++ b/db/migrations/202508041712_delete_non_cascade_deleted_records.go
@@ -18,26 +18,11 @@ var _202508041712_delete_non_cascade_deleted_records = &gormigrate.Migration{
 		// - app_permissions -> apps
 		// - request_events -> apps
 		// - response_events -> request_events
+		// however we will only delete app permissions.
+		// excess request and response events will be removed in batches by a background task.
 
-		if err := db.Transaction(func(tx *gorm.DB) error {
-
-			// delete orphaned app permissions
-			if err := tx.Exec(`DELETE FROM app_permissions
+		if err := db.Exec(`DELETE FROM app_permissions
 WHERE app_id NOT IN (SELECT id FROM apps)`).Error; err != nil {
-				return err
-			}
-
-			// delete request and response events, later we will setup a task to delete excess events
-			if err := tx.Exec(`DELETE FROM request_events`).Error; err != nil {
-				return err
-			}
-
-			if err := tx.Exec(`DELETE FROM response_events`).Error; err != nil {
-				return err
-			}
-
-			return nil
-		}); err != nil {
 			return err
 		}
 

--- a/service/service.go
+++ b/service/service.go
@@ -326,4 +326,15 @@ func (svc *service) removeExcessEvents() {
 		"amount":   numEventsToDelete,
 		"below_id": deleteEventsBelowId,
 	}).Info("Removed excess events")
+
+	// TODO: REMOVE AFTER 2025-01-01
+	// this is needed due to cascading delete previously not working
+	err = svc.db.Exec("delete from response_events where request_id < ?", deleteEventsBelowId).Error
+	if err != nil {
+		logger.Logger.WithError(err).WithFields(logrus.Fields{
+			"amount":   numEventsToDelete,
+			"below_id": deleteEventsBelowId,
+		}).Error("Failed to delete excess response events")
+		return
+	}
 }


### PR DESCRIPTION
Deleting all at once is too slow for hubs that have many events. Instead we will use the background task to slowly remove excess events in batches.