### PR TITLE
feat: include fees with amount in transaction lists

### DIFF
--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -196,17 +196,31 @@ function TransactionItem({ tx }: Props) {
                   {type == "outgoing" ? "-" : "+"}
                   <span className="font-medium">
                     {new Intl.NumberFormat().format(
-                      Math.floor(tx.amount / 1000)
+                      Math.floor(
+                        type === "outgoing" && tx.state !== "failed"
+                          ? (tx.amount + tx.feesPaid) / 1000
+                          : tx.amount / 1000
+                      )
                     )}
                   </span>
                 </p>
                 <p className="text-muted-foreground">
-                  {Math.floor(tx.amount / 1000) == 1 ? "sat" : "sats"}
+                  {Math.floor(
+                    type === "outgoing" && tx.state !== "failed"
+                      ? (tx.amount + tx.feesPaid) / 1000
+                      : tx.amount / 1000
+                  ) == 1
+                    ? "sat"
+                    : "sats"}
                 </p>
               </div>
               <FormattedFiatAmount
                 className="text-xs md:text-base"
-                amount={Math.floor(tx.amount / 1000)}
+                amount={Math.floor(
+                  type === "outgoing" && tx.state !== "failed"
+                    ? (tx.amount + tx.feesPaid) / 1000
+                    : tx.amount / 1000
+                )}
               />
             </div>
           </div>
@@ -227,10 +241,28 @@ function TransactionItem({ tx }: Props) {
               {typeStateIcon}
               <div className="ml-4">
                 <p className="text-xl md:text-2xl font-semibold sensitive">
-                  {new Intl.NumberFormat().format(Math.floor(tx.amount / 1000))}{" "}
-                  {Math.floor(tx.amount / 1000) == 1 ? "sat" : "sats"}
+                  {new Intl.NumberFormat().format(
+                    Math.floor(
+                      type === "outgoing" && tx.state !== "failed"
+                        ? (tx.amount + tx.feesPaid) / 1000
+                        : tx.amount / 1000
+                    )
+                  )}{" "}
+                  {Math.floor(
+                    type === "outgoing" && tx.state !== "failed"
+                      ? (tx.amount + tx.feesPaid) / 1000
+                      : tx.amount / 1000
+                  ) == 1
+                    ? "sat"
+                    : "sats"}
                 </p>
-                <FormattedFiatAmount amount={Math.floor(tx.amount / 1000)} />
+                <FormattedFiatAmount
+                  amount={Math.floor(
+                    type === "outgoing" && tx.state !== "failed"
+                      ? (tx.amount + tx.feesPaid) / 1000
+                      : tx.amount / 1000
+                  )}
+                />
               </div>
             </div>
             {app && (
@@ -276,13 +308,38 @@ function TransactionItem({ tx }: Props) {
             </div>
             {tx.state != "failed" && type == "outgoing" && (
               <div className="mt-6">
-                <p>Fee</p>
-                <p className="text-muted-foreground">
-                  {new Intl.NumberFormat().format(
-                    Math.floor(tx.feesPaid / 1000)
-                  )}{" "}
-                  {Math.floor(tx.feesPaid / 1000) == 1 ? "sat" : "sats"}
-                </p>
+                <p>Amount Breakdown</p>
+                <div className="text-muted-foreground space-y-1">
+                  <div className="flex justify-between">
+                    <span>Payment amount:</span>
+                    <span>
+                      {new Intl.NumberFormat().format(
+                        Math.floor(tx.amount / 1000)
+                      )}{" "}
+                      {Math.floor(tx.amount / 1000) == 1 ? "sat" : "sats"}
+                    </span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span>Fee:</span>
+                    <span>
+                      {new Intl.NumberFormat().format(
+                        Math.floor(tx.feesPaid / 1000)
+                      )}{" "}
+                      {Math.floor(tx.feesPaid / 1000) == 1 ? "sat" : "sats"}
+                    </span>
+                  </div>
+                  <div className="flex justify-between border-t pt-1 font-medium text-foreground">
+                    <span>Total sent:</span>
+                    <span>
+                      {new Intl.NumberFormat().format(
+                        Math.floor((tx.amount + tx.feesPaid) / 1000)
+                      )}{" "}
+                      {Math.floor((tx.amount + tx.feesPaid) / 1000) == 1
+                        ? "sat"
+                        : "sats"}
+                    </span>
+                  </div>
+                </div>
               </div>
             )}
             {tx.description && (


### PR DESCRIPTION
fixes #464 

Changes:

Showed amount + fees in the transactions lists and once user clicks on a particular transaction, it will be shown like this 

<img width="562" height="419" alt="Screenshot from 2025-07-22 02-09-15" src="https://github.com/user-attachments/assets/0bad7c75-d95f-4ae1-bb63-da3c61ff6810" />
