### PR TITLE
fix: add alert dialog and loading spinner to delete app button

### DIFF
--- a/frontend/src/screens/apps/AppsCleanup.tsx
+++ b/frontend/src/screens/apps/AppsCleanup.tsx
@@ -5,6 +5,7 @@ import AppCard from "src/components/connections/AppCard";
 import Loading from "src/components/Loading";
 import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
 import { Button, LinkButton } from "src/components/ui/button";
+import { LoadingButton } from "src/components/ui/loading-button";
 import {
   Card,
   CardDescription,
@@ -23,7 +24,7 @@ export function AppsCleanup() {
   const [skippedCount, setSkippedCount] = React.useState<number>(0);
   const [deletedCount, setDeletedCount] = React.useState<number>(0);
   const [appsToReview, setAppsToReview] = React.useState<App[]>();
-  const { deleteApp } = useDeleteApp();
+  const { deleteApp, isDeleting } = useDeleteApp();
   React.useEffect(() => {
     if (!unusedApps) {
       return;
@@ -85,8 +86,9 @@ export function AppsCleanup() {
                         <SkipForwardIcon className="h-4 w-4 mr-2" />
                         Skip
                       </Button>
-                      <Button
+                      <LoadingButton
                         variant="destructive"
+                        loading={isDeleting}
                         onClick={() => {
                           deleteApp(currentApp.appPubkey);
                           setAppIndex(appIndex + 1);
@@ -95,7 +97,7 @@ export function AppsCleanup() {
                       >
                         <Trash2Icon className="h-4 w-4 mr-2" />
                         Delete
-                      </Button>
+                      </LoadingButton>
                     </>
                   }
                   readonly

--- a/frontend/src/screens/apps/ShowApp.tsx
+++ b/frontend/src/screens/apps/ShowApp.tsx
@@ -23,7 +23,6 @@ import Permissions from "src/components/Permissions";
 import TransactionsList from "src/components/TransactionsList";
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -228,12 +227,12 @@ function AppInternal({ app, refetchApp, capabilities }: AppInternalProps) {
                   </AlertDialogHeader>
                   <AlertDialogFooter>
                     <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction
+                    <LoadingButton
                       onClick={() => deleteApp(app.appPubkey)}
-                      disabled={isDeleting}
+                      loading={isDeleting}
                     >
                       Continue
-                    </AlertDialogAction>
+                    </LoadingButton>
                   </AlertDialogFooter>
                 </AlertDialogContent>
               </AlertDialog>


### PR DESCRIPTION
fixes #17 

## Changes:

I have added a alert dialog box and the loading spinner. 

<img width="913" height="508" alt="Screenshot from 2025-07-22 03-35-09" src="https://github.com/user-attachments/assets/2c459c16-41f2-4026-8a13-8be1c6c61e7d" />

and when user clicks on the continue button, the button becomes loading.

## One Issue: 
Though I have tested it and it works fine, but the loading spinning state is so fast and disappears so fast that it's not easy to notice.