### PR TITLE
fix: ignore sigpipe signal

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -22,7 +22,7 @@ func main() {
 	// Create a channel to receive OS signals.
 	osSignalChannel := make(chan os.Signal, 1)
 	// Notify the channel on os.Interrupt, syscall.SIGTERM. os.Kill cannot be caught.
-	signal.Notify(osSignalChannel, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(osSignalChannel, os.Interrupt, syscall.SIGTERM, syscall.SIGPIPE)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -31,6 +31,12 @@ func main() {
 		// wait for exit signal
 		signal = <-osSignalChannel
 		logger.Logger.WithField("signal", signal).Info("Received OS signal")
+
+		if signal == syscall.SIGPIPE {
+			logger.Logger.WithField("signal", signal).Warn("Ignoring SIGPIPE signal")
+			return
+		}
+
 		cancel()
 	}()
 


### PR DESCRIPTION
It is unclear right now where this is coming from but it's causing the app to be restarted for some of our cloud instances. Possibly it could be due to log forwarding or something on the LDK side (I also saw this with one of our users who had a Breez backend). By ignoring it, it should hopefully trigger an error which can be caught and hopefully we get extra logs as to what caused it in the first place