### PR TITLE
feat: add convert to sub-wallet button for isolated apps

### DIFF
--- a/frontend/src/screens/apps/ShowApp.tsx
+++ b/frontend/src/screens/apps/ShowApp.tsx
@@ -18,6 +18,7 @@ import {
   AlertCircleIcon,
   PencilIcon,
   Settings2Icon,
+  SquareStackIcon,
   Trash2Icon,
 } from "lucide-react";
 import AppAvatar from "src/components/AppAvatar";
@@ -172,7 +173,7 @@ function AppInternal({ app, refetchApp, capabilities }: AppInternalProps) {
     try {
       const updateAppRequest: UpdateAppRequest = {
         name: app.name,
-        scopes: Array.from(app.scopes),
+        scopes: app.scopes,
         budgetRenewal: app.budgetRenewal,
         expiresAt: app.expiresAt,
         maxAmount: app.maxAmount,
@@ -250,8 +251,7 @@ function AppInternal({ app, refetchApp, capabilities }: AppInternalProps) {
             contentRight={
               <div className="flex gap-2 items-center">
                 {app.isolated &&
-                  app.metadata?.app_store_app_id !==
-                    SUBWALLET_APPSTORE_APP_ID &&
+                  !app.metadata?.app_store_app_id &&
                   albyMe?.subscription.plan_code && (
                     <DropdownMenu modal={false}>
                       <DropdownMenuTrigger asChild>
@@ -263,10 +263,11 @@ function AppInternal({ app, refetchApp, capabilities }: AppInternalProps) {
                         <DropdownMenuGroup>
                           <DropdownMenuItem>
                             <div
-                              className="w-full cursor-pointer"
+                              className="w-full cursor-pointer flex items-center gap-2"
                               onClick={handleConvertToSubwallet}
                             >
-                              Convert to Sub-wallet
+                              <SquareStackIcon className="w-4 h-4" /> Convert to
+                              Sub-wallet
                             </div>
                           </DropdownMenuItem>
                         </DropdownMenuGroup>

--- a/frontend/src/screens/apps/ShowApp.tsx
+++ b/frontend/src/screens/apps/ShowApp.tsx
@@ -14,7 +14,12 @@ import {
 import { handleRequestError } from "src/utils/handleRequestError";
 import { request } from "src/utils/request"; // build the project for this to appear
 
-import { AlertCircleIcon, PencilIcon, Trash2Icon } from "lucide-react";
+import {
+  AlertCircleIcon,
+  PencilIcon,
+  Settings2Icon,
+  Trash2Icon,
+} from "lucide-react";
 import AppAvatar from "src/components/AppAvatar";
 import AppHeader from "src/components/AppHeader";
 import { IsolatedAppTopupDialog } from "src/components/IsolatedAppTopupDialog";
@@ -39,6 +44,13 @@ import {
   CardHeader,
   CardTitle,
 } from "src/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "src/components/ui/dropdown-menu";
 import { Input } from "src/components/ui/input";
 import { LoadingButton } from "src/components/ui/loading-button";
 import { Table, TableBody, TableCell, TableRow } from "src/components/ui/table";
@@ -145,7 +157,7 @@ function AppInternal({ app, refetchApp, capabilities }: AppInternalProps) {
         body: JSON.stringify(updateAppRequest),
       });
 
-      await refetchApp();
+      refetchApp();
       setIsEditingName(false);
       setIsEditingPermissions(false);
       toast({
@@ -153,6 +165,39 @@ function AppInternal({ app, refetchApp, capabilities }: AppInternalProps) {
       });
     } catch (error) {
       handleRequestError(toast, "Failed to update connection", error);
+    }
+  };
+
+  const handleConvertToSubwallet = async () => {
+    try {
+      const updateAppRequest: UpdateAppRequest = {
+        name: app.name,
+        scopes: Array.from(app.scopes),
+        budgetRenewal: app.budgetRenewal,
+        expiresAt: app.expiresAt,
+        maxAmount: app.maxAmount,
+        isolated: app.isolated,
+        metadata: {
+          ...app.metadata,
+          app_store_app_id: SUBWALLET_APPSTORE_APP_ID,
+        },
+      };
+
+      await request(`/api/apps/${app.appPubkey}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(updateAppRequest),
+      });
+
+      refetchApp();
+      toast({
+        title: "Successfully converted to sub-wallet",
+        description: "This isolated app is now a sub-wallet.",
+      });
+    } catch (error) {
+      handleRequestError(toast, "Failed to convert to sub-wallet", error);
     }
   };
 
@@ -203,40 +248,66 @@ function AppInternal({ app, refetchApp, capabilities }: AppInternalProps) {
               </div>
             }
             contentRight={
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button variant="destructive" size="icon">
-                    <Trash2Icon className="w-4 h-4" />
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>
-                      Are you sure you want to delete this connection?
-                    </AlertDialogTitle>
-                    <AlertDialogDescription>
-                      Connected apps will no longer be able to use this
-                      connection.
-                      {app.isolated && (
-                        <>
-                          {" "}
-                          No funds will be lost during this process, the balance
-                          will remain in your wallet.
-                        </>
-                      )}
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction
-                      onClick={() => deleteApp(app.appPubkey)}
-                      disabled={isDeleting}
-                    >
-                      Continue
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
+              <div className="flex gap-2 items-center">
+                {app.isolated &&
+                  app.metadata?.app_store_app_id !==
+                    SUBWALLET_APPSTORE_APP_ID &&
+                  albyMe?.subscription.plan_code && (
+                    <DropdownMenu modal={false}>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="outline" size="icon">
+                          <Settings2Icon className="w-4 h-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent className="w-56">
+                        <DropdownMenuGroup>
+                          <DropdownMenuItem>
+                            <div
+                              className="w-full cursor-pointer"
+                              onClick={handleConvertToSubwallet}
+                            >
+                              Convert to Sub-wallet
+                            </div>
+                          </DropdownMenuItem>
+                        </DropdownMenuGroup>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button variant="destructive" size="icon">
+                      <Trash2Icon className="w-4 h-4" />
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>
+                        Are you sure you want to delete this connection?
+                      </AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Connected apps will no longer be able to use this
+                        connection.
+                        {app.isolated && (
+                          <>
+                            {" "}
+                            No funds will be lost during this process, the
+                            balance will remain in your wallet.
+                          </>
+                        )}
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={() => deleteApp(app.appPubkey)}
+                        disabled={isDeleting}
+                      >
+                        Continue
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </div>
             }
             description={""}
           />

--- a/frontend/src/screens/apps/ShowApp.tsx
+++ b/frontend/src/screens/apps/ShowApp.tsx
@@ -16,8 +16,8 @@ import { request } from "src/utils/request"; // build the project for this to ap
 
 import {
   AlertCircleIcon,
+  EllipsisIcon,
   PencilIcon,
-  Settings2Icon,
   SquareStackIcon,
   Trash2Icon,
 } from "lucide-react";
@@ -256,7 +256,7 @@ function AppInternal({ app, refetchApp, capabilities }: AppInternalProps) {
                     <DropdownMenu modal={false}>
                       <DropdownMenuTrigger asChild>
                         <Button variant="outline" size="icon">
-                          <Settings2Icon className="w-4 h-4" />
+                          <EllipsisIcon className="w-4 h-4" />
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent className="w-56">

--- a/frontend/src/screens/internal-apps/ZapPlanner.tsx
+++ b/frontend/src/screens/internal-apps/ZapPlanner.tsx
@@ -230,10 +230,12 @@ export function ZapPlanner() {
       const maxAmount = Math.ceil((rawSpend * 1.01 + 10) * 1.3);
       const isolated = false;
 
+      const budgetRenewal = "monthly";
+
       const createAppRequest: CreateAppRequest = {
         name: `ZapPlanner - ${recipientName}`,
         scopes: ["pay_invoice"],
-        budgetRenewal: "monthly",
+        budgetRenewal,
         maxAmount,
         isolated,
         metadata: {
@@ -251,7 +253,6 @@ export function ZapPlanner() {
           ? `${monthsToDays(frequencyValue)} days`
           : `${frequencyValue} ${frequencyUnit}`;
 
-      // Build a “stable fiat” payload when needed
       const subscriptionBody: Record<string, unknown> = {
         recipientLightningAddress,
         message: comment || "ZapPlanner payment from Alby Hub",
@@ -290,7 +291,7 @@ export function ZapPlanner() {
       const updateAppRequest: UpdateAppRequest = {
         name: createAppRequest.name,
         scopes: createAppRequest.scopes,
-        budgetRenewal: createAppRequest.budgetRenewal!,
+        budgetRenewal,
         expiresAt: createAppRequest.expiresAt,
         maxAmount,
         isolated,


### PR DESCRIPTION
fixes #1533 

Changes:
Added the dropdown menu and `handleConvertToSubwallet` function to convert the isolated app to sub-wallet for the paid users.