### PR TITLE
fix: use dynamic JWT key func

### DIFF
--- a/http/http_service.go
+++ b/http/http_service.go
@@ -111,7 +111,10 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 		NewClaimsFunc: func(c echo.Context) jwt.Claims {
 			return new(jwtCustomClaims)
 		},
-		SigningKey: []byte(httpSvc.cfg.GetJWTSecret()),
+		// use a custom key func as the JWT secret will change if the user changes their unlock password
+		KeyFunc: func(token *jwt.Token) (interface{}, error) {
+			return []byte(httpSvc.cfg.GetJWTSecret()), nil
+		},
 	}
 	restrictedApiGroup := e.Group("/api")
 	restrictedApiGroup.Use(echojwt.WithConfig(jwtConfig))


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/1551

This was introduced when we changed the JWT secret when the password was changed. I think I didn't test it well, by only testing I could change my password and then change it back, without properly testing using the hub with the new password :disappointed: 

An invalid token correctly returns 401 on all endpoints and redirects the user to the unlock screen.

The problem before was the middleware returned 401, but we return an `unlocked` boolean in the info endpoint, which is based on comparing against the correct token. This is why the hub was in a weird state ("unlocked" but all endpoints were returning 401)