### PR TITLE
fix: signal handling after ignoring sigpipe signal

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -39,6 +39,7 @@ func main() {
 			}
 
 			cancel()
+			break
 		}
 	}()
 


### PR DESCRIPTION
Currently if a SIGPIPE signal is captured, we cannot gracefully exit the application.

Tested by sending 2 SIGPIPES and then a SIGINT