### PR TITLE
fix: execute button not closing dialog

### DIFF
--- a/frontend/src/components/ExecuteCustomNodeCommandDialogContent.tsx
+++ b/frontend/src/components/ExecuteCustomNodeCommandDialogContent.tsx
@@ -37,8 +37,7 @@ export function ExecuteCustomNodeCommandDialogContent({
     // ignore unexpected json
   }
 
-  async function onSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  async function executeCommand() {
     try {
       if (!command) {
         throw new Error("No command set");
@@ -67,32 +66,30 @@ export function ExecuteCustomNodeCommandDialogContent({
 
   return (
     <AlertDialogContent>
-      <form onSubmit={onSubmit}>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Execute Custom Node Command</AlertDialogTitle>
-          <AlertDialogDescription className="text-left">
-            <Textarea
-              className="h-36 font-mono"
-              value={command}
-              onChange={(e) => setCommand(e.target.value)}
-              placeholder="commandname --arg1=value1"
-            />
-            <p className="mt-2">Available commands</p>
-            <Textarea
-              readOnly
-              className="mt-2 font-mono"
-              value={parsedAvailableCommands}
-              rows={10}
-            />
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter className="mt-4">
-          <AlertDialogCancel onClick={() => setCommand("")}>
-            Cancel
-          </AlertDialogCancel>
-          <AlertDialogAction type="submit">Execute</AlertDialogAction>
-        </AlertDialogFooter>
-      </form>
+      <AlertDialogHeader>
+        <AlertDialogTitle>Execute Custom Node Command</AlertDialogTitle>
+        <AlertDialogDescription className="text-left">
+          <Textarea
+            className="h-36 font-mono"
+            value={command}
+            onChange={(e) => setCommand(e.target.value)}
+            placeholder="commandname --arg1=value1"
+          />
+          <p className="mt-2">Available commands</p>
+          <Textarea
+            readOnly
+            className="mt-2 font-mono"
+            value={parsedAvailableCommands}
+            rows={10}
+          />
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter className="mt-4">
+        <AlertDialogCancel onClick={() => setCommand("")}>
+          Cancel
+        </AlertDialogCancel>
+        <AlertDialogAction onClick={executeCommand}>Execute</AlertDialogAction>
+      </AlertDialogFooter>
     </AlertDialogContent>
   );
 }


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/1557

The problem was because we were using `e.preventDefault();`, this PR aligns it with how we use AlertDialogs elsewhere