### PR TITLE
fix: remove support contact message from offline channel warning (#1531)

### DIFF
--- a/frontend/src/components/channels/ChannelWarning.tsx
+++ b/frontend/src/components/channels/ChannelWarning.tsx
@@ -19,7 +19,7 @@ export function ChannelWarning({ channel }: ChannelWarningProps) {
   }
   if (!channelWarning && channel.status === "offline") {
     channelWarning =
-      "This channel is currently offline and cannot be used to send or receive payments. Please contact Alby Support for more information.";
+      "This channel is currently offline and cannot be used to send or receive payments.";
   }
   if (!channelWarning && channel.localSpendableBalance > capacity * 0.9) {
     channelWarning =


### PR DESCRIPTION
This PR addresses issue #1531 by removing the sentence "Please contact Alby Support for more information." from the offline channel warning in ChannelWarning.tsx. 