### PR TITLE
chore: remove payment timeout

### DIFF
--- a/api/rebalance.go
+++ b/api/rebalance.go
@@ -124,7 +124,7 @@ func (api *api) RebalanceChannel(ctx context.Context, rebalanceChannelRequest *R
 		"order_id":        rebalanceCreateOrderResponse.OrderId,
 	}
 
-	payRebalanceInvoiceResponse, err := api.svc.GetTransactionsService().SendPaymentSync(ctx, rebalanceCreateOrderResponse.PayRequest, nil, payMetadata, api.svc.GetLNClient(), nil, nil, nil)
+	payRebalanceInvoiceResponse, err := api.svc.GetTransactionsService().SendPaymentSync(ctx, rebalanceCreateOrderResponse.PayRequest, nil, payMetadata, api.svc.GetLNClient(), nil, nil)
 
 	if err != nil {
 		logger.Logger.WithError(err).Error("failed to pay rebalance invoice")

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -65,7 +65,7 @@ func (api *api) SendPayment(ctx context.Context, invoice string, amountMsat *uin
 	if api.svc.GetLNClient() == nil {
 		return nil, errors.New("LNClient not started")
 	}
-	transaction, err := api.svc.GetTransactionsService().SendPaymentSync(ctx, invoice, amountMsat, metadata, api.svc.GetLNClient(), nil, nil, nil)
+	transaction, err := api.svc.GetTransactionsService().SendPaymentSync(ctx, invoice, amountMsat, metadata, api.svc.GetLNClient(), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func (api *api) TopupIsolatedApp(ctx context.Context, userApp *db.App, amountMsa
 		return err
 	}
 
-	_, err = api.svc.GetTransactionsService().SendPaymentSync(ctx, transaction.PaymentRequest, nil, nil, api.svc.GetLNClient(), nil, nil, nil)
+	_, err = api.svc.GetTransactionsService().SendPaymentSync(ctx, transaction.PaymentRequest, nil, nil, api.svc.GetLNClient(), nil, nil)
 	return err
 }
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -56,8 +56,6 @@ const (
 // accounting for encryption and other metadata in the response, this is set to 4096 characters
 const INVOICE_METADATA_MAX_LENGTH = 4096
 
-const SEND_PAYMENT_TIMEOUT = 50
-
 // errors used by NIP-47 and the transaction service
 const (
 	ERROR_INTERNAL               = "INTERNAL"

--- a/lnclient/cashu/cashu.go
+++ b/lnclient/cashu/cashu.go
@@ -72,7 +72,7 @@ func (cs *CashuService) Shutdown() error {
 	return cs.wallet.Shutdown()
 }
 
-func (cs *CashuService) SendPaymentSync(ctx context.Context, invoice string, amount *uint64, timeoutSeconds *int64) (response *lnclient.PayInvoiceResponse, err error) {
+func (cs *CashuService) SendPaymentSync(ctx context.Context, invoice string, amount *uint64) (response *lnclient.PayInvoiceResponse, err error) {
 	// TODO: support 0-amount invoices
 	if amount != nil {
 		return nil, errors.New("0-amount invoices not supported")

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -27,7 +27,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/getAlby/hub/config"
-	"github.com/getAlby/hub/constants"
 	"github.com/getAlby/hub/events"
 	"github.com/getAlby/hub/lnclient"
 	"github.com/getAlby/hub/logger"
@@ -489,12 +488,7 @@ func (ls *LDKService) MakeOffer(ctx context.Context, description string) (string
 	return offer, nil
 }
 
-func (ls *LDKService) SendPaymentSync(ctx context.Context, invoice string, amount *uint64, timeoutSeconds *int64) (*lnclient.PayInvoiceResponse, error) {
-	sendPaymentTimeout := int64(constants.SEND_PAYMENT_TIMEOUT)
-	if timeoutSeconds != nil {
-		sendPaymentTimeout = *timeoutSeconds
-	}
-
+func (ls *LDKService) SendPaymentSync(ctx context.Context, invoice string, amount *uint64) (*lnclient.PayInvoiceResponse, error) {
 	paymentRequest, err := decodepay.Decodepay(invoice)
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
@@ -555,20 +549,10 @@ func (ls *LDKService) SendPaymentSync(ctx context.Context, invoice string, amoun
 	fee := uint64(0)
 	preimage := ""
 
-	timeout := time.Second * time.Duration(sendPaymentTimeout)
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-
-		case <-timer.C:
-			logger.Logger.WithFields(logrus.Fields{
-				"paymentHash": paymentHash,
-			}).Warn("Timed out waiting for payment to be sent")
-			return nil, lnclient.NewTimeoutError()
 
 		case ev := <-ldkEventSubscription:
 			switch event := (*ev).(type) {
@@ -652,8 +636,7 @@ func (ls *LDKService) SendKeysend(ctx context.Context, amount uint64, destinatio
 		return nil, err
 	}
 	fee := uint64(0)
-	paid := false
-	for start := time.Now(); time.Since(start) < time.Second*50; {
+	for {
 		event := <-ldkEventSubscription
 
 		eventPaymentSuccessful, isEventPaymentSuccessfulEvent := (*event).(ldk_node.EventPaymentSuccessful)
@@ -661,8 +644,6 @@ func (ls *LDKService) SendKeysend(ctx context.Context, amount uint64, destinatio
 
 		if isEventPaymentSuccessfulEvent && eventPaymentSuccessful.PaymentHash == paymentHash {
 			logger.Logger.Info("Got payment success event")
-
-			paid = true
 
 			if eventPaymentSuccessful.FeePaidMsat != nil {
 				fee = *eventPaymentSuccessful.FeePaidMsat
@@ -680,12 +661,6 @@ func (ls *LDKService) SendKeysend(ctx context.Context, amount uint64, destinatio
 
 			return nil, fmt.Errorf("payment failed event: %s", failureReasonMessage)
 		}
-	}
-	if !paid {
-		logger.Logger.WithFields(logrus.Fields{
-			"payment_hash": paymentHash,
-		}).Warn("Timed out waiting for keysend to be sent")
-		return nil, lnclient.NewTimeoutError()
 	}
 
 	logger.Logger.WithFields(logrus.Fields{
@@ -2194,13 +2169,6 @@ func (ls *LDKService) PayOfferSync(ctx context.Context, offer string, amount uin
 
 			return nil, fmt.Errorf("received payment failed event: %s", reason)
 		}
-	}
-
-	if preimage == "" {
-		logger.Logger.WithFields(logrus.Fields{
-			"payment_id": paymentId,
-		}).Warn("Timed out waiting for payment to be sent")
-		return nil, lnclient.NewTimeoutError()
 	}
 
 	logger.Logger.WithFields(logrus.Fields{

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -19,7 +19,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/getAlby/hub/config"
-	"github.com/getAlby/hub/constants"
 	"github.com/getAlby/hub/events"
 	"github.com/getAlby/hub/lnclient"
 	"github.com/getAlby/hub/lnclient/lnd/wrapper"
@@ -398,13 +397,8 @@ func (svc *LNDService) Shutdown() error {
 	return nil
 }
 
-func (svc *LNDService) SendPaymentSync(ctx context.Context, payReq string, amount *uint64, timeoutSeconds *int64) (*lnclient.PayInvoiceResponse, error) {
+func (svc *LNDService) SendPaymentSync(ctx context.Context, payReq string, amount *uint64) (*lnclient.PayInvoiceResponse, error) {
 	const MAX_PARTIAL_PAYMENTS = 16
-
-	sendPaymentTimeout := int64(constants.SEND_PAYMENT_TIMEOUT)
-	if timeoutSeconds != nil {
-		sendPaymentTimeout = *timeoutSeconds
-	}
 
 	paymentRequest, err := decodepay.Decodepay(payReq)
 	if err != nil {
@@ -421,7 +415,6 @@ func (svc *LNDService) SendPaymentSync(ctx context.Context, payReq string, amoun
 	sendRequest := &routerrpc.SendPaymentRequest{
 		PaymentRequest: payReq,
 		MaxParts:       MAX_PARTIAL_PAYMENTS,
-		TimeoutSeconds: int32(sendPaymentTimeout),
 		FeeLimitMsat:   int64(transactions.CalculateFeeReserveMsat(paymentAmountMsat)),
 	}
 

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -57,7 +57,7 @@ type NodeConnectionInfo struct {
 }
 
 type LNClient interface {
-	SendPaymentSync(ctx context.Context, payReq string, amount *uint64, timeoutSeconds *int64) (*PayInvoiceResponse, error)
+	SendPaymentSync(ctx context.Context, payReq string, amount *uint64) (*PayInvoiceResponse, error)
 	SendKeysend(ctx context.Context, amount uint64, destination string, customRecords []TLVRecord, preimage string) (*PayKeysendResponse, error)
 	GetPubkey() string
 	GetInfo(ctx context.Context) (info *NodeInfo, err error)
@@ -249,17 +249,6 @@ var ErrUnknownCustomNodeCommand = errors.New("unknown custom node command")
 
 // default invoice expiry in seconds (1 day)
 const DEFAULT_INVOICE_EXPIRY = 86400
-
-type timeoutError struct {
-}
-
-func NewTimeoutError() error {
-	return &timeoutError{}
-}
-
-func (err *timeoutError) Error() string {
-	return "Timeout"
-}
 
 type holdInvoiceCanceledError struct {
 }

--- a/lnclient/phoenixd/phoenixd.go
+++ b/lnclient/phoenixd/phoenixd.go
@@ -362,7 +362,7 @@ func (svc *PhoenixService) LookupInvoice(ctx context.Context, paymentHash string
 	return transaction, nil
 }
 
-func (svc *PhoenixService) SendPaymentSync(ctx context.Context, payReq string, amount *uint64, timeoutSeconds *int64) (*lnclient.PayInvoiceResponse, error) {
+func (svc *PhoenixService) SendPaymentSync(ctx context.Context, payReq string, amount *uint64) (*lnclient.PayInvoiceResponse, error) {
 	// TODO: support 0-amount invoices
 	if amount != nil {
 		return nil, errors.New("0-amount invoices not supported")

--- a/nip47/controllers/pay_invoice_controller.go
+++ b/nip47/controllers/pay_invoice_controller.go
@@ -59,7 +59,7 @@ func (controller *nip47Controller) pay(ctx context.Context, bolt11 string, amoun
 		"bolt11":           bolt11,
 	}).Info("Sending payment")
 
-	transaction, err := controller.transactionsService.SendPaymentSync(ctx, bolt11, amount, metadata, controller.lnClient, &app.ID, &requestEventId, nil)
+	transaction, err := controller.transactionsService.SendPaymentSync(ctx, bolt11, amount, metadata, controller.lnClient, &app.ID, &requestEventId)
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
 			"request_event_id": requestEventId,

--- a/swaps/swaps_service.go
+++ b/swaps/swaps_service.go
@@ -1087,21 +1087,14 @@ func (svc *swapsService) startSwapOutListener(swap *db.Swap) {
 					metadata := map[string]interface{}{
 						"swap_id": swap.SwapId,
 					}
-					sendPaymentTimeout := int64(3600)
 					logger.Logger.WithField("swapId", swap.SwapId).Info("Initiating swap invoice payment")
-					_, err = svc.transactionsService.SendPaymentSync(svc.ctx, swap.Invoice, nil, metadata, svc.lnClient, nil, nil, &sendPaymentTimeout)
+					_, err = svc.transactionsService.SendPaymentSync(svc.ctx, swap.Invoice, nil, metadata, svc.lnClient, nil, nil)
 					if err != nil {
-						if errors.Is(err, lnclient.NewTimeoutError()) {
-							logger.Logger.WithFields(logrus.Fields{
-								"swapId": swap.SwapId,
-							}).Info("Ignoring payment timeout while swapping out")
-						} else {
-							logger.Logger.WithError(err).WithFields(logrus.Fields{
-								"swapId": swap.SwapId,
-							}).Error("Error paying the swap invoice")
-							paymentErrorCh <- err
-							return
-						}
+						logger.Logger.WithError(err).WithFields(logrus.Fields{
+							"swapId": swap.SwapId,
+						}).Error("Error paying the swap invoice")
+						paymentErrorCh <- err
+						return
 					}
 				}()
 			case boltz.TransactionMempool:

--- a/tests/mock_ln_client.go
+++ b/tests/mock_ln_client.go
@@ -79,6 +79,7 @@ var MockLNClientHoldTransaction = &lnclient.Transaction{
 type MockLn struct {
 	PayInvoiceResponses        []*lnclient.PayInvoiceResponse
 	PayInvoiceErrors           []error
+	PaymentDelay               *time.Duration
 	Pubkey                     string
 	MockTransaction            *lnclient.Transaction
 	SupportedNotificationTypes *[]string
@@ -88,13 +89,16 @@ func NewMockLn() (*MockLn, error) {
 	return &MockLn{}, nil
 }
 
-func (mln *MockLn) SendPaymentSync(ctx context.Context, payReq string, amount *uint64, timeoutSeconds *int64) (*lnclient.PayInvoiceResponse, error) {
+func (mln *MockLn) SendPaymentSync(ctx context.Context, payReq string, amount *uint64) (*lnclient.PayInvoiceResponse, error) {
 	if len(mln.PayInvoiceResponses) > 0 {
 		response := mln.PayInvoiceResponses[0]
 		err := mln.PayInvoiceErrors[0]
 		mln.PayInvoiceResponses = mln.PayInvoiceResponses[1:]
 		mln.PayInvoiceErrors = mln.PayInvoiceErrors[1:]
 		return response, err
+	}
+	if mln.PaymentDelay != nil {
+		time.Sleep(*mln.PaymentDelay)
 	}
 
 	return &lnclient.PayInvoiceResponse{

--- a/tests/mocks/Config.go
+++ b/tests/mocks/Config.go
@@ -59,26 +59,15 @@ type MockConfig_ChangeUnlockPassword_Call struct {
 }
 
 // ChangeUnlockPassword is a helper method to define mock.On call
-//   - currentUnlockPassword string
-//   - newUnlockPassword string
+//   - currentUnlockPassword
+//   - newUnlockPassword
 func (_e *MockConfig_Expecter) ChangeUnlockPassword(currentUnlockPassword interface{}, newUnlockPassword interface{}) *MockConfig_ChangeUnlockPassword_Call {
 	return &MockConfig_ChangeUnlockPassword_Call{Call: _e.mock.On("ChangeUnlockPassword", currentUnlockPassword, newUnlockPassword)}
 }
 
 func (_c *MockConfig_ChangeUnlockPassword_Call) Run(run func(currentUnlockPassword string, newUnlockPassword string)) *MockConfig_ChangeUnlockPassword_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(string), args[1].(string))
 	})
 	return _c
 }
@@ -116,20 +105,14 @@ type MockConfig_CheckUnlockPassword_Call struct {
 }
 
 // CheckUnlockPassword is a helper method to define mock.On call
-//   - password string
+//   - password
 func (_e *MockConfig_Expecter) CheckUnlockPassword(password interface{}) *MockConfig_CheckUnlockPassword_Call {
 	return &MockConfig_CheckUnlockPassword_Call{Call: _e.mock.On("CheckUnlockPassword", password)}
 }
 
 func (_c *MockConfig_CheckUnlockPassword_Call) Run(run func(password string)) *MockConfig_CheckUnlockPassword_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
+		run(args[0].(string))
 	})
 	return _c
 }
@@ -176,26 +159,15 @@ type MockConfig_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
-//   - key string
-//   - encryptionKey string
+//   - key
+//   - encryptionKey
 func (_e *MockConfig_Expecter) Get(key interface{}, encryptionKey interface{}) *MockConfig_Get_Call {
 	return &MockConfig_Get_Call{Call: _e.mock.On("Get", key, encryptionKey)}
 }
 
 func (_c *MockConfig_Get_Call) Run(run func(key string, encryptionKey string)) *MockConfig_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(string), args[1].(string))
 	})
 	return _c
 }
@@ -499,20 +471,14 @@ type MockConfig_SaveUnlockPasswordCheck_Call struct {
 }
 
 // SaveUnlockPasswordCheck is a helper method to define mock.On call
-//   - encryptionKey string
+//   - encryptionKey
 func (_e *MockConfig_Expecter) SaveUnlockPasswordCheck(encryptionKey interface{}) *MockConfig_SaveUnlockPasswordCheck_Call {
 	return &MockConfig_SaveUnlockPasswordCheck_Call{Call: _e.mock.On("SaveUnlockPasswordCheck", encryptionKey)}
 }
 
 func (_c *MockConfig_SaveUnlockPasswordCheck_Call) Run(run func(encryptionKey string)) *MockConfig_SaveUnlockPasswordCheck_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
+		run(args[0].(string))
 	})
 	return _c
 }
@@ -550,20 +516,14 @@ type MockConfig_SetAutoUnlockPassword_Call struct {
 }
 
 // SetAutoUnlockPassword is a helper method to define mock.On call
-//   - unlockPassword string
+//   - unlockPassword
 func (_e *MockConfig_Expecter) SetAutoUnlockPassword(unlockPassword interface{}) *MockConfig_SetAutoUnlockPassword_Call {
 	return &MockConfig_SetAutoUnlockPassword_Call{Call: _e.mock.On("SetAutoUnlockPassword", unlockPassword)}
 }
 
 func (_c *MockConfig_SetAutoUnlockPassword_Call) Run(run func(unlockPassword string)) *MockConfig_SetAutoUnlockPassword_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
+		run(args[0].(string))
 	})
 	return _c
 }
@@ -601,20 +561,14 @@ type MockConfig_SetCurrency_Call struct {
 }
 
 // SetCurrency is a helper method to define mock.On call
-//   - value string
+//   - value
 func (_e *MockConfig_Expecter) SetCurrency(value interface{}) *MockConfig_SetCurrency_Call {
 	return &MockConfig_SetCurrency_Call{Call: _e.mock.On("SetCurrency", value)}
 }
 
 func (_c *MockConfig_SetCurrency_Call) Run(run func(value string)) *MockConfig_SetCurrency_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
+		run(args[0].(string))
 	})
 	return _c
 }
@@ -652,32 +606,16 @@ type MockConfig_SetIgnore_Call struct {
 }
 
 // SetIgnore is a helper method to define mock.On call
-//   - key string
-//   - value string
-//   - encryptionKey string
+//   - key
+//   - value
+//   - encryptionKey
 func (_e *MockConfig_Expecter) SetIgnore(key interface{}, value interface{}, encryptionKey interface{}) *MockConfig_SetIgnore_Call {
 	return &MockConfig_SetIgnore_Call{Call: _e.mock.On("SetIgnore", key, value, encryptionKey)}
 }
 
 func (_c *MockConfig_SetIgnore_Call) Run(run func(key string, value string, encryptionKey string)) *MockConfig_SetIgnore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
+		run(args[0].(string), args[1].(string), args[2].(string))
 	})
 	return _c
 }
@@ -715,32 +653,16 @@ type MockConfig_SetUpdate_Call struct {
 }
 
 // SetUpdate is a helper method to define mock.On call
-//   - key string
-//   - value string
-//   - encryptionKey string
+//   - key
+//   - value
+//   - encryptionKey
 func (_e *MockConfig_Expecter) SetUpdate(key interface{}, value interface{}, encryptionKey interface{}) *MockConfig_SetUpdate_Call {
 	return &MockConfig_SetUpdate_Call{Call: _e.mock.On("SetUpdate", key, value, encryptionKey)}
 }
 
 func (_c *MockConfig_SetUpdate_Call) Run(run func(key string, value string, encryptionKey string)) *MockConfig_SetUpdate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
+		run(args[0].(string), args[1].(string), args[2].(string))
 	})
 	return _c
 }

--- a/tests/mocks/LNClient.go
+++ b/tests/mocks/LNClient.go
@@ -61,26 +61,15 @@ type MockLNClient_CancelHoldInvoice_Call struct {
 }
 
 // CancelHoldInvoice is a helper method to define mock.On call
-//   - ctx context.Context
-//   - paymentHash string
+//   - ctx
+//   - paymentHash
 func (_e *MockLNClient_Expecter) CancelHoldInvoice(ctx interface{}, paymentHash interface{}) *MockLNClient_CancelHoldInvoice_Call {
 	return &MockLNClient_CancelHoldInvoice_Call{Call: _e.mock.On("CancelHoldInvoice", ctx, paymentHash)}
 }
 
 func (_c *MockLNClient_CancelHoldInvoice_Call) Run(run func(ctx context.Context, paymentHash string)) *MockLNClient_CancelHoldInvoice_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -129,26 +118,15 @@ type MockLNClient_CloseChannel_Call struct {
 }
 
 // CloseChannel is a helper method to define mock.On call
-//   - ctx context.Context
-//   - closeChannelRequest *lnclient.CloseChannelRequest
+//   - ctx
+//   - closeChannelRequest
 func (_e *MockLNClient_Expecter) CloseChannel(ctx interface{}, closeChannelRequest interface{}) *MockLNClient_CloseChannel_Call {
 	return &MockLNClient_CloseChannel_Call{Call: _e.mock.On("CloseChannel", ctx, closeChannelRequest)}
 }
 
 func (_c *MockLNClient_CloseChannel_Call) Run(run func(ctx context.Context, closeChannelRequest *lnclient.CloseChannelRequest)) *MockLNClient_CloseChannel_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 *lnclient.CloseChannelRequest
-		if args[1] != nil {
-			arg1 = args[1].(*lnclient.CloseChannelRequest)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(context.Context), args[1].(*lnclient.CloseChannelRequest))
 	})
 	return _c
 }
@@ -186,26 +164,15 @@ type MockLNClient_ConnectPeer_Call struct {
 }
 
 // ConnectPeer is a helper method to define mock.On call
-//   - ctx context.Context
-//   - connectPeerRequest *lnclient.ConnectPeerRequest
+//   - ctx
+//   - connectPeerRequest
 func (_e *MockLNClient_Expecter) ConnectPeer(ctx interface{}, connectPeerRequest interface{}) *MockLNClient_ConnectPeer_Call {
 	return &MockLNClient_ConnectPeer_Call{Call: _e.mock.On("ConnectPeer", ctx, connectPeerRequest)}
 }
 
 func (_c *MockLNClient_ConnectPeer_Call) Run(run func(ctx context.Context, connectPeerRequest *lnclient.ConnectPeerRequest)) *MockLNClient_ConnectPeer_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 *lnclient.ConnectPeerRequest
-		if args[1] != nil {
-			arg1 = args[1].(*lnclient.ConnectPeerRequest)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(context.Context), args[1].(*lnclient.ConnectPeerRequest))
 	})
 	return _c
 }
@@ -243,26 +210,15 @@ type MockLNClient_DisconnectPeer_Call struct {
 }
 
 // DisconnectPeer is a helper method to define mock.On call
-//   - ctx context.Context
-//   - peerId string
+//   - ctx
+//   - peerId
 func (_e *MockLNClient_Expecter) DisconnectPeer(ctx interface{}, peerId interface{}) *MockLNClient_DisconnectPeer_Call {
 	return &MockLNClient_DisconnectPeer_Call{Call: _e.mock.On("DisconnectPeer", ctx, peerId)}
 }
 
 func (_c *MockLNClient_DisconnectPeer_Call) Run(run func(ctx context.Context, peerId string)) *MockLNClient_DisconnectPeer_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -311,26 +267,15 @@ type MockLNClient_ExecuteCustomNodeCommand_Call struct {
 }
 
 // ExecuteCustomNodeCommand is a helper method to define mock.On call
-//   - ctx context.Context
-//   - command *lnclient.CustomNodeCommandRequest
+//   - ctx
+//   - command
 func (_e *MockLNClient_Expecter) ExecuteCustomNodeCommand(ctx interface{}, command interface{}) *MockLNClient_ExecuteCustomNodeCommand_Call {
 	return &MockLNClient_ExecuteCustomNodeCommand_Call{Call: _e.mock.On("ExecuteCustomNodeCommand", ctx, command)}
 }
 
 func (_c *MockLNClient_ExecuteCustomNodeCommand_Call) Run(run func(ctx context.Context, command *lnclient.CustomNodeCommandRequest)) *MockLNClient_ExecuteCustomNodeCommand_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 *lnclient.CustomNodeCommandRequest
-		if args[1] != nil {
-			arg1 = args[1].(*lnclient.CustomNodeCommandRequest)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(context.Context), args[1].(*lnclient.CustomNodeCommandRequest))
 	})
 	return _c
 }
@@ -379,26 +324,15 @@ type MockLNClient_GetBalances_Call struct {
 }
 
 // GetBalances is a helper method to define mock.On call
-//   - ctx context.Context
-//   - includeInactiveChannels bool
+//   - ctx
+//   - includeInactiveChannels
 func (_e *MockLNClient_Expecter) GetBalances(ctx interface{}, includeInactiveChannels interface{}) *MockLNClient_GetBalances_Call {
 	return &MockLNClient_GetBalances_Call{Call: _e.mock.On("GetBalances", ctx, includeInactiveChannels)}
 }
 
 func (_c *MockLNClient_GetBalances_Call) Run(run func(ctx context.Context, includeInactiveChannels bool)) *MockLNClient_GetBalances_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 bool
-		if args[1] != nil {
-			arg1 = args[1].(bool)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(context.Context), args[1].(bool))
 	})
 	return _c
 }
@@ -493,20 +427,14 @@ type MockLNClient_GetInfo_Call struct {
 }
 
 // GetInfo is a helper method to define mock.On call
-//   - ctx context.Context
+//   - ctx
 func (_e *MockLNClient_Expecter) GetInfo(ctx interface{}) *MockLNClient_GetInfo_Call {
 	return &MockLNClient_GetInfo_Call{Call: _e.mock.On("GetInfo", ctx)}
 }
 
 func (_c *MockLNClient_GetInfo_Call) Run(run func(ctx context.Context)) *MockLNClient_GetInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		run(
-			arg0,
-		)
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -555,26 +483,15 @@ type MockLNClient_GetLogOutput_Call struct {
 }
 
 // GetLogOutput is a helper method to define mock.On call
-//   - ctx context.Context
-//   - maxLen int
+//   - ctx
+//   - maxLen
 func (_e *MockLNClient_Expecter) GetLogOutput(ctx interface{}, maxLen interface{}) *MockLNClient_GetLogOutput_Call {
 	return &MockLNClient_GetLogOutput_Call{Call: _e.mock.On("GetLogOutput", ctx, maxLen)}
 }
 
 func (_c *MockLNClient_GetLogOutput_Call) Run(run func(ctx context.Context, maxLen int)) *MockLNClient_GetLogOutput_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 int
-		if args[1] != nil {
-			arg1 = args[1].(int)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(context.Context), args[1].(int))
 	})
 	return _c
 }
@@ -623,26 +540,15 @@ type MockLNClient_GetNetworkGraph_Call struct {
 }
 
 // GetNetworkGraph is a helper method to define mock.On call
-//   - ctx context.Context
-//   - nodeIds []string
+//   - ctx
+//   - nodeIds
 func (_e *MockLNClient_Expecter) GetNetworkGraph(ctx interface{}, nodeIds interface{}) *MockLNClient_GetNetworkGraph_Call {
 	return &MockLNClient_GetNetworkGraph_Call{Call: _e.mock.On("GetNetworkGraph", ctx, nodeIds)}
 }
 
 func (_c *MockLNClient_GetNetworkGraph_Call) Run(run func(ctx context.Context, nodeIds []string)) *MockLNClient_GetNetworkGraph_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 []string
-		if args[1] != nil {
-			arg1 = args[1].([]string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(context.Context), args[1].([]string))
 	})
 	return _c
 }
@@ -689,20 +595,14 @@ type MockLNClient_GetNewOnchainAddress_Call struct {
 }
 
 // GetNewOnchainAddress is a helper method to define mock.On call
-//   - ctx context.Context
+//   - ctx
 func (_e *MockLNClient_Expecter) GetNewOnchainAddress(ctx interface{}) *MockLNClient_GetNewOnchainAddress_Call {
 	return &MockLNClient_GetNewOnchainAddress_Call{Call: _e.mock.On("GetNewOnchainAddress", ctx)}
 }
 
 func (_c *MockLNClient_GetNewOnchainAddress_Call) Run(run func(ctx context.Context)) *MockLNClient_GetNewOnchainAddress_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		run(
-			arg0,
-		)
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -751,20 +651,14 @@ type MockLNClient_GetNodeConnectionInfo_Call struct {
 }
 
 // GetNodeConnectionInfo is a helper method to define mock.On call
-//   - ctx context.Context
+//   - ctx
 func (_e *MockLNClient_Expecter) GetNodeConnectionInfo(ctx interface{}) *MockLNClient_GetNodeConnectionInfo_Call {
 	return &MockLNClient_GetNodeConnectionInfo_Call{Call: _e.mock.On("GetNodeConnectionInfo", ctx)}
 }
 
 func (_c *MockLNClient_GetNodeConnectionInfo_Call) Run(run func(ctx context.Context)) *MockLNClient_GetNodeConnectionInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		run(
-			arg0,
-		)
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -813,20 +707,14 @@ type MockLNClient_GetNodeStatus_Call struct {
 }
 
 // GetNodeStatus is a helper method to define mock.On call
-//   - ctx context.Context
+//   - ctx
 func (_e *MockLNClient_Expecter) GetNodeStatus(ctx interface{}) *MockLNClient_GetNodeStatus_Call {
 	return &MockLNClient_GetNodeStatus_Call{Call: _e.mock.On("GetNodeStatus", ctx)}
 }
 
 func (_c *MockLNClient_GetNodeStatus_Call) Run(run func(ctx context.Context)) *MockLNClient_GetNodeStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		run(
-			arg0,
-		)
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -875,20 +763,14 @@ type MockLNClient_GetOnchainBalance_Call struct {
 }
 
 // GetOnchainBalance is a helper method to define mock.On call
-//   - ctx context.Context
+//   - ctx
 func (_e *MockLNClient_Expecter) GetOnchainBalance(ctx interface{}) *MockLNClient_GetOnchainBalance_Call {
 	return &MockLNClient_GetOnchainBalance_Call{Call: _e.mock.On("GetOnchainBalance", ctx)}
 }
 
 func (_c *MockLNClient_GetOnchainBalance_Call) Run(run func(ctx context.Context)) *MockLNClient_GetOnchainBalance_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		run(
-			arg0,
-		)
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -1126,20 +1008,14 @@ type MockLNClient_ListChannels_Call struct {
 }
 
 // ListChannels is a helper method to define mock.On call
-//   - ctx context.Context
+//   - ctx
 func (_e *MockLNClient_Expecter) ListChannels(ctx interface{}) *MockLNClient_ListChannels_Call {
 	return &MockLNClient_ListChannels_Call{Call: _e.mock.On("ListChannels", ctx)}
 }
 
 func (_c *MockLNClient_ListChannels_Call) Run(run func(ctx context.Context)) *MockLNClient_ListChannels_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		run(
-			arg0,
-		)
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -1188,20 +1064,14 @@ type MockLNClient_ListOnchainTransactions_Call struct {
 }
 
 // ListOnchainTransactions is a helper method to define mock.On call
-//   - ctx context.Context
+//   - ctx
 func (_e *MockLNClient_Expecter) ListOnchainTransactions(ctx interface{}) *MockLNClient_ListOnchainTransactions_Call {
 	return &MockLNClient_ListOnchainTransactions_Call{Call: _e.mock.On("ListOnchainTransactions", ctx)}
 }
 
 func (_c *MockLNClient_ListOnchainTransactions_Call) Run(run func(ctx context.Context)) *MockLNClient_ListOnchainTransactions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		run(
-			arg0,
-		)
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -1250,20 +1120,14 @@ type MockLNClient_ListPeers_Call struct {
 }
 
 // ListPeers is a helper method to define mock.On call
-//   - ctx context.Context
+//   - ctx
 func (_e *MockLNClient_Expecter) ListPeers(ctx interface{}) *MockLNClient_ListPeers_Call {
 	return &MockLNClient_ListPeers_Call{Call: _e.mock.On("ListPeers", ctx)}
 }
 
 func (_c *MockLNClient_ListPeers_Call) Run(run func(ctx context.Context)) *MockLNClient_ListPeers_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		run(
-			arg0,
-		)
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -1312,56 +1176,20 @@ type MockLNClient_ListTransactions_Call struct {
 }
 
 // ListTransactions is a helper method to define mock.On call
-//   - ctx context.Context
-//   - from uint64
-//   - until uint64
-//   - limit uint64
-//   - offset uint64
-//   - unpaid bool
-//   - invoiceType string
+//   - ctx
+//   - from
+//   - until
+//   - limit
+//   - offset
+//   - unpaid
+//   - invoiceType
 func (_e *MockLNClient_Expecter) ListTransactions(ctx interface{}, from interface{}, until interface{}, limit interface{}, offset interface{}, unpaid interface{}, invoiceType interface{}) *MockLNClient_ListTransactions_Call {
 	return &MockLNClient_ListTransactions_Call{Call: _e.mock.On("ListTransactions", ctx, from, until, limit, offset, unpaid, invoiceType)}
 }
 
 func (_c *MockLNClient_ListTransactions_Call) Run(run func(ctx context.Context, from uint64, until uint64, limit uint64, offset uint64, unpaid bool, invoiceType string)) *MockLNClient_ListTransactions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 uint64
-		if args[1] != nil {
-			arg1 = args[1].(uint64)
-		}
-		var arg2 uint64
-		if args[2] != nil {
-			arg2 = args[2].(uint64)
-		}
-		var arg3 uint64
-		if args[3] != nil {
-			arg3 = args[3].(uint64)
-		}
-		var arg4 uint64
-		if args[4] != nil {
-			arg4 = args[4].(uint64)
-		}
-		var arg5 bool
-		if args[5] != nil {
-			arg5 = args[5].(bool)
-		}
-		var arg6 string
-		if args[6] != nil {
-			arg6 = args[6].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-			arg4,
-			arg5,
-			arg6,
-		)
+		run(args[0].(context.Context), args[1].(uint64), args[2].(uint64), args[3].(uint64), args[4].(uint64), args[5].(bool), args[6].(string))
 	})
 	return _c
 }
@@ -1410,26 +1238,15 @@ type MockLNClient_LookupInvoice_Call struct {
 }
 
 // LookupInvoice is a helper method to define mock.On call
-//   - ctx context.Context
-//   - paymentHash string
+//   - ctx
+//   - paymentHash
 func (_e *MockLNClient_Expecter) LookupInvoice(ctx interface{}, paymentHash interface{}) *MockLNClient_LookupInvoice_Call {
 	return &MockLNClient_LookupInvoice_Call{Call: _e.mock.On("LookupInvoice", ctx, paymentHash)}
 }
 
 func (_c *MockLNClient_LookupInvoice_Call) Run(run func(ctx context.Context, paymentHash string)) *MockLNClient_LookupInvoice_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -1478,50 +1295,19 @@ type MockLNClient_MakeHoldInvoice_Call struct {
 }
 
 // MakeHoldInvoice is a helper method to define mock.On call
-//   - ctx context.Context
-//   - amount int64
-//   - description string
-//   - descriptionHash string
-//   - expiry int64
-//   - paymentHash string
+//   - ctx
+//   - amount
+//   - description
+//   - descriptionHash
+//   - expiry
+//   - paymentHash
 func (_e *MockLNClient_Expecter) MakeHoldInvoice(ctx interface{}, amount interface{}, description interface{}, descriptionHash interface{}, expiry interface{}, paymentHash interface{}) *MockLNClient_MakeHoldInvoice_Call {
 	return &MockLNClient_MakeHoldInvoice_Call{Call: _e.mock.On("MakeHoldInvoice", ctx, amount, description, descriptionHash, expiry, paymentHash)}
 }
 
 func (_c *MockLNClient_MakeHoldInvoice_Call) Run(run func(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string)) *MockLNClient_MakeHoldInvoice_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 int64
-		if args[1] != nil {
-			arg1 = args[1].(int64)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		var arg3 string
-		if args[3] != nil {
-			arg3 = args[3].(string)
-		}
-		var arg4 int64
-		if args[4] != nil {
-			arg4 = args[4].(int64)
-		}
-		var arg5 string
-		if args[5] != nil {
-			arg5 = args[5].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-			arg4,
-			arg5,
-		)
+		run(args[0].(context.Context), args[1].(int64), args[2].(string), args[3].(string), args[4].(int64), args[5].(string))
 	})
 	return _c
 }
@@ -1570,44 +1356,18 @@ type MockLNClient_MakeInvoice_Call struct {
 }
 
 // MakeInvoice is a helper method to define mock.On call
-//   - ctx context.Context
-//   - amount int64
-//   - description string
-//   - descriptionHash string
-//   - expiry int64
+//   - ctx
+//   - amount
+//   - description
+//   - descriptionHash
+//   - expiry
 func (_e *MockLNClient_Expecter) MakeInvoice(ctx interface{}, amount interface{}, description interface{}, descriptionHash interface{}, expiry interface{}) *MockLNClient_MakeInvoice_Call {
 	return &MockLNClient_MakeInvoice_Call{Call: _e.mock.On("MakeInvoice", ctx, amount, description, descriptionHash, expiry)}
 }
 
 func (_c *MockLNClient_MakeInvoice_Call) Run(run func(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64)) *MockLNClient_MakeInvoice_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 int64
-		if args[1] != nil {
-			arg1 = args[1].(int64)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		var arg3 string
-		if args[3] != nil {
-			arg3 = args[3].(string)
-		}
-		var arg4 int64
-		if args[4] != nil {
-			arg4 = args[4].(int64)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-			arg4,
-		)
+		run(args[0].(context.Context), args[1].(int64), args[2].(string), args[3].(string), args[4].(int64))
 	})
 	return _c
 }
@@ -1654,26 +1414,15 @@ type MockLNClient_MakeOffer_Call struct {
 }
 
 // MakeOffer is a helper method to define mock.On call
-//   - ctx context.Context
-//   - description string
+//   - ctx
+//   - description
 func (_e *MockLNClient_Expecter) MakeOffer(ctx interface{}, description interface{}) *MockLNClient_MakeOffer_Call {
 	return &MockLNClient_MakeOffer_Call{Call: _e.mock.On("MakeOffer", ctx, description)}
 }
 
 func (_c *MockLNClient_MakeOffer_Call) Run(run func(ctx context.Context, description string)) *MockLNClient_MakeOffer_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -1722,26 +1471,15 @@ type MockLNClient_OpenChannel_Call struct {
 }
 
 // OpenChannel is a helper method to define mock.On call
-//   - ctx context.Context
-//   - openChannelRequest *lnclient.OpenChannelRequest
+//   - ctx
+//   - openChannelRequest
 func (_e *MockLNClient_Expecter) OpenChannel(ctx interface{}, openChannelRequest interface{}) *MockLNClient_OpenChannel_Call {
 	return &MockLNClient_OpenChannel_Call{Call: _e.mock.On("OpenChannel", ctx, openChannelRequest)}
 }
 
 func (_c *MockLNClient_OpenChannel_Call) Run(run func(ctx context.Context, openChannelRequest *lnclient.OpenChannelRequest)) *MockLNClient_OpenChannel_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 *lnclient.OpenChannelRequest
-		if args[1] != nil {
-			arg1 = args[1].(*lnclient.OpenChannelRequest)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(context.Context), args[1].(*lnclient.OpenChannelRequest))
 	})
 	return _c
 }
@@ -1788,44 +1526,18 @@ type MockLNClient_RedeemOnchainFunds_Call struct {
 }
 
 // RedeemOnchainFunds is a helper method to define mock.On call
-//   - ctx context.Context
-//   - toAddress string
-//   - amount uint64
-//   - feeRate *uint64
-//   - sendAll bool
+//   - ctx
+//   - toAddress
+//   - amount
+//   - feeRate
+//   - sendAll
 func (_e *MockLNClient_Expecter) RedeemOnchainFunds(ctx interface{}, toAddress interface{}, amount interface{}, feeRate interface{}, sendAll interface{}) *MockLNClient_RedeemOnchainFunds_Call {
 	return &MockLNClient_RedeemOnchainFunds_Call{Call: _e.mock.On("RedeemOnchainFunds", ctx, toAddress, amount, feeRate, sendAll)}
 }
 
 func (_c *MockLNClient_RedeemOnchainFunds_Call) Run(run func(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool)) *MockLNClient_RedeemOnchainFunds_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 uint64
-		if args[2] != nil {
-			arg2 = args[2].(uint64)
-		}
-		var arg3 *uint64
-		if args[3] != nil {
-			arg3 = args[3].(*uint64)
-		}
-		var arg4 bool
-		if args[4] != nil {
-			arg4 = args[4].(bool)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-			arg4,
-		)
+		run(args[0].(context.Context), args[1].(string), args[2].(uint64), args[3].(*uint64), args[4].(bool))
 	})
 	return _c
 }
@@ -1863,20 +1575,14 @@ type MockLNClient_ResetRouter_Call struct {
 }
 
 // ResetRouter is a helper method to define mock.On call
-//   - key string
+//   - key
 func (_e *MockLNClient_Expecter) ResetRouter(key interface{}) *MockLNClient_ResetRouter_Call {
 	return &MockLNClient_ResetRouter_Call{Call: _e.mock.On("ResetRouter", key)}
 }
 
 func (_c *MockLNClient_ResetRouter_Call) Run(run func(key string)) *MockLNClient_ResetRouter_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
+		run(args[0].(string))
 	})
 	return _c
 }
@@ -1925,44 +1631,18 @@ type MockLNClient_SendKeysend_Call struct {
 }
 
 // SendKeysend is a helper method to define mock.On call
-//   - ctx context.Context
-//   - amount uint64
-//   - destination string
-//   - customRecords []lnclient.TLVRecord
-//   - preimage string
+//   - ctx
+//   - amount
+//   - destination
+//   - customRecords
+//   - preimage
 func (_e *MockLNClient_Expecter) SendKeysend(ctx interface{}, amount interface{}, destination interface{}, customRecords interface{}, preimage interface{}) *MockLNClient_SendKeysend_Call {
 	return &MockLNClient_SendKeysend_Call{Call: _e.mock.On("SendKeysend", ctx, amount, destination, customRecords, preimage)}
 }
 
 func (_c *MockLNClient_SendKeysend_Call) Run(run func(ctx context.Context, amount uint64, destination string, customRecords []lnclient.TLVRecord, preimage string)) *MockLNClient_SendKeysend_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 uint64
-		if args[1] != nil {
-			arg1 = args[1].(uint64)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		var arg3 []lnclient.TLVRecord
-		if args[3] != nil {
-			arg3 = args[3].([]lnclient.TLVRecord)
-		}
-		var arg4 string
-		if args[4] != nil {
-			arg4 = args[4].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-			arg4,
-		)
+		run(args[0].(context.Context), args[1].(uint64), args[2].(string), args[3].([]lnclient.TLVRecord), args[4].(string))
 	})
 	return _c
 }
@@ -2000,26 +1680,15 @@ type MockLNClient_SendPaymentProbes_Call struct {
 }
 
 // SendPaymentProbes is a helper method to define mock.On call
-//   - ctx context.Context
-//   - invoice string
+//   - ctx
+//   - invoice
 func (_e *MockLNClient_Expecter) SendPaymentProbes(ctx interface{}, invoice interface{}) *MockLNClient_SendPaymentProbes_Call {
 	return &MockLNClient_SendPaymentProbes_Call{Call: _e.mock.On("SendPaymentProbes", ctx, invoice)}
 }
 
 func (_c *MockLNClient_SendPaymentProbes_Call) Run(run func(ctx context.Context, invoice string)) *MockLNClient_SendPaymentProbes_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -2035,8 +1704,8 @@ func (_c *MockLNClient_SendPaymentProbes_Call) RunAndReturn(run func(ctx context
 }
 
 // SendPaymentSync provides a mock function for the type MockLNClient
-func (_mock *MockLNClient) SendPaymentSync(ctx context.Context, payReq string, amount *uint64, timeoutSeconds *int64) (*lnclient.PayInvoiceResponse, error) {
-	ret := _mock.Called(ctx, payReq, amount, timeoutSeconds)
+func (_mock *MockLNClient) SendPaymentSync(ctx context.Context, payReq string, amount *uint64) (*lnclient.PayInvoiceResponse, error) {
+	ret := _mock.Called(ctx, payReq, amount)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendPaymentSync")
@@ -2044,18 +1713,18 @@ func (_mock *MockLNClient) SendPaymentSync(ctx context.Context, payReq string, a
 
 	var r0 *lnclient.PayInvoiceResponse
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *uint64, *int64) (*lnclient.PayInvoiceResponse, error)); ok {
-		return returnFunc(ctx, payReq, amount, timeoutSeconds)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *uint64) (*lnclient.PayInvoiceResponse, error)); ok {
+		return returnFunc(ctx, payReq, amount)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *uint64, *int64) *lnclient.PayInvoiceResponse); ok {
-		r0 = returnFunc(ctx, payReq, amount, timeoutSeconds)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *uint64) *lnclient.PayInvoiceResponse); ok {
+		r0 = returnFunc(ctx, payReq, amount)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*lnclient.PayInvoiceResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *uint64, *int64) error); ok {
-		r1 = returnFunc(ctx, payReq, amount, timeoutSeconds)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *uint64) error); ok {
+		r1 = returnFunc(ctx, payReq, amount)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2068,38 +1737,16 @@ type MockLNClient_SendPaymentSync_Call struct {
 }
 
 // SendPaymentSync is a helper method to define mock.On call
-//   - ctx context.Context
-//   - payReq string
-//   - amount *uint64
-//   - timeoutSeconds *int64
-func (_e *MockLNClient_Expecter) SendPaymentSync(ctx interface{}, payReq interface{}, amount interface{}, timeoutSeconds interface{}) *MockLNClient_SendPaymentSync_Call {
-	return &MockLNClient_SendPaymentSync_Call{Call: _e.mock.On("SendPaymentSync", ctx, payReq, amount, timeoutSeconds)}
+//   - ctx
+//   - payReq
+//   - amount
+func (_e *MockLNClient_Expecter) SendPaymentSync(ctx interface{}, payReq interface{}, amount interface{}) *MockLNClient_SendPaymentSync_Call {
+	return &MockLNClient_SendPaymentSync_Call{Call: _e.mock.On("SendPaymentSync", ctx, payReq, amount)}
 }
 
-func (_c *MockLNClient_SendPaymentSync_Call) Run(run func(ctx context.Context, payReq string, amount *uint64, timeoutSeconds *int64)) *MockLNClient_SendPaymentSync_Call {
+func (_c *MockLNClient_SendPaymentSync_Call) Run(run func(ctx context.Context, payReq string, amount *uint64)) *MockLNClient_SendPaymentSync_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 *uint64
-		if args[2] != nil {
-			arg2 = args[2].(*uint64)
-		}
-		var arg3 *int64
-		if args[3] != nil {
-			arg3 = args[3].(*int64)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-		)
+		run(args[0].(context.Context), args[1].(string), args[2].(*uint64))
 	})
 	return _c
 }
@@ -2109,7 +1756,7 @@ func (_c *MockLNClient_SendPaymentSync_Call) Return(payInvoiceResponse *lnclient
 	return _c
 }
 
-func (_c *MockLNClient_SendPaymentSync_Call) RunAndReturn(run func(ctx context.Context, payReq string, amount *uint64, timeoutSeconds *int64) (*lnclient.PayInvoiceResponse, error)) *MockLNClient_SendPaymentSync_Call {
+func (_c *MockLNClient_SendPaymentSync_Call) RunAndReturn(run func(ctx context.Context, payReq string, amount *uint64) (*lnclient.PayInvoiceResponse, error)) *MockLNClient_SendPaymentSync_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2137,32 +1784,16 @@ type MockLNClient_SendSpontaneousPaymentProbes_Call struct {
 }
 
 // SendSpontaneousPaymentProbes is a helper method to define mock.On call
-//   - ctx context.Context
-//   - amountMsat uint64
-//   - nodeId string
+//   - ctx
+//   - amountMsat
+//   - nodeId
 func (_e *MockLNClient_Expecter) SendSpontaneousPaymentProbes(ctx interface{}, amountMsat interface{}, nodeId interface{}) *MockLNClient_SendSpontaneousPaymentProbes_Call {
 	return &MockLNClient_SendSpontaneousPaymentProbes_Call{Call: _e.mock.On("SendSpontaneousPaymentProbes", ctx, amountMsat, nodeId)}
 }
 
 func (_c *MockLNClient_SendSpontaneousPaymentProbes_Call) Run(run func(ctx context.Context, amountMsat uint64, nodeId string)) *MockLNClient_SendSpontaneousPaymentProbes_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 uint64
-		if args[1] != nil {
-			arg1 = args[1].(uint64)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
+		run(args[0].(context.Context), args[1].(uint64), args[2].(string))
 	})
 	return _c
 }
@@ -2200,26 +1831,15 @@ type MockLNClient_SettleHoldInvoice_Call struct {
 }
 
 // SettleHoldInvoice is a helper method to define mock.On call
-//   - ctx context.Context
-//   - preimage string
+//   - ctx
+//   - preimage
 func (_e *MockLNClient_Expecter) SettleHoldInvoice(ctx interface{}, preimage interface{}) *MockLNClient_SettleHoldInvoice_Call {
 	return &MockLNClient_SettleHoldInvoice_Call{Call: _e.mock.On("SettleHoldInvoice", ctx, preimage)}
 }
 
 func (_c *MockLNClient_SettleHoldInvoice_Call) Run(run func(ctx context.Context, preimage string)) *MockLNClient_SettleHoldInvoice_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -2310,26 +1930,15 @@ type MockLNClient_SignMessage_Call struct {
 }
 
 // SignMessage is a helper method to define mock.On call
-//   - ctx context.Context
-//   - message string
+//   - ctx
+//   - message
 func (_e *MockLNClient_Expecter) SignMessage(ctx interface{}, message interface{}) *MockLNClient_SignMessage_Call {
 	return &MockLNClient_SignMessage_Call{Call: _e.mock.On("SignMessage", ctx, message)}
 }
 
 func (_c *MockLNClient_SignMessage_Call) Run(run func(ctx context.Context, message string)) *MockLNClient_SignMessage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -2367,26 +1976,15 @@ type MockLNClient_UpdateChannel_Call struct {
 }
 
 // UpdateChannel is a helper method to define mock.On call
-//   - ctx context.Context
-//   - updateChannelRequest *lnclient.UpdateChannelRequest
+//   - ctx
+//   - updateChannelRequest
 func (_e *MockLNClient_Expecter) UpdateChannel(ctx interface{}, updateChannelRequest interface{}) *MockLNClient_UpdateChannel_Call {
 	return &MockLNClient_UpdateChannel_Call{Call: _e.mock.On("UpdateChannel", ctx, updateChannelRequest)}
 }
 
 func (_c *MockLNClient_UpdateChannel_Call) Run(run func(ctx context.Context, updateChannelRequest *lnclient.UpdateChannelRequest)) *MockLNClient_UpdateChannel_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 *lnclient.UpdateChannelRequest
-		if args[1] != nil {
-			arg1 = args[1].(*lnclient.UpdateChannelRequest)
-		}
-		run(
-			arg0,
-			arg1,
-		)
+		run(args[0].(context.Context), args[1].(*lnclient.UpdateChannelRequest))
 	})
 	return _c
 }

--- a/tests/mocks/Service.go
+++ b/tests/mocks/Service.go
@@ -555,20 +555,14 @@ type MockService_StartApp_Call struct {
 }
 
 // StartApp is a helper method to define mock.On call
-//   - encryptionKey string
+//   - encryptionKey
 func (_e *MockService_Expecter) StartApp(encryptionKey interface{}) *MockService_StartApp_Call {
 	return &MockService_StartApp_Call{Call: _e.mock.On("StartApp", encryptionKey)}
 }
 
 func (_c *MockService_StartApp_Call) Run(run func(encryptionKey string)) *MockService_StartApp_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
+		run(args[0].(string))
 	})
 	return _c
 }

--- a/transactions/app_payments_test.go
+++ b/transactions/app_payments_test.go
@@ -28,7 +28,7 @@ func TestSendPaymentSync_App_NoPermission(t *testing.T) {
 	assert.NoError(t, err)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.Equal(t, "app does not have pay_invoice scope", err.Error())
@@ -57,7 +57,7 @@ func TestSendPaymentSync_App_WithPermission(t *testing.T) {
 	assert.NoError(t, err)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -94,7 +94,7 @@ func TestSendPaymentSync_App_BudgetExceeded(t *testing.T) {
 	svc.EventPublisher.RegisterSubscriber(mockEventConsumer)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, NewQuotaExceededError())
@@ -141,7 +141,7 @@ func TestSendPaymentSync_App_BudgetExceeded_SettledPayment(t *testing.T) {
 	assert.NoError(t, err)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, NewQuotaExceededError())
@@ -180,7 +180,7 @@ func TestSendPaymentSync_App_BudgetExceeded_UnsettledPayment(t *testing.T) {
 	assert.NoError(t, err)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, NewQuotaExceededError())
@@ -220,7 +220,7 @@ func TestSendPaymentSync_App_BudgetNotExceeded_FailedPayment(t *testing.T) {
 	assert.NoError(t, err)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)

--- a/transactions/isolated_app_payments_test.go
+++ b/transactions/isolated_app_payments_test.go
@@ -37,7 +37,7 @@ func TestSendPaymentSync_IsolatedApp_NoBalance(t *testing.T) {
 	assert.NoError(t, err)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, NewInsufficientBalanceError())
@@ -79,7 +79,7 @@ func TestSendPaymentSync_IsolatedApp_BalanceInsufficient(t *testing.T) {
 	svc.EventPublisher.RegisterSubscriber(mockEventConsumer)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, NewInsufficientBalanceError())
@@ -125,7 +125,7 @@ func TestSendPaymentSync_IsolatedApp_BalanceSufficient(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -174,7 +174,7 @@ func TestSendPaymentSync_IsolatedApp_BalanceInsufficient_OutstandingPayment(t *t
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, NewInsufficientBalanceError())
@@ -220,7 +220,7 @@ func TestSendPaymentSync_IsolatedApp_BalanceInsufficient_SettledPayment(t *testi
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, NewInsufficientBalanceError())
@@ -265,7 +265,7 @@ func TestSendPaymentSync_IsolatedApp_BalanceSufficient_UnrelatedPayment(t *testi
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -313,7 +313,7 @@ func TestSendPaymentSync_IsolatedApp_BalanceSufficient_FailedPayment(t *testing.
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -355,7 +355,7 @@ func TestSendPaymentSync_IsolatedApp_BalanceInsufficientThenSufficient(t *testin
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, NewInsufficientBalanceError())
@@ -368,7 +368,7 @@ func TestSendPaymentSync_IsolatedApp_BalanceInsufficientThenSufficient(t *testin
 		AmountMsat: 10000, // add extra to cover fee reserves max of(10 sats or 1%)
 	})
 
-	transaction, err = transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err = transactionsService.SendPaymentSync(ctx, tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)

--- a/transactions/self_hold_payments_test.go
+++ b/transactions/self_hold_payments_test.go
@@ -35,7 +35,7 @@ func TestSelfHoldPaymentSettled(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		result, err := transactionsService.SendPaymentSync(ctx, transaction.PaymentRequest, nil, nil, svc.LNClient, nil, nil, nil)
+		result, err := transactionsService.SendPaymentSync(ctx, transaction.PaymentRequest, nil, nil, svc.LNClient, nil, nil)
 		assert.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Equal(t, constants.TRANSACTION_STATE_SETTLED, result.State)
@@ -73,7 +73,7 @@ func TestSelfHoldPaymentCanceled(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		result, err := transactionsService.SendPaymentSync(ctx, transaction.PaymentRequest, nil, nil, svc.LNClient, nil, nil, nil)
+		result, err := transactionsService.SendPaymentSync(ctx, transaction.PaymentRequest, nil, nil, svc.LNClient, nil, nil)
 		assert.ErrorIs(t, err, lnclient.NewHoldInvoiceCanceledError())
 		assert.Nil(t, result)
 

--- a/transactions/self_payments_test.go
+++ b/transactions/self_payments_test.go
@@ -34,7 +34,7 @@ func TestSendPaymentSync_SelfPayment_NoAppToNoApp(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockInvoice, nil, nil, svc.LNClient, nil, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockInvoice, nil, nil, svc.LNClient, nil, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -86,7 +86,7 @@ func TestSendPaymentSync_SelfPayment_NoAppToIsolatedApp(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockInvoice, nil, nil, svc.LNClient, nil, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockInvoice, nil, nil, svc.LNClient, nil, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -139,7 +139,7 @@ func TestSendPaymentSync_SelfPayment_NoAppToApp(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockInvoice, nil, nil, svc.LNClient, nil, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockInvoice, nil, nil, svc.LNClient, nil, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -208,7 +208,7 @@ func TestSendPaymentSync_SelfPayment_IsolatedAppToNoApp(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockInvoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockInvoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -283,7 +283,7 @@ func TestSendPaymentSync_SelfPayment_IsolatedAppToApp(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockInvoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockInvoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -365,7 +365,7 @@ func TestSendPaymentSync_SelfPayment_IsolatedAppToIsolatedApp(t *testing.T) {
 	svc.EventPublisher.RegisterSubscriber(mockEventConsumer)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockInvoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockInvoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -457,7 +457,7 @@ func TestSendPaymentSync_SelfPayment_IsolatedAppToSelf(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockInvoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.SendPaymentSync(ctx, tests.MockInvoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)

--- a/transactions/transactions_service.go
+++ b/transactions/transactions_service.go
@@ -38,7 +38,7 @@ type TransactionsService interface {
 	MakeInvoice(ctx context.Context, amount uint64, description string, descriptionHash string, expiry uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error)
 	LookupTransaction(ctx context.Context, paymentHash string, transactionType *string, lnClient lnclient.LNClient, appId *uint) (*Transaction, error)
 	ListTransactions(ctx context.Context, from, until, limit, offset uint64, unpaidOutgoing bool, unpaidIncoming bool, transactionType *string, lnClient lnclient.LNClient, appId *uint, forceFilterByAppId bool) (transactions []Transaction, totalCount uint64, err error)
-	SendPaymentSync(ctx context.Context, payReq string, amountMsat *uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint, timeoutSeconds *int64) (*Transaction, error)
+	SendPaymentSync(ctx context.Context, payReq string, amountMsat *uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error)
 	SendKeysend(ctx context.Context, amount uint64, destination string, customRecords []lnclient.TLVRecord, preimage string, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error)
 	MakeHoldInvoice(ctx context.Context, amount uint64, description string, descriptionHash string, expiry uint64, paymentHash string, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error)
 	SettleHoldInvoice(ctx context.Context, preimage string, lnClient lnclient.LNClient) (*Transaction, error)
@@ -266,7 +266,7 @@ func (svc *transactionsService) MakeHoldInvoice(ctx context.Context, amount uint
 	return &dbTransaction, nil
 }
 
-func (svc *transactionsService) SendPaymentSync(ctx context.Context, payReq string, amountMsat *uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint, timeoutSeconds *int64) (*Transaction, error) {
+func (svc *transactionsService) SendPaymentSync(ctx context.Context, payReq string, amountMsat *uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error) {
 	var metadataBytes []byte
 	if metadata != nil {
 		var err error
@@ -382,7 +382,7 @@ func (svc *transactionsService) SendPaymentSync(ctx context.Context, payReq stri
 	if selfPayment {
 		response, err = svc.interceptSelfPayment(ctx, paymentRequest.PaymentHash, lnClient)
 	} else {
-		response, err = lnClient.SendPaymentSync(ctx, payReq, amountMsat, timeoutSeconds)
+		response, err = lnClient.SendPaymentSync(ctx, payReq, amountMsat)
 	}
 
 	if err != nil {
@@ -390,16 +390,6 @@ func (svc *transactionsService) SendPaymentSync(ctx context.Context, payReq stri
 			"bolt11": payReq,
 		}).WithError(err).Error("Failed to send payment")
 
-		if errors.Is(err, lnclient.NewTimeoutError()) {
-			logger.Logger.WithFields(logrus.Fields{
-				"bolt11": payReq,
-			}).WithError(err).Error("Timed out waiting for payment to be sent. It may still succeed. Skipping update of transaction status")
-			// we cannot update the payment to failed as it still might succeed.
-			// we'll need to check the status of it later
-			return nil, err
-		}
-
-		// As the LNClient did not return a timeout error, we assume the payment definitely failed
 		svc.db.Transaction(func(tx *gorm.DB) error {
 			return svc.markPaymentFailed(tx, &dbTransaction, err.Error())
 		})
@@ -535,29 +525,6 @@ func (svc *transactionsService) SendKeysend(ctx context.Context, amount uint64, 
 			"amount":      amount,
 		}).WithError(err).Error("Failed to send payment")
 
-		if errors.Is(err, lnclient.NewTimeoutError()) {
-
-			logger.Logger.WithFields(logrus.Fields{
-				"destination": destination,
-				"amount":      amount,
-			}).WithError(err).Error("Timed out waiting for payment to be sent. It may still succeed. Skipping update of transaction status")
-
-			// we cannot update the payment to failed as it still might succeed.
-			// we'll need to check the status of it later
-			// but we have the payment hash now, so save it on the transaction
-			dbErr := svc.db.Model(&dbTransaction).Updates(&db.Transaction{
-				PaymentHash: paymentHash,
-			}).Error
-			if dbErr != nil {
-				logger.Logger.WithFields(logrus.Fields{
-					"destination": destination,
-					"amount":      amount,
-				}).WithError(dbErr).Error("Failed to update DB transaction")
-			}
-			return nil, err
-		}
-
-		// As the LNClient did not return a timeout error, we assume the payment definitely failed
 		dbErr := svc.db.Model(&dbTransaction).Updates(&db.Transaction{
 			PaymentHash: paymentHash,
 			State:       constants.TRANSACTION_STATE_FAILED,
@@ -1003,6 +970,7 @@ func (svc *transactionsService) interceptSelfHoldPayment(ctx context.Context, pa
 	holdInvoiceUpdatedConsumer := newHoldInvoiceUpdatedConsumer(paymentHash, settledChannel, canceledChannel)
 
 	svc.eventPublisher.RegisterSubscriber(holdInvoiceUpdatedConsumer)
+	defer svc.eventPublisher.RemoveSubscriber(holdInvoiceUpdatedConsumer)
 
 	clientInfo, err := lnClient.GetInfo(ctx)
 	if err != nil {
@@ -1030,15 +998,7 @@ func (svc *transactionsService) interceptSelfHoldPayment(ctx context.Context, pa
 	case canceledTransaction := <-canceledChannel:
 		logger.Logger.WithField("canceled_transaction", canceledTransaction).Info("self hold payment was canceled")
 		return nil, lnclient.NewHoldInvoiceCanceledError()
-	case <-time.After(50 * time.Second):
-		logger.Logger.WithFields(logrus.Fields{
-			"payment_hash": paymentHash,
-		}).Error("Timeout executing self payment for hold invoice")
 	}
-
-	svc.eventPublisher.RemoveSubscriber(holdInvoiceUpdatedConsumer)
-
-	return nil, lnclient.NewTimeoutError()
 }
 
 func (svc *transactionsService) validateCanPay(tx *gorm.DB, appId *uint, amount uint64, description string, selfPayment bool) error {


### PR DESCRIPTION
Closes https://github.com/getAlby/hub/issues/1520

Now LDK SendPaymentSync will not return until the payment definitely succeeds or fails.

Both LDK and LND will have ~50-60 seconds to successfully initiate the payment or they will return an error. But if the payment is initiated and stuck along the path or held, there will be no timeout. So things like swaps and hold invoice payments will work as expected.

In the hub UI on the wallet send screen, the payment will also be pending until it definitely succeeds or fails.

Only in NWC (Alby JS SDK) we will return an error after 50 seconds, as it is configured there currently.

Also it is good to remove a decent amount of code :bomb: 