### PR TITLE
fix: use actual swap limits from boltz api

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -746,6 +746,8 @@ func (api *api) GetSwapInFees() (*SwapFeesResponse, error) {
 		AlbyServiceFee:  swapInFees.AlbyServiceFee,
 		BoltzServiceFee: swapInFees.BoltzServiceFee,
 		BoltzNetworkFee: swapInFees.BoltzNetworkFee,
+		MinAmount:       swapInFees.MinAmount,
+		MaxAmount:       swapInFees.MaxAmount,
 	}, nil
 }
 
@@ -760,6 +762,8 @@ func (api *api) GetSwapOutFees() (*SwapFeesResponse, error) {
 		AlbyServiceFee:  swapOutFees.AlbyServiceFee,
 		BoltzServiceFee: swapOutFees.BoltzServiceFee,
 		BoltzNetworkFee: swapOutFees.BoltzNetworkFee,
+		MinAmount:       swapOutFees.MinAmount,
+		MaxAmount:       swapOutFees.MaxAmount,
 	}, nil
 }
 

--- a/api/models.go
+++ b/api/models.go
@@ -173,6 +173,8 @@ type SwapFeesResponse struct {
 	AlbyServiceFee  float64 `json:"albyServiceFee"`
 	BoltzServiceFee float64 `json:"boltzServiceFee"`
 	BoltzNetworkFee uint64  `json:"boltzNetworkFee"`
+	MinAmount       uint64  `json:"minAmount"`
+	MaxAmount       uint64  `json:"maxAmount"`
 }
 
 type ListSwapsResponse struct {

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -14,8 +14,6 @@ export const ALBY_MIN_HOSTED_BALANCE_FOR_FIRST_CHANNEL = 30_000;
 export const LIST_TRANSACTIONS_LIMIT = 20;
 export const LIST_APPS_LIMIT = 20;
 
-export const MIN_SWAP_AMOUNT = 50_000;
-
 export const SUPPORT_ALBY_CONNECTION_NAME = `ZapPlanner - Alby Hub`;
 export const SUPPORT_ALBY_LIGHTNING_ADDRESS = "hub@getalby.com";
 

--- a/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
@@ -42,7 +42,6 @@ import { Input } from "src/components/ui/input";
 import { Label } from "src/components/ui/label";
 import { LoadingButton } from "src/components/ui/loading-button";
 import { useTheme } from "src/components/ui/theme-provider";
-import { MIN_SWAP_AMOUNT } from "src/constants";
 import { useBalances } from "src/hooks/useBalances";
 import { useSwapFees } from "src/hooks/useSwaps";
 import { request } from "src/utils/request";
@@ -315,7 +314,7 @@ function ReceiveToSpending() {
     }
   };
 
-  if (!info || !balances) {
+  if (!info || !balances || !swapFees) {
     return <Loading />;
   }
 
@@ -343,8 +342,11 @@ function ReceiveToSpending() {
             autoFocus
             placeholder="Amount in satoshis"
             value={swapAmount}
-            min={MIN_SWAP_AMOUNT}
-            max={(balances.lightning.totalReceivable / 1000) * 0.99}
+            min={swapFees.minAmount}
+            max={Math.min(
+              swapFees.maxAmount,
+              (balances.lightning.totalReceivable / 1000) * 0.99
+            )}
             onChange={(e) => setSwapAmount(e.target.value)}
             required
             className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
@@ -370,8 +372,14 @@ function ReceiveToSpending() {
               />
             </div>
             <div className="flex justify-between text-muted-foreground text-xs sensitive slashed-zero">
-              <div>Minimum: 50000 sats</div>
-              <FormattedFiatAmount className="text-xs" amount={50000} />
+              <div>
+                Minimum: {new Intl.NumberFormat().format(swapFees.minAmount)}{" "}
+                sats
+              </div>
+              <FormattedFiatAmount
+                className="text-xs"
+                amount={swapFees.minAmount}
+              />
             </div>
           </div>
         </div>
@@ -379,21 +387,13 @@ function ReceiveToSpending() {
         <div className="border-t pt-4 text-sm grid gap-2">
           <div className="flex items-center justify-between">
             <p className="text-muted-foreground">On-chain Fee</p>
-            {swapFees ? (
-              <p>
-                ~{new Intl.NumberFormat().format(swapFees.boltzNetworkFee)} sats
-              </p>
-            ) : (
-              <Loading />
-            )}
+            <p>
+              ~{new Intl.NumberFormat().format(swapFees.boltzNetworkFee)} sats
+            </p>
           </div>
           <div className="flex items-center justify-between">
             <p className="text-muted-foreground">Swap Fee</p>
-            {swapFees ? (
-              <p>{swapFees.albyServiceFee + swapFees.boltzServiceFee}%</p>
-            ) : (
-              <Loading />
-            )}
+            <p>{swapFees.albyServiceFee + swapFees.boltzServiceFee}%</p>
           </div>
         </div>
         <div className="grid gap-2">

--- a/frontend/src/screens/wallet/send/Onchain.tsx
+++ b/frontend/src/screens/wallet/send/Onchain.tsx
@@ -11,7 +11,7 @@ import { Label } from "src/components/ui/label";
 import { LoadingButton } from "src/components/ui/loading-button";
 import { Switch } from "src/components/ui/switch";
 import { useToast } from "src/components/ui/use-toast";
-import { MIN_SWAP_AMOUNT, ONCHAIN_DUST_SATS } from "src/constants";
+import { ONCHAIN_DUST_SATS } from "src/constants";
 import { useBalances } from "src/hooks/useBalances";
 import { useMempoolApi } from "src/hooks/useMempoolApi";
 import { useSwapFees } from "src/hooks/useSwaps";
@@ -272,7 +272,7 @@ function SwapForm({
     }
   };
 
-  if (!balances) {
+  if (!balances || !swapFees) {
     return <Loading />;
   }
 
@@ -288,8 +288,11 @@ function SwapForm({
           onChange={(e) => {
             setAmount(e.target.value.trim());
           }}
-          min={MIN_SWAP_AMOUNT}
-          max={Math.floor(balances.lightning.totalSpendable / 1000)}
+          min={swapFees.minAmount}
+          max={Math.min(
+            swapFees.maxAmount,
+            Math.floor(balances.lightning.totalSpendable / 1000)
+          )}
           required
           autoFocus
           className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
@@ -312,8 +315,13 @@ function SwapForm({
             />
           </div>
           <div className="flex justify-between text-muted-foreground text-xs sensitive slashed-zero">
-            <div>Minimum: 50000 sats</div>
-            <FormattedFiatAmount className="text-xs" amount={50000} />
+            <div>
+              Minimum: {new Intl.NumberFormat().format(swapFees.minAmount)} sats
+            </div>
+            <FormattedFiatAmount
+              className="text-xs"
+              amount={swapFees.minAmount}
+            />
           </div>
         </div>
       </div>
@@ -326,21 +334,13 @@ function SwapForm({
       <div className="grid gap-2 text-sm border-t pt-4">
         <div className="flex items-center justify-between">
           <p className="text-muted-foreground">On-chain Fee</p>
-          {swapFees ? (
-            <p>
-              ~{new Intl.NumberFormat().format(swapFees.boltzNetworkFee)} sats
-            </p>
-          ) : (
-            <Loading className="w-4 h-4" />
-          )}
+          <p>
+            ~{new Intl.NumberFormat().format(swapFees.boltzNetworkFee)} sats
+          </p>
         </div>
         <div className="flex items-center justify-between">
           <p className="text-muted-foreground">Swap Fee</p>
-          {swapFees ? (
-            <p>{swapFees.albyServiceFee + swapFees.boltzServiceFee}%</p>
-          ) : (
-            <Loading className="w-4 h-4" />
-          )}
+          <p>{swapFees.albyServiceFee + swapFees.boltzServiceFee}%</p>
         </div>
       </div>
       <div className="flex gap-2">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -207,6 +207,8 @@ export type SwapFees = {
   albyServiceFee: number;
   boltzServiceFee: number;
   boltzNetworkFee: number;
+  minAmount: number;
+  maxAmount: number;
 };
 
 export type BaseSwap = {

--- a/swaps/swaps_service.go
+++ b/swaps/swaps_service.go
@@ -88,6 +88,8 @@ type SwapFees struct {
 	AlbyServiceFee  float64 `json:"albyServiceFee"`
 	BoltzServiceFee float64 `json:"boltzServiceFee"`
 	BoltzNetworkFee uint64  `json:"boltzNetworkFee"`
+	MinAmount       uint64  `json:"minAmount"`
+	MaxAmount       uint64  `json:"maxAmount"`
 }
 
 type SwapResponse struct {
@@ -517,11 +519,14 @@ func (svc *swapsService) CalculateSwapOutFee() (*SwapFees, error) {
 
 	fees := pairInfo.Fees
 	networkFee := fees.MinerFees.Lockup + fees.MinerFees.Claim
+	limits := pairInfo.Limits
 
 	return &SwapFees{
 		AlbyServiceFee:  AlbySwapServiceFee,
 		BoltzServiceFee: fees.Percentage,
 		BoltzNetworkFee: networkFee,
+		MinAmount:       limits.Minimal,
+		MaxAmount:       limits.Maximal,
 	}, nil
 }
 
@@ -538,11 +543,14 @@ func (svc *swapsService) CalculateSwapInFee() (*SwapFees, error) {
 	}
 
 	fees := pairInfo.Fees
+	limits := pairInfo.Limits
 
 	return &SwapFees{
 		AlbyServiceFee:  AlbySwapServiceFee,
 		BoltzServiceFee: fees.Percentage,
 		BoltzNetworkFee: fees.MinerFees,
+		MinAmount:       limits.Minimal,
+		MaxAmount:       limits.Maximal,
 	}, nil
 }
 


### PR DESCRIPTION
This PR adds fetching swap min and max amounts from the boltz api instead of hardcoding to `50_000` sats

Addresses this [comment](https://github.com/getAlby/hub/pull/1585#discussion_r2272384741)