### PR TITLE
chore: shift send receive buttons in wallet page

### DIFF
--- a/frontend/src/screens/wallet/index.tsx
+++ b/frontend/src/screens/wallet/index.tsx
@@ -11,7 +11,6 @@ import ExternalLink from "src/components/ExternalLink";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
 import Loading from "src/components/Loading";
 import LowReceivingCapacityAlert from "src/components/LowReceivingCapacityAlert";
-import ResponsiveButton from "src/components/ResponsiveButton";
 import TransactionsList from "src/components/TransactionsList";
 import {
   Alert,
@@ -19,6 +18,7 @@ import {
   AlertTitle,
 } from "src/components/ui/alert.tsx";
 import { Button } from "src/components/ui/button";
+import { LinkButton } from "src/components/ui/custom/link-button";
 import { useBalances } from "src/hooks/useBalances";
 import { useChannels } from "src/hooks/useChannels";
 import { useInfo } from "src/hooks/useInfo";
@@ -39,12 +39,22 @@ function Wallet() {
         description=""
         contentRight={
           <>
-            <Link to="/wallet/receive">
-              <ResponsiveButton icon={ArrowDownIcon} text="Receive" size="lg" />
-            </Link>
-            <Link to="/wallet/send">
-              <ResponsiveButton icon={ArrowUpIcon} text="Send" size="lg" />
-            </Link>
+            <LinkButton
+              to="/wallet/receive"
+              size="lg"
+              className="hidden xl:inline-flex !px-12"
+            >
+              <ArrowDownIcon />
+              Receive
+            </LinkButton>
+            <LinkButton
+              to="/wallet/send"
+              size="lg"
+              className="hidden xl:inline-flex !px-12"
+            >
+              <ArrowUpIcon />
+              Send
+            </LinkButton>
           </>
         }
       />
@@ -85,8 +95,8 @@ function Wallet() {
           </AlertDescription>
         </Alert>
       )}
-      <div className="flex flex-col xl:flex-row justify-between xl:items-start gap-5">
-        <div className="flex flex-col gap-1 text-center xl:text-left">
+      <div className="flex flex-col xl:flex-row justify-between xl:items-start gap-3">
+        <div className="flex flex-col gap-1 p-6 xl:p-0 text-center xl:text-left">
           <div className="text-5xl font-medium balance sensitive slashed-zero">
             {new Intl.NumberFormat().format(
               Math.floor(balances.lightning.totalSpendable / 1000)
@@ -97,6 +107,14 @@ function Wallet() {
             className="text-xl"
             amount={balances.lightning.totalSpendable / 1000}
           />
+        </div>
+        <div className="grid grid-cols-2 items-center gap-3 xl:hidden">
+          <LinkButton to="/wallet/receive" size="lg">
+            Receive
+          </LinkButton>
+          <LinkButton to="/wallet/send" size="lg">
+            Send
+          </LinkButton>
         </div>
         <div className="grid grid-cols-2 items-center gap-3">
           <ExternalLink to="https://www.getalby.com/topup">


### PR DESCRIPTION
## Description

Shifts the Send/Receive buttons from the top to under the wallet balance, as per the Alby Hub 2.0 design

<table>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/25ec1d32-7435-4974-b5f3-c1e81863db45" />
</td>
<td>
<img src="https://github.com/user-attachments/assets/512f0ced-7cd9-4e61-8b10-7311386cdbf9" />
</td>
</tr>
</table>