### PR TITLE
Fix: husky 10 warning

### DIFF
--- a/frontend/.husky/commit-msg
+++ b/frontend/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 cd frontend && yarn commitlint --edit 

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 cd frontend && yarn lint-staged


### PR DESCRIPTION
```
husky - DEPRECATED

Please remove the following two lines from frontend/.husky/commit-msg:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0

husky - DEPRECATED

Please remove the following two lines from frontend/.husky/pre-commit:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0
```