### PR TITLE
fix: disconnect LDK peer on connect only if address changes

### DIFF
--- a/frontend/src/components/channels/LDKChannelWithoutPeerAlert.tsx
+++ b/frontend/src/components/channels/LDKChannelWithoutPeerAlert.tsx
@@ -1,0 +1,65 @@
+import { AlertTriangleIcon } from "lucide-react";
+import { Link } from "react-router-dom";
+import ExternalLink from "src/components/ExternalLink";
+import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
+import { useChannels } from "src/hooks/useChannels";
+import { useInfo } from "src/hooks/useInfo";
+import { useNodeDetails } from "src/hooks/useNodeDetails";
+import { usePeers } from "src/hooks/usePeers";
+import { Channel } from "src/types";
+
+export function LDKChannelWithoutPeerAlert() {
+  const { data: info } = useInfo();
+  const { data: peers } = usePeers();
+  const { data: channels } = useChannels();
+
+  if (info?.backendType !== "LDK") {
+    // LND does not show disconnected peers
+    return null;
+  }
+
+  const channelWithoutPeer = channels?.find(
+    (channel) => !peers?.some((peer) => peer.nodeId === channel.remotePubkey)
+  );
+  if (!channelWithoutPeer) {
+    return null;
+  }
+
+  return <ChannelWithoutPeerAlertInternal channel={channelWithoutPeer} />;
+}
+
+function ChannelWithoutPeerAlertInternal({ channel }: { channel: Channel }) {
+  const { data: nodeDetails } = useNodeDetails(channel.remotePubkey);
+  return (
+    <Alert>
+      <AlertTriangleIcon className="h-4 w-4" />
+      <AlertTitle>
+        Channel with peer{" "}
+        {nodeDetails?.alias || channel.remotePubkey.substring(0, 8) + "..."} is
+        not peered
+      </AlertTitle>
+      <AlertDescription>
+        <p>
+          Your channel will be offline until you manually reconnect to this
+          peer.
+        </p>
+        <p>
+          1. Copy the peer connection details from{" "}
+          <ExternalLink
+            to={`https://amboss.space/node/${channel.remotePubkey}`}
+            className="font-semibold inline-flex gap-2"
+          >
+            amboss.space
+          </ExternalLink>{" "}
+        </p>
+        <p>
+          2. Open{" "}
+          <Link to="/peers" className="font-semibold">
+            Peers
+          </Link>{" "}
+          to re-connect the peer.
+        </p>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -19,6 +19,7 @@ import AppHeader from "src/components/AppHeader.tsx";
 import { ChannelsCards } from "src/components/channels/ChannelsCards.tsx";
 import { ChannelsTable } from "src/components/channels/ChannelsTable.tsx";
 import { HealthCheckAlert } from "src/components/channels/HealthcheckAlert";
+import { LDKChannelWithoutPeerAlert } from "src/components/channels/LDKChannelWithoutPeerAlert";
 import { OnchainTransactionsTable } from "src/components/channels/OnchainTransactionsTable.tsx";
 import EmptyState from "src/components/EmptyState.tsx";
 import ExternalLink from "src/components/ExternalLink";
@@ -582,6 +583,8 @@ export default function Channels() {
               buttonLink="/channels/incoming"
             />
           )}
+
+          <LDKChannelWithoutPeerAlert />
 
           <ChannelsTable
             channels={channels}


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/1627

Also added a reconnect peer option in peers page, for LDK nodes (normally this will happen at least once per hour, due to the maximum exponential backoff)

Also shows an alert on the node page for LDK if you have a channel open and the channel's remote pubkey is not in your list of peers (this means the channel will only become online if the counterparty initiates the connection).

<img width="2320" height="794" alt="image" src="https://github.com/user-attachments/assets/b1fccb4c-e65e-4cab-88d0-7164f95059c7" />
