### PR TITLE
fix: optimize App Store Alby Extension download flow (#1624)

### DIFF
--- a/frontend/src/components/SuggestedAppData.tsx
+++ b/frontend/src/components/SuggestedAppData.tsx
@@ -115,7 +115,7 @@ export const suggestedApps: SuggestedApp[] = [
     id: "alby-extension",
     title: "Alby Extension",
     description: "Wallet in your browser",
-    webLink: "https://getalby.com/",
+    webLink: "https://getalby.com/products/browser-extension",
     chromeLink:
       "https://chromewebstore.google.com/detail/iokeahhehimjnekafflcihljlcjccdbe",
     firefoxLink: "https://addons.mozilla.org/en-US/firefox/addon/alby/",


### PR DESCRIPTION
Change webLink from homepage to specific extension page.
Now the users will be able to jump right into the extension download page when clicking on the weblink in both places mentioned in the issue.