### PR TITLE
fix: remove Alby Cloud sidebar link

### DIFF
--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -279,8 +279,6 @@ export function NavSecondary({
     icon: LucideIcon;
   }[];
 } & React.ComponentPropsWithoutRef<typeof SidebarGroup>) {
-  const { data: albyMe } = useAlbyMe();
-  const { data: info } = useInfo();
   const { setOpenMobile } = useSidebar();
 
   return (
@@ -311,16 +309,6 @@ export function NavSecondary({
               </SidebarMenuButton>
             </SidebarMenuItem>
           </ExternalLink>
-          {!albyMe?.subscription.plan_code && info?.albyAccountConnected && (
-            <ExternalLink to="https://getalby.com/subscription/pro">
-              <SidebarMenuItem>
-                <SidebarMenuButton>
-                  <Sparkles className="h-4 w-4" />
-                  Alby Pro
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </ExternalLink>
-          )}
         </SidebarMenu>
       </SidebarGroupContent>
     </SidebarGroup>

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -2,7 +2,6 @@ import {
   BoxIcon,
   ChevronsUpDown,
   CircleHelp,
-  Cloud,
   HomeIcon,
   LogOut,
   LucideIcon,
@@ -316,8 +315,8 @@ export function NavSecondary({
             <ExternalLink to="https://getalby.com/subscription/pro">
               <SidebarMenuItem>
                 <SidebarMenuButton>
-                  <Cloud className="h-4 w-4" />
-                  Alby Cloud
+                  <Sparkles className="h-4 w-4" />
+                  Alby Pro
                 </SidebarMenuButton>
               </SidebarMenuItem>
             </ExternalLink>

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -311,7 +311,7 @@ export function NavSecondary({
               </SidebarMenuButton>
             </SidebarMenuItem>
           </ExternalLink>
-          {!albyMe?.hub.name && info?.albyAccountConnected && (
+          {!albyMe?.subscription.plan_code && info?.albyAccountConnected && (
             <ExternalLink to="https://getalby.com/subscription/pro">
               <SidebarMenuItem>
                 <SidebarMenuButton>


### PR DESCRIPTION
<img width="519" height="1555" alt="image" src="https://github.com/user-attachments/assets/1dc6957e-2b19-4a0c-9973-1449523d9ad6" />

Later this could be "Upgrade" and also recommend Alby Cloud?