### PR TITLE
feat: display apps in command palette

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -19,16 +19,17 @@ import {
 } from "lucide-react";
 import * as React from "react";
 import { useNavigate } from "react-router-dom";
+import AppAvatar from "src/components/AppAvatar";
 
 import {
   CommandDialog,
-  CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
   CommandList,
   CommandSeparator,
 } from "src/components/ui/command";
+import { useApps } from "src/hooks/useApps";
 
 interface CommandPaletteProps {
   open?: boolean;
@@ -37,6 +38,17 @@ interface CommandPaletteProps {
 
 export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const navigate = useNavigate();
+  const [searchText, setSearchText] = React.useState("");
+
+  const { data: connectedAppsByAppName } = useApps(
+    undefined,
+    undefined,
+    {
+      name: searchText,
+    },
+    undefined,
+    !!searchText?.length
+  );
 
   const runCommand = React.useCallback(
     (command: () => void) => {
@@ -48,9 +60,14 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 
   return (
     <CommandDialog open={open} onOpenChange={onOpenChange}>
-      <CommandInput placeholder="Type a command or search..." />
+      <CommandInput
+        placeholder="Type a command or search..."
+        value={searchText}
+        onValueChange={setSearchText}
+      />
+
       <CommandList>
-        <CommandEmpty>No results found.</CommandEmpty>
+        {/* <CommandEmpty>No results found</CommandEmpty> */}
         <CommandGroup heading="Navigation">
           <CommandItem onSelect={() => runCommand(() => navigate("/home"))}>
             <Home />
@@ -190,6 +207,19 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             <span>Open First Channel</span>
           </CommandItem>
         </CommandGroup>
+        {!!connectedAppsByAppName?.apps.length && (
+          <CommandGroup heading="Connected Apps" forceMount>
+            {connectedAppsByAppName?.apps.map((app) => (
+              <CommandItem
+                key={app.id}
+                onSelect={() => runCommand(() => navigate(`/apps/${app.id}`))}
+              >
+                <AppAvatar app={app} className="w-4 h-4" />
+                <span>{app.name}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
       </CommandList>
     </CommandDialog>
   );


### PR DESCRIPTION
Unfortunately the command component is a bit buggy and doesn't seem to handle dynamic commands well :confused:  so it's not perfect. I had to hide the empty state as it incorrectly shows empty even if it finds an app, and sometimes the focus is wrong so I put the connected apps at the bottom of the list.