### PR TITLE
fix: use InvoicePaid state to mark swap in success

### DIFF
--- a/swaps/swaps_service.go
+++ b/swaps/swaps_service.go
@@ -954,7 +954,7 @@ func (svc *swapsService) startSwapInListener(swap *db.Swap) {
 					"swapId":     swap.SwapId,
 					"lockupTxId": swap.LockupTxId,
 				}).Info("Lockup transaction confirmed in mempool")
-			case boltz.TransactionClaimed:
+			case boltz.InvoicePaid:
 				svc.markSwapState(swap, constants.SWAP_STATE_SUCCESS)
 				err = svc.db.Model(swap).Updates(&db.Swap{
 					ReceiveAmount: amount,


### PR DESCRIPTION
Fixes #1669

We used to wait for `TransactionClaimed` state before which is sent when Boltz successfully claims the bitcoin onchain. I think the best thing to do is to listen on `InvoicePaid` state as that would be in sync with the Hub's state (in transactions list)