### PR TITLE
Add Educational Links to Channel Warning Messages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -111,6 +111,5 @@
     "vite": "^5.4.0",
     "vite-plugin-pwa": "^0.20.1",
     "vite-tsconfig-paths": "^4.3.2"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }


### PR DESCRIPTION
This PR adds "Learn more here" links to channel warning messages to help users understand and resolve channel issues.
Changes:
Offline channels: [Links to channel offline FAQ](https://guides.getalby.com/user-guide/alby-hub/faq/why-is-my-channel-offline-and-what-should-i-do-now)
Low receiving capacity: [Links to receiving capacity documentation](https://guides.getalby.com/user-guide/alby-hub/node#what-is-receiving-capacity-and-spending-balance-in-lightning-terminology)