### PR TITLE
fix: filter out suggestions that do not allow public channels if the order is for a public channel

### DIFF
--- a/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
@@ -157,6 +157,7 @@ function NewChannelInternal({
       partner.paymentMethod === "lightning" &&
       partner.type === "LSPS1" &&
       partner.pubkey &&
+      (partner.publicChannelsAllowed || !order.isPublic) &&
       !channels.some((channel) => channel.remotePubkey === partner.pubkey)
   );
 


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/1696