### PR TITLE
feat: add support for cron tabs in zapplanner

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "compare-versions": "^6.1.1",
+    "cron-parser": "^5.3.1",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.10",
     "embla-carousel-react": "^8.6.0",

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import { clsx, type ClassValue } from "clsx";
+import { CronExpressionParser } from "cron-parser";
 import { BudgetRenewalType } from "src/types";
 import { twMerge } from "tailwind-merge";
 
@@ -74,4 +75,39 @@ export function getBudgetRenewalLabel(renewalType: BudgetRenewalType): string {
     case "":
       return "";
   }
+}
+
+export function isValidCronExpression(cronExpression: string): boolean {
+  try {
+    CronExpressionParser.parse(cronExpression);
+    return true;
+  } catch (error) {
+    console.error(error);
+    return false;
+  }
+}
+
+// counts the total number of cron runs in the current month
+export function countCronRuns(cronExpression: string) {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth() + 1;
+
+  const startDate = new Date(year, month - 1, 1, 0, 0, 0);
+  const endDate = new Date(year, month, 0, 23, 59, 59);
+
+  const options = { currentDate: startDate, endDate };
+  const interval = CronExpressionParser.parse(cronExpression, options);
+
+  let count = 0;
+  try {
+    while (true) {
+      interval.next();
+      count++;
+    }
+  } catch (error) {
+    console.error(error);
+  }
+
+  return count;
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3067,6 +3067,13 @@ cosmiconfig@^9.0.0:
     js-yaml "^4.1.0"
     parse-json "^5.2.0"
 
+cron-parser@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-5.3.1.tgz#cb74511fb7ae36bcbe2bff7529577767af82a2a0"
+  integrity sha512-Mu5Jk1b4cUfY8u34+thI9TZxvQiuhaMBS2Ag84rOSoHlU33xtIPkXwr6lWuw3XPmxSxq317B+hl0o4J+LdhwNg==
+  dependencies:
+    luxon "^3.7.1"
+
 cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
@@ -4643,6 +4650,11 @@ lucide-react@^0.525.0:
   version "0.525.0"
   resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.525.0.tgz#5f7bcecd65e4f9b2b5b6b5d295e3376df032d5e3"
   integrity sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==
+
+luxon@^3.7.1:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.7.2.tgz#d697e48f478553cca187a0f8436aff468e3ba0ba"
+  integrity sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==
 
 magic-string@^0.25.0, magic-string@^0.25.7:
   version "0.25.9"


### PR DESCRIPTION
Fixes #1643

The default will make the payment every month (starting the next midnight, so if you start on 8th 9:45 am, it will make the payment on 9th 00:00, and 9th of the next month and so on). Otherwise you can select advanced options and set a cron expression. The runs are calculated for that month and budget is decided accordingly.