### PR TITLE
fix: add min width 0 to SidebarInset to stop overflows

### DIFF
--- a/frontend/src/components/layouts/AppLayout.tsx
+++ b/frontend/src/components/layouts/AppLayout.tsx
@@ -40,7 +40,7 @@ function AppLayoutInner() {
           {showBanner && <Banner onDismiss={dismissBanner} />}
           <div className="flex flex-1">
             <AppSidebar />
-            <SidebarInset>
+            <SidebarInset className="min-w-0">
               <div
                 className={cn(
                   "flex flex-1 flex-col gap-4 p-4",


### PR DESCRIPTION
Fixes #1694

## Description

Flex children have `min-width:auto` set by default, which causes this behaviour, this change should fix all other screens too where the content overflows and adds a scrollbar. 

## Screenshot
<img width="100%" height="956" alt="Screenshot 2025-09-09 at 5 46 23 PM" src="https://github.com/user-attachments/assets/5d48d4cc-d8f4-4da0-948e-956da442ee6d" />
