### PR TITLE
fix: set direction in swap alert

### DIFF
--- a/frontend/src/components/channels/SwapAlert.tsx
+++ b/frontend/src/components/channels/SwapAlert.tsx
@@ -8,8 +8,13 @@ import { LinkButton } from "../ui/custom/link-button";
 type SwapAlertProps = {
   className?: string;
   minChannels?: number;
+  swapType?: "in" | "out";
 };
-export function SwapAlert({ className, minChannels = 2 }: SwapAlertProps) {
+export function SwapAlert({
+  className,
+  minChannels = 2,
+  swapType,
+}: SwapAlertProps) {
   const { data: channels } = useChannels();
   const { data: balances } = useBalances();
 
@@ -20,8 +25,9 @@ export function SwapAlert({ className, minChannels = 2 }: SwapAlertProps) {
     return null;
   }
 
-  const isSwapOut =
-    balances.lightning.totalSpendable > balances.lightning.totalReceivable;
+  const isSwapOut = swapType
+    ? swapType === "out"
+    : balances.lightning.totalSpendable > balances.lightning.totalReceivable;
   const directionText = isSwapOut ? "out from" : "into";
 
   return (

--- a/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
@@ -460,7 +460,7 @@ function NewChannelInternal({
             </Button>
           )}
           <MempoolAlert />
-          <SwapAlert />
+          <SwapAlert swapType="out" />
           {channels?.some((channel) => channel.public !== !!order.isPublic) && (
             <ChannelPublicPrivateAlert />
           )}

--- a/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
@@ -397,7 +397,7 @@ function NewChannelInternal({
             </div>
           </>
           <MempoolAlert />
-          <SwapAlert />
+          <SwapAlert swapType="in" />
           {channels?.some((channel) => channel.public !== !!order.isPublic) && (
             <ChannelPublicPrivateAlert />
           )}


### PR DESCRIPTION
This fixes wrong swap alerts being shown based on balance info in both incoming/outgoing channel screens.