### PR TITLE
chore: add note about channels being non-refundable

### DIFF
--- a/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
@@ -472,6 +472,9 @@ function NewChannelInternal({
               name={selectedPeer?.name}
             />
           )}
+          <p className="text-center text-xs text-muted-foreground">
+            By continuing, you agree that channel purchases are non-refundable.
+          </p>
           <Button size="lg">Next</Button>
         </form>
 

--- a/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
@@ -473,7 +473,8 @@ function NewChannelInternal({
             />
           )}
           <p className="text-center text-xs text-muted-foreground">
-            By continuing, you agree that channel purchases are non-refundable.
+            By continuing, you consent the channel opens immediately and that
+            you lose the right to revoke once it is open.
           </p>
           <Button size="lg">Next</Button>
         </form>

--- a/frontend/src/screens/channels/first/FirstChannel.tsx
+++ b/frontend/src/screens/channels/first/FirstChannel.tsx
@@ -366,8 +366,8 @@ export function FirstChannel() {
                 </p>
               )}
             <p className="text-center text-xs -mb-2">
-              By continuing, you agree that channel purchases are
-              non-refundable.
+              By continuing, you consent the channel opens immediately and that
+              you lose the right to revoke once it is open.
             </p>
             {lspChannelOffer.currentPaymentMethod === "included" && (
               <p className="text-xs text-muted-foreground flex items-center justify-center -mb-2">

--- a/frontend/src/screens/channels/first/FirstChannel.tsx
+++ b/frontend/src/screens/channels/first/FirstChannel.tsx
@@ -361,13 +361,17 @@ export function FirstChannel() {
             {lspChannelOffer.currentPaymentMethod !== "prepaid" &&
               lspChannelOffer.currentPaymentMethod !== "fee_credits" &&
               lspChannelOffer.currentPaymentMethod !== "included" && (
-                <p className="text-xs text-muted-foreground flex items-center justify-center -mb-2">
-                  The cost will be included in your next subscription payment
+                <p className="text-xs text-muted-foreground flex items-center justify-center -mb-4">
+                  The cost will be included in your next subscription payment.
                 </p>
               )}
+            <p className="text-center text-xs -mb-2">
+              By continuing, you agree that channel purchases are
+              non-refundable.
+            </p>
             {lspChannelOffer.currentPaymentMethod === "included" && (
               <p className="text-xs text-muted-foreground flex items-center justify-center -mb-2">
-                This channel comes free with your Alby Pro subscription
+                This channel comes free with your Alby Pro subscription.
               </p>
             )}
             <LoadingButton loading={isLoading} onClick={openChannel}>


### PR DESCRIPTION
Closes https://github.com/getAlby/hub/issues/1691

Added to the first channel flow and the manual incoming channel flow

<img width="443" height="720" alt="image" src="https://github.com/user-attachments/assets/ac73de01-68cc-453c-b7c9-954665a87c36" />

<img width="957" height="1462" alt="image" src="https://github.com/user-attachments/assets/de9141bd-2b13-485d-b63b-071f75f8b708" />
