### PR TITLE
fix(UX): Alert users about anchor-reserve when they try to use their max on-chain balance

### DIFF
--- a/frontend/src/components/AnchorReserveAlert.tsx
+++ b/frontend/src/components/AnchorReserveAlert.tsx
@@ -6,8 +6,10 @@ import { useChannels } from "src/hooks/useChannels";
 export function AnchorReserveAlert({
   amount,
   className,
+  isSwap,
 }: {
   amount: number;
+  isSwap?: boolean;
   className?: string;
 }) {
   const { data: balances } = useBalances();
@@ -18,6 +20,7 @@ export function AnchorReserveAlert({
   }
 
   const showAlert =
+    amount &&
     !!channels.length &&
     +amount > balances.onchain.spendable - channels.length * 25000;
 
@@ -26,15 +29,16 @@ export function AnchorReserveAlert({
   }
 
   return (
-    <Alert className={className}>
+    <Alert className={className} variant="warning">
       <AlertTriangleIcon className="h-4 w-4" />
-      <AlertTitle>Channel Anchor Reserves may be depleted</AlertTitle>
+      <AlertTitle>Channel Anchor Reserves will be depleted</AlertTitle>
       <AlertDescription>
-        You have channels open and this withdrawal may deplete your anchor
-        reserves which may make it harder to close channels without depositing
-        additional onchain funds to your savings balance. To avoid this, set
-        aside at least {new Intl.NumberFormat().format(channels.length * 25000)}{" "}
-        sats on-chain.
+        You have channels open and by spending your entire on-chain balance
+        including your anchor reserves may put your node at risk of unable to
+        reclaim funds in your channel after a force-closure. To prevent this,
+        set aside at least{" "}
+        {new Intl.NumberFormat().format(channels.length * 25000)} sats on-chain
+        {isSwap ? ", or pay with an external on-chain wallet." : "."}
       </AlertDescription>
     </Alert>
   );

--- a/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
@@ -10,6 +10,7 @@ import TickSVG from "public/images/illustrations/tick.svg";
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
+import { AnchorReserveAlert } from "src/components/AnchorReserveAlert";
 import AppHeader from "src/components/AppHeader";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
 import Loading from "src/components/Loading";
@@ -331,6 +332,9 @@ function ReceiveToSpending() {
           </Alert>
         )}
       <div className="grid gap-1.5">
+        {hasChannelManagement && (
+          <AnchorReserveAlert amount={+swapAmount} className="mb-4" isSwap />
+        )}
         <Label>Amount</Label>
         <InputWithAdornment
           type="number"

--- a/frontend/src/screens/wallet/swap/SwapInStatus.tsx
+++ b/frontend/src/screens/wallet/swap/SwapInStatus.tsx
@@ -194,8 +194,7 @@ export default function SwapInStatus() {
                     )}
                     {swap.state === "PENDING" &&
                       balances &&
-                      balances.onchain.spendable - 25000 /* anchor reserve */ >
-                        swap.sendAmount && (
+                      balances.onchain.spendable > swap.sendAmount && (
                         <LoadingButton
                           loading={isPaying}
                           onClick={payWithAlbyHub}

--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -2,6 +2,7 @@ import { ClipboardPasteIcon, MoveRightIcon, RefreshCwIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
+import { AnchorReserveAlert } from "src/components/AnchorReserveAlert";
 import AppHeader from "src/components/AppHeader";
 import Loading from "src/components/Loading";
 import LowReceivingCapacityAlert from "src/components/LowReceivingCapacityAlert";
@@ -120,6 +121,9 @@ function SwapInForm() {
             0.8 * balances.lightning.totalReceivable && (
             <LowReceivingCapacityAlert />
           )}
+        {swapAmount && (
+          <AnchorReserveAlert amount={+swapAmount} className="mb-4" />
+        )}
         <h2 className="font-medium text-foreground flex items-center gap-1">
           On-chain <MoveRightIcon /> Lightning
         </h2>

--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -121,9 +121,6 @@ function SwapInForm() {
             0.8 * balances.lightning.totalReceivable && (
             <LowReceivingCapacityAlert />
           )}
-        {swapAmount && (
-          <AnchorReserveAlert amount={+swapAmount} className="mb-4" />
-        )}
         <h2 className="font-medium text-foreground flex items-center gap-1">
           On-chain <MoveRightIcon /> Lightning
         </h2>
@@ -132,6 +129,9 @@ function SwapInForm() {
         </p>
       </div>
       <div className="grid gap-1.5">
+        {hasChannelManagement && (
+          <AnchorReserveAlert amount={+swapAmount} className="mb-4" isSwap />
+        )}
         <Label>Swap amount</Label>
         <Input
           type="number"


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/1695

https://github.com/user-attachments/assets/1e3a374b-464e-4112-9dad-878d187c2cb8

With reference to this [comment](https://github.com/getAlby/hub/issues/1695#issuecomment-3312101834), I found the Anchor reserve alert componet , whiich get triggered when user tries to use the onchain balance, that leaves less than 50k sats on-chain and not 25k , Let me know if that needs to be changed or this works. 

Thanks! 