### PR TITLE
chore: do not pass channel expiry blocks to alby create LSP order endpoint

### DIFF
--- a/alby/models.go
+++ b/alby/models.go
@@ -171,15 +171,15 @@ type LSPChannelResponse struct {
 }
 
 type LSPChannelRequest struct {
-	PublicKey                    string `json:"public_key"`
-	LSPBalanceSat                string `json:"lsp_balance_sat"`
-	ClientBalanceSat             string `json:"client_balance_sat"`
-	RequiredChannelConfirmations uint64 `json:"required_channel_confirmations"`
-	FundingConfirmsWithinBlocks  uint64 `json:"funding_confirms_within_blocks"`
-	ChannelExpiryBlocks          uint64 `json:"channel_expiry_blocks"`
-	Token                        string `json:"token"`
-	RefundOnchainAddress         string `json:"refund_onchain_address"`
-	AnnounceChannel              bool   `json:"announce_channel"`
+	PublicKey                    string  `json:"public_key"`
+	LSPBalanceSat                string  `json:"lsp_balance_sat"`
+	ClientBalanceSat             string  `json:"client_balance_sat"`
+	RequiredChannelConfirmations uint64  `json:"required_channel_confirmations"`
+	FundingConfirmsWithinBlocks  uint64  `json:"funding_confirms_within_blocks"`
+	ChannelExpiryBlocks          *uint64 `json:"channel_expiry_blocks"`
+	Token                        string  `json:"token"`
+	RefundOnchainAddress         string  `json:"refund_onchain_address"`
+	AnnounceChannel              bool    `json:"announce_channel"`
 }
 
 type LSPInfo struct {

--- a/api/lsp.go
+++ b/api/lsp.go
@@ -136,10 +136,10 @@ func (api *api) requestLSPS1Invoice(ctx context.Context, request *LSPOrderReques
 		ClientBalanceSat:             "0",
 		RequiredChannelConfirmations: requiredChannelConfirmations,
 		FundingConfirmsWithinBlocks:  minFundingConfirmsWithinBlocks,
-		ChannelExpiryBlocks:          channelExpiryBlocks,
-		Token:                        token,
-		RefundOnchainAddress:         refundAddress,
-		AnnounceChannel:              request.Public,
+		// ChannelExpiryBlocks:          channelExpiryBlocks, // allow getalby.com to choose expiry instead (to reduce channel cost)
+		Token:                token,
+		RefundOnchainAddress: refundAddress,
+		AnnounceChannel:      request.Public,
 	}
 
 	channelResponse, err := api.albyOAuthSvc.CreateLSPOrder(ctx, request.LSPIdentifier, network, lsps1ChannelRequest)


### PR DESCRIPTION
(so alby can dynamically choose it based on channel costs)

fixes https://github.com/getAlby/hub/issues/1732

Normally we pick the max returned by the LSP. Note, by this change the request is no longer LSPS1-compatible. But we always proxy through getalby.com now.