### PR TITLE
fix: ensure boostagrams are valid json before adding to the transaction

### DIFF
--- a/transactions/receive_keysend_test.go
+++ b/transactions/receive_keysend_test.go
@@ -3,6 +3,7 @@ package transactions
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"strconv"
 	"testing"
 
@@ -13,6 +14,86 @@ import (
 	"github.com/getAlby/hub/lnclient"
 	"github.com/getAlby/hub/tests"
 )
+
+func TestReceiveKeysend_ValidBoostagram(t *testing.T) {
+	ctx := context.TODO()
+
+	svc, err := tests.CreateTestService(t)
+	require.NoError(t, err)
+	defer svc.Remove()
+
+	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
+
+	tlv := []lnclient.TLVRecord{
+		{
+			Type:  7629169,
+			Value: hex.EncodeToString([]byte("{\"app_name\": \"Castamatic\"}")),
+		},
+	}
+	tx := lnclient.Transaction{
+		Type:        "incoming",
+		Description: "mock invoice 1",
+		Preimage:    "9f59b18f80a77c2930deb8be5ff1143eacdd1891c63c23d61bc9f99c64e57325",
+		PaymentHash: "ae4277b7be3ca1420cafd24c143866190f52b996856b0e4164763f936e61ea1b",
+		Amount:      1000,
+		FeesPaid:    50,
+		SettledAt:   &tests.MockTimeUnix,
+		Metadata: map[string]interface{}{
+			"tlv_records": tlv,
+		},
+	}
+
+	event := events.Event{
+		Event:      "nwc_lnclient_payment_received",
+		Properties: &tx,
+	}
+	transactionsService.ConsumeEvent(ctx, &event, map[string]interface{}{})
+
+	transaction, err := transactionsService.LookupTransaction(ctx, tx.PaymentHash, nil, svc.LNClient, nil)
+	require.NoError(t, err)
+	var txBoostagram Boostagram
+	err = json.Unmarshal(transaction.Boostagram, &txBoostagram)
+	require.NoError(t, err)
+	assert.Equal(t, "Castamatic", txBoostagram.AppName)
+}
+func TestReceiveKeysend_InvalidBoostagram(t *testing.T) {
+	ctx := context.TODO()
+
+	svc, err := tests.CreateTestService(t)
+	require.NoError(t, err)
+	defer svc.Remove()
+
+	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
+
+	tlv := []lnclient.TLVRecord{
+		{
+			Type:  7629169,
+			Value: hex.EncodeToString([]byte("asdf")),
+		},
+	}
+	tx := lnclient.Transaction{
+		Type:        "incoming",
+		Description: "mock invoice 1",
+		Preimage:    "9f59b18f80a77c2930deb8be5ff1143eacdd1891c63c23d61bc9f99c64e57325",
+		PaymentHash: "ae4277b7be3ca1420cafd24c143866190f52b996856b0e4164763f936e61ea1b",
+		Amount:      1000,
+		FeesPaid:    50,
+		SettledAt:   &tests.MockTimeUnix,
+		Metadata: map[string]interface{}{
+			"tlv_records": tlv,
+		},
+	}
+
+	event := events.Event{
+		Event:      "nwc_lnclient_payment_received",
+		Properties: &tx,
+	}
+	transactionsService.ConsumeEvent(ctx, &event, map[string]interface{}{})
+
+	transaction, err := transactionsService.LookupTransaction(ctx, tx.PaymentHash, nil, svc.LNClient, nil)
+	require.NoError(t, err)
+	assert.Nil(t, transaction.Boostagram)
+}
 
 func TestReceiveKeysendWithCustomKey(t *testing.T) {
 	ctx := context.TODO()


### PR DESCRIPTION
Closes https://github.com/getAlby/hub/issues/1749

If the boostagram is not valid it will break the transaction from being saved (postgres is strict that the field is actually json)