### PR TITLE
fix: forward ref down to button component

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -5,25 +5,25 @@ import { buttonVariants } from "src/components/ui/buttonVariants";
 
 import { cn } from "src/lib/utils";
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
-  }) {
+const Button = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<"button"> &
+    VariantProps<typeof buttonVariants> & {
+      asChild?: boolean;
+    }
+>(({ className, variant, size, asChild = false, ...props }, ref) => {
   const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
+      ref={ref}
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
   );
-}
+});
+
+Button.displayName = "Button";
 
 export { Button };


### PR DESCRIPTION
fixes #1763


so our `Button` component wasn’t forwarding refs to the actual DOM element. Inside the calendar, the `CalendarDayButton` tried to call `ref.current.focus()` on a day button, but since the ref never attached, `ref.current` was always `null`. This broke keyboard navigation — pressing Space or Enter didn’t select a date. that's why when you swapped in a plain `<button>`, everything worked again because refs attach correctly to native elements.

this fix is to wrap `Button` with `React.forwardRef`, so refs get passed down to the real `<button>` (or to the `Slot` when `asChild` is used). This keeps the public API the same while restoring proper focus and keyboard behavior. I also added `Button.displayName = "Button";` so it shows up with a readable name in React DevTools.

video

https://github.com/user-attachments/assets/1985b088-1bd0-455e-88ca-b76c42f11b2f






