### PR TITLE
fix: add transaction fee percentage

### DIFF
--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -282,6 +282,9 @@ function TransactionItem({ tx }: Props) {
                     Math.floor(tx.feesPaid / 1000)
                   )}{" "}
                   {Math.floor(tx.feesPaid / 1000) == 1 ? "sat" : "sats"}
+                  {tx.feesPaid > 0 && (
+                    <>&nbsp;({((tx.feesPaid / tx.amount) * 100).toFixed(2)}%)</>
+                  )}
                 </p>
               </div>
             )}


### PR DESCRIPTION
Adds the fee percentage to the transaction detail dialog: 

<img width="544" height="359" alt="image" src="https://github.com/user-attachments/assets/45563dca-9a7a-427c-b02f-2ff1572e8633" />
