### PR TITLE
feat: expose node URI address

### DIFF
--- a/config/models.go
+++ b/config/models.go
@@ -58,6 +58,7 @@ type AppConfig struct {
 	AutoUnlockPassword                 string `envconfig:"AUTO_UNLOCK_PASSWORD"`
 	LogDBQueries                       bool   `envconfig:"LOG_DB_QUERIES" default:"false"`
 	BoltzApi                           string `envconfig:"BOLTZ_API" default:"https://api.boltz.exchange"`
+	NodeIPv6                           string `envconfig:"NODE_IPV6"`
 }
 
 func (c *AppConfig) IsDefaultClientId() bool {

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import React from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader.tsx";
 import { ChannelsCards } from "src/components/channels/ChannelsCards.tsx";
 import { ChannelsTable } from "src/components/channels/ChannelsTable.tsx";
@@ -162,6 +163,7 @@ export default function Channels() {
                 </DropdownMenuTrigger>
                 <DropdownMenuContent className="w-56">
                   <DropdownMenuGroup>
+                    <DropdownMenuLabel>Node</DropdownMenuLabel>
                     <DropdownMenuItem>
                       <div
                         className="flex flex-row gap-4 items-center w-full cursor-pointer"
@@ -172,8 +174,8 @@ export default function Channels() {
                           copyToClipboard(nodeConnectionInfo.pubkey);
                         }}
                       >
-                        <div>Node</div>
-                        <div className="overflow-hidden text-ellipsis flex-1">
+                        <div>Public key</div>
+                        <div className="overflow-hidden text-ellipsis flex-1 font-mono text-xs">
                           {nodeConnectionInfo?.pubkey || "Loading..."}
                         </div>
                         {nodeConnectionInfo && (
@@ -181,6 +183,29 @@ export default function Channels() {
                         )}
                       </div>
                     </DropdownMenuItem>
+                    {nodeConnectionInfo?.address &&
+                      nodeConnectionInfo?.port && (
+                        <DropdownMenuItem>
+                          <div
+                            className="flex flex-row gap-4 items-center w-full cursor-pointer"
+                            onClick={() => {
+                              const connectionAddress = `${nodeConnectionInfo.pubkey}@${nodeConnectionInfo.address}:${nodeConnectionInfo.port}`;
+                              copyToClipboard(connectionAddress);
+                              toast.success(
+                                "Connection address copied to clipboard"
+                              );
+                            }}
+                          >
+                            <div>URI</div>
+                            <div className="overflow-hidden text-ellipsis flex-1 font-mono text-xs">
+                              {nodeConnectionInfo.pubkey}@
+                              {nodeConnectionInfo.address}:
+                              {nodeConnectionInfo.port}
+                            </div>
+                            <CopyIcon className="shrink-0 size-4" />
+                          </div>
+                        </DropdownMenuItem>
+                      )}
                   </DropdownMenuGroup>
                   <DropdownMenuSeparator />
                   <DropdownMenuGroup>


### PR DESCRIPTION
Add node URI option to advanced menu.
If using LND will use directly the address retuned by backend, and when using LDK will expect a NODE_IPV6 env var set