### PR TITLE
fix: added context sensitivbity to anchor reserver alert

### DIFF
--- a/frontend/src/components/AnchorReserveAlert.tsx
+++ b/frontend/src/components/AnchorReserveAlert.tsx
@@ -3,15 +3,19 @@ import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
 import { useBalances } from "src/hooks/useBalances";
 import { useChannels } from "src/hooks/useChannels";
 
-export function AnchorReserveAlert({
-  amount,
-  className,
-  isSwap,
-}: {
+interface AnchorReserveAlertProps {
   amount: number;
   isSwap?: boolean;
   className?: string;
-}) {
+  context?: "spend" | "receive" | "swap";
+}
+
+export default function AnchorReserveAlert({
+  amount,
+  isSwap = false,
+  className,
+  context = "spend", // Default for backward compatibility
+}: AnchorReserveAlertProps) {
   const { data: balances } = useBalances();
   const { data: channels } = useChannels();
 
@@ -29,16 +33,28 @@ export function AnchorReserveAlert({
   }
 
   return (
-    <Alert className={className} variant="warning">
+    <Alert className={className} variant="default">
       <AlertTriangleIcon className="h-4 w-4" />
-      <AlertTitle>Channel Anchor Reserves will be depleted</AlertTitle>
+      <AlertTitle>Consider your channel anchor reserves</AlertTitle>
       <AlertDescription>
-        You have channels open and by spending your entire on-chain balance
-        including your anchor reserves may put your node at risk of unable to
-        reclaim funds in your channel after a force-closure. To prevent this,
-        set aside at least{" "}
-        {new Intl.NumberFormat().format(channels.length * 25000)} sats on-chain
-        {isSwap ? ", or pay with an external on-chain wallet." : "."}
+        You have {channels.length} channel{channels.length > 1 ? "s" : ""} open.
+        {context === "receive" ? (
+          <>
+            If you plan to spend from your hub wallet later, consider keeping at
+            least {new Intl.NumberFormat().format(channels.length * 25000)} sats
+            on-chain to maintain channel anchor reserves for potential
+            force-closures.
+          </>
+        ) : (
+          <>
+            Keep at least{" "}
+            {new Intl.NumberFormat().format(channels.length * 25000)} sats
+            on-chain to maintain channel anchor reserves for potential
+            force-closures
+          </>
+        )}
+        {isSwap &&
+          ". You can also use an external on-chain wallet to avoid this concern."}
       </AlertDescription>
     </Alert>
   );

--- a/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
+++ b/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
@@ -7,7 +7,7 @@ import {
 } from "lucide-react";
 import React from "react";
 import { toast } from "sonner";
-import { AnchorReserveAlert } from "src/components/AnchorReserveAlert";
+import AnchorReserveAlert from "src/components/AnchorReserveAlert";
 import AppHeader from "src/components/AppHeader";
 import ExternalLink from "src/components/ExternalLink";
 import Loading from "src/components/Loading";
@@ -226,6 +226,7 @@ export default function WithdrawOnchainFunds() {
             <AnchorReserveAlert
               amount={sendAll ? balances.onchain.spendable : +amount}
               className="mt-4"
+              context="spend"
             />
           </div>
           <div className="grid gap-2">

--- a/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
@@ -333,7 +333,12 @@ function ReceiveToSpending() {
         )}
       <div className="grid gap-1.5">
         {hasChannelManagement && (
-          <AnchorReserveAlert amount={+swapAmount} className="mb-4" isSwap />
+          <AnchorReserveAlert
+            amount={+swapAmount}
+            className="mb-4"
+            isSwap
+            context="receive"
+          />
         )}
         <Label>Amount</Label>
         <InputWithAdornment

--- a/frontend/src/screens/wallet/send/Onchain.tsx
+++ b/frontend/src/screens/wallet/send/Onchain.tsx
@@ -8,7 +8,7 @@ import {
 import React from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
-import { AnchorReserveAlert } from "src/components/AnchorReserveAlert";
+import AnchorReserveAlert from "src/components/AnchorReserveAlert";
 import AppHeader from "src/components/AppHeader";
 import ExternalLink from "src/components/ExternalLink";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
@@ -297,7 +297,7 @@ function OnchainForm({
           </AlertDescription>
         </Alert>
       )}
-      <AnchorReserveAlert amount={+amount} />
+      <AnchorReserveAlert amount={+amount} context="spend" />
       <div className="flex gap-2">
         <LinkButton to="/wallet/send" variant="outline">
           Back

--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -130,7 +130,12 @@ function SwapInForm() {
       </div>
       <div className="grid gap-1.5">
         {hasChannelManagement && (
-          <AnchorReserveAlert amount={+swapAmount} className="mb-4" isSwap />
+          <AnchorReserveAlert
+            amount={+swapAmount}
+            className="mb-4"
+            isSwap
+            context="swap"
+          />
         )}
         <Label>Swap amount</Label>
         <Input


### PR DESCRIPTION
fixes #1783

My fix for the issue describes includes: 

1. Softened Alert Messaging & Variant
Changed variant: "warning" → "default" for less alarming appearance
Improved title: "Channel Anchor Reserves will be depleted" → "Consider your channel anchor reserves"
Context-aware messaging: Different explanations based on user action (spend/receive/swap)

2. Context-Aware Alert System
Added context prop with three scenarios:

"spend": "Keep at least X sats on-chain to maintain channel anchor reserves..."
"receive": "If you plan to spend from your hub wallet later, consider keeping at least X sats..."
"swap": Uses "spend" logic but adds external wallet suggestion
