### PR TITLE
feat: add database storage for BOLT12 offers

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -945,7 +947,54 @@ func (api *api) MakeOffer(ctx context.Context, description string) (string, erro
 		return "", err
 	}
 
+	// Store the offer in the database
+	err = api.storeOffer(ctx, offer, description)
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to store offer in database")
+		// Don't fail the request if we can't store the offer, just log it
+	}
+
 	return offer, nil
+}
+
+// storeOffer stores the BOLT12 offer details in the database
+func (api *api) storeOffer(ctx context.Context, offerString, description string) error {
+	// Generate a unique offer ID from the offer string
+	// In the future, this should extract the actual offer ID from the BOLT12 offer
+	hash := sha256.Sum256([]byte(offerString))
+	offerID := hex.EncodeToString(hash[:16]) // Use first 16 bytes for shorter ID
+
+	offer := &db.Offer{
+		OfferID:     offerID,
+		OfferString: offerString,
+		Description: description,
+	}
+
+	err := api.db.WithContext(ctx).Create(offer).Error
+	if err != nil {
+		return fmt.Errorf("failed to store offer: %w", err)
+	}
+
+	logger.Logger.WithFields(logrus.Fields{
+		"offer_id":    offerID,
+		"description": description,
+	}).Info("Stored BOLT12 offer in database")
+
+	return nil
+}
+
+// GetOffers retrieves all BOLT12 offers from the database
+func (api *api) GetOffers(ctx context.Context) ([]db.Offer, error) {
+	var offers []db.Offer
+
+	err := api.db.WithContext(ctx).Order("created_at DESC").Find(&offers).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve offers: %w", err)
+	}
+
+	logger.Logger.WithField("count", len(offers)).Info("Retrieved BOLT12 offers from database")
+
+	return offers, nil
 }
 
 func (api *api) GetNewOnchainAddress(ctx context.Context) (string, error) {

--- a/api/models.go
+++ b/api/models.go
@@ -37,6 +37,7 @@ type API interface {
 	CloseChannel(ctx context.Context, peerId, channelId string, force bool) (*CloseChannelResponse, error)
 	UpdateChannel(ctx context.Context, updateChannelRequest *UpdateChannelRequest) error
 	MakeOffer(ctx context.Context, description string) (string, error)
+	GetOffers(ctx context.Context) ([]db.Offer, error)
 	GetNewOnchainAddress(ctx context.Context) (string, error)
 	GetUnusedOnchainAddress(ctx context.Context) (string, error)
 	SignMessage(ctx context.Context, message string) (*SignMessageResponse, error)

--- a/db/migrations/202509271400_create_offers_table.go
+++ b/db/migrations/202509271400_create_offers_table.go
@@ -1,0 +1,55 @@
+package migrations
+
+import (
+	_ "embed"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// _202509271400_create_offers_table creates the offers table to store BOLT12 offer details
+var _202509271400_create_offers_table = &gormigrate.Migration{
+	ID: "202509271400_create_offers_table",
+	Migrate: func(tx *gorm.DB) error {
+		// Create the offers table
+		err := tx.Exec(`
+			CREATE TABLE IF NOT EXISTS offers (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				offer_id TEXT NOT NULL UNIQUE,
+				offer_string TEXT NOT NULL,
+				description TEXT,
+				created_at DATETIME NOT NULL,
+				updated_at DATETIME NOT NULL
+			);
+		`).Error
+		if err != nil {
+			return err
+		}
+
+		// Create indexes
+		err = tx.Exec("CREATE INDEX IF NOT EXISTS idx_offers_offer_id ON offers(offer_id);").Error
+		if err != nil {
+			return err
+		}
+
+		err = tx.Exec("CREATE INDEX IF NOT EXISTS idx_offers_created_at ON offers(created_at);").Error
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+	Rollback: func(tx *gorm.DB) error {
+		err := tx.Exec("DROP INDEX IF EXISTS idx_offers_created_at;").Error
+		if err != nil {
+			return err
+		}
+
+		err = tx.Exec("DROP INDEX IF EXISTS idx_offers_offer_id;").Error
+		if err != nil {
+			return err
+		}
+
+		return tx.Exec("DROP TABLE IF EXISTS offers;").Error
+	},
+}

--- a/db/migrations/migrate.go
+++ b/db/migrations/migrate.go
@@ -38,6 +38,7 @@ func Migrate(gormDB *gorm.DB) error {
 		_202508151405_swap_xpub,
 		_202508192137_forwards,
 		_202509031250_transactions_updated_at_index,
+		_202509271400_create_offers_table,
 	})
 
 	return m.Migrate()

--- a/db/models.go
+++ b/db/models.go
@@ -122,6 +122,15 @@ type Forward struct {
 	UpdatedAt                   time.Time
 }
 
+type Offer struct {
+	ID          uint   `gorm:"primaryKey"`
+	OfferID     string `gorm:"uniqueIndex;not null" validate:"required"`
+	OfferString string `gorm:"not null" validate:"required"`
+	Description string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
 const (
 	REQUEST_EVENT_STATE_HANDLER_EXECUTING = "executing"
 	REQUEST_EVENT_STATE_HANDLER_EXECUTED  = "executed"

--- a/http/http_service.go
+++ b/http/http_service.go
@@ -149,6 +149,7 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	readOnlyApiGroup.GET("/swaps/mnemonic", httpSvc.swapMnemonicHandler)
 	readOnlyApiGroup.GET("/autoswap", httpSvc.getAutoSwapConfigHandler)
 	readOnlyApiGroup.GET("/forwards", httpSvc.forwardsHandler)
+	readOnlyApiGroup.GET("/offers", httpSvc.getOffersHandler)
 
 	// Full access API group - requires a token with full permissions
 	fullAccessApiGroup := e.Group("/api")
@@ -644,6 +645,19 @@ func (httpSvc *HttpService) makeOfferHandler(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, offer)
+}
+
+func (httpSvc *HttpService) getOffersHandler(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	offers, err := httpSvc.api.GetOffers(ctx)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Message: fmt.Sprintf("Failed to retrieve offers: %s", err.Error()),
+		})
+	}
+
+	return c.JSON(http.StatusOK, offers)
 }
 
 func (httpSvc *HttpService) makeInvoiceHandler(c echo.Context) error {


### PR DESCRIPTION
fixes:  #1372

# Add Database Storage for BOLT12 Offers


## Solution Implemented

###  Database Layer
- **New `offers` table** with proper schema:
  - `offer_id`: Unique identifier (currently SHA256 hash, future: extracted from BOLT12)
  - `offer_string`: Complete BOLT12 offer string
  - `description`: Human-readable description
  - `created_at`/`updated_at`: Timestamps
- **Database migration** (`202509271400_create_offers_table`) with proper rollback
- **Indexes** on `offer_id` and `created_at` for performance

###  API Layer
- **Enhanced `MakeOffer`**: Automatically stores offer details when created
- **New `GetOffers`**: Retrieves all stored offers from database
- **Error handling**: Graceful fallback if storage fails (doesn't break offer creation)

###  HTTP Layer  
- **New endpoint**: `GET /api/offers` to list all stored offers
- **Authentication**: Uses existing read-only API group (requires JWT)

### Models
- **New `Offer` struct** in `db/models.go` with GORM tags
- **Interface update**: Added `GetOffers` to API interface


###  Next Steps
1. **BOLT12 Parsing**: Replace SHA256 hash with actual offer_id extraction from BOLT12 offer string
2. **Transaction Linking**: Update payment flow to reference stored offer_id in transaction metadata  
3. **Frontend UI**: Add offers management page to display offer history


Demo: 

https://github.com/user-attachments/assets/96694bc1-638b-4e15-a30a-f760cc0d43f7



