### PR TITLE
feat: show connection string right away for subwallets

### DIFF
--- a/frontend/src/screens/apps/ConnectAppCard.tsx
+++ b/frontend/src/screens/apps/ConnectAppCard.tsx
@@ -1,9 +1,9 @@
 import { CheckIcon, CopyIcon, EyeIcon } from "lucide-react";
 import { useEffect, useState } from "react";
-import QRCode from "react-qr-code";
 import { Link } from "react-router-dom";
 import { AppStoreApp } from "src/components/connections/SuggestedAppData";
 import Loading from "src/components/Loading";
+import QRCode from "src/components/QRCode";
 import { Badge } from "src/components/ui/badge";
 import { Button } from "src/components/ui/button";
 import {

--- a/frontend/src/screens/subwallets/SubwalletCreated.tsx
+++ b/frontend/src/screens/subwallets/SubwalletCreated.tsx
@@ -11,7 +11,6 @@ import {
   Zap,
 } from "lucide-react";
 import React from "react";
-import QRCode from "react-qr-code";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import AppHeader from "src/components/AppHeader";
 import ExternalLink from "src/components/ExternalLink";
@@ -19,6 +18,7 @@ import { AppleIcon } from "src/components/icons/Apple";
 import { PlayStoreIcon } from "src/components/icons/PlayStore";
 import { ZapStoreIcon } from "src/components/icons/ZapStore";
 import { IsolatedAppTopupDialog } from "src/components/IsolatedAppTopupDialog";
+import QRCode from "src/components/QRCode";
 import {
   Accordion,
   AccordionContent,


### PR DESCRIPTION
Prevent users from clicking "other apps" but show the connection string right away. 