### PR TITLE
feat: make Zapplanner settings managment easier

### DIFF
--- a/frontend/src/components/connections/ConnectedApps.tsx
+++ b/frontend/src/components/connections/ConnectedApps.tsx
@@ -1,4 +1,4 @@
-import { CableIcon, TrashIcon } from "lucide-react";
+import { CableIcon, ExternalLinkIcon, TrashIcon } from "lucide-react";
 import { useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { CustomPagination } from "src/components/CustomPagination";
@@ -7,6 +7,7 @@ import Loading from "src/components/Loading";
 import ResponsiveButton from "src/components/ResponsiveButton";
 import AlbyConnectionCard from "src/components/connections/AlbyConnectionCard";
 import AppCard from "src/components/connections/AppCard";
+import { ExternalLinkButton } from "src/components/ui/custom/external-link-button";
 import {
   ALBY_ACCOUNT_APP_NAME,
   LIST_APPS_LIMIT,
@@ -100,7 +101,20 @@ function ConnectedApps() {
           className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-stretch app-list"
         >
           {otherApps.map((app, index) => (
-            <AppCard key={index} app={app} />
+            <AppCard
+              key={index}
+              app={app}
+              actions={
+                app.metadata?.zapplanner_subscription_id ? (
+                  <ExternalLinkButton
+                    to={`https://zapplanner.albylabs.com/subscriptions/${app.metadata.zapplanner_subscription_id}`}
+                    size="sm"
+                  >
+                    View <ExternalLinkIcon className="size-4 ml-2" />
+                  </ExternalLinkButton>
+                ) : undefined
+              }
+            />
           ))}
         </div>
       )}

--- a/frontend/src/screens/apps/AppDetails.tsx
+++ b/frontend/src/screens/apps/AppDetails.tsx
@@ -15,6 +15,7 @@ import {
   CheckCircleIcon,
   ChevronDownIcon,
   EllipsisIcon,
+  ExternalLinkIcon,
   InfoIcon,
   PlusIcon,
   SquarePenIcon,
@@ -190,6 +191,8 @@ function AppInternal({ app, refetchApp, capabilities }: AppInternalProps) {
   const appStoreApp = getAppStoreApp(app);
   const connectedApps = useAppsForAppStoreApp(appStoreApp);
 
+  const subscriptionId = app?.metadata?.zapplanner_subscription_id;
+
   return (
     <>
       <div className="w-full">
@@ -265,6 +268,20 @@ function AppInternal({ app, refetchApp, capabilities }: AppInternalProps) {
                             </DropdownMenuGroup>
                           )}
                         <DropdownMenuGroup>
+                          {typeof subscriptionId === "string" &&
+                            subscriptionId && (
+                              <DropdownMenuItem asChild>
+                                <Link
+                                  target="_blank"
+                                  to={`https://zapplanner.albylabs.com/subscriptions/${subscriptionId}`}
+                                  className="flex flex-1 items-center gap-2"
+                                >
+                                  <ExternalLinkIcon className="size-4" />
+                                  View
+                                </Link>
+                              </DropdownMenuItem>
+                            )}
+
                           {appStoreApp && (
                             <DropdownMenuItem asChild>
                               <Link
@@ -276,6 +293,7 @@ function AppInternal({ app, refetchApp, capabilities }: AppInternalProps) {
                               </Link>
                             </DropdownMenuItem>
                           )}
+
                           <DropdownMenuItem asChild>
                             <div
                               className="flex items-center gap-2"
@@ -284,6 +302,7 @@ function AppInternal({ app, refetchApp, capabilities }: AppInternalProps) {
                               <InfoIcon className="size-4" /> Connection Details
                             </div>
                           </DropdownMenuItem>
+
                           <DropdownMenuSeparator />
                           <DropdownMenuItem variant="destructive" asChild>
                             <div

--- a/frontend/src/screens/internal-apps/ZapPlanner.tsx
+++ b/frontend/src/screens/internal-apps/ZapPlanner.tsx
@@ -16,7 +16,7 @@ import {
   getSatoshiValue,
   LightningAddress,
 } from "@getalby/lightning-tools";
-import { ExternalLinkIcon, PlusCircleIcon } from "lucide-react";
+import { PlusCircleIcon } from "lucide-react";
 import { toast } from "sonner";
 import alby from "src/assets/suggested-apps/alby.png";
 import bitcoinbrink from "src/assets/zapplanner/bitcoinbrink.png";
@@ -26,7 +26,6 @@ import { AppStoreDetailHeader } from "src/components/connections/AppStoreDetailH
 import { appStoreApps } from "src/components/connections/SuggestedAppData";
 import ExternalLink from "src/components/ExternalLink";
 import { Button } from "src/components/ui/button";
-import { ExternalLinkButton } from "src/components/ui/custom/external-link-button";
 import { LoadingButton } from "src/components/ui/custom/loading-button";
 import {
   Dialog,
@@ -552,20 +551,7 @@ export function ZapPlanner() {
           <h2 className="font-semibold text-xl">Recurring Payments</h2>
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-stretch app-list">
             {zapplannerApps.map((app, index) => (
-              <AppCard
-                key={index}
-                app={app}
-                actions={
-                  app.metadata?.zapplanner_subscription_id ? (
-                    <ExternalLinkButton
-                      to={`https://zapplanner.albylabs.com/subscriptions/${app.metadata.zapplanner_subscription_id}`}
-                      size="sm"
-                    >
-                      View <ExternalLinkIcon className="size-4 ml-2" />
-                    </ExternalLinkButton>
-                  ) : undefined
-                }
-              />
+              <AppCard key={index} app={app} />
             ))}
           </div>
         </>


### PR DESCRIPTION
## fixes  #1815

<img width="1366" height="768" alt="zapplanner-mang" src="https://github.com/user-attachments/assets/e7bbc12f-8b92-419c-9b63-1218c914333c" />

<img width="1366" height="768" alt="zapplanner-mang2" src="https://github.com/user-attachments/assets/45e082b4-fec6-4e75-8785-e7729aea037c" />

<img width="1366" height="768" alt="zapplanner-mang3" src="https://github.com/user-attachments/assets/ecac5a31-7b3a-43fa-977a-19a01855a5a9" />


## Suggestion.
the View Subscription link is better kept here alongside (website link, App store link, Playstore link, etc.) for ease accessibility.
<img width="1157" height="281" alt="zapplanner mang observation" src="https://github.com/user-attachments/assets/5abf4652-eb2b-4f35-8d2b-d3bb20b27f35" />

However, I've placed it in the dropdown menu to avoid a substantial refactor. The main links are static, and adding this dynamic link alongside them would require reworking how they are all rendered. This approach delivers the feature quickly while maintaining code stability.
