### PR TITLE
fix: Improve mobile layout for ZapPlanner page

### DIFF
--- a/frontend/src/components/connections/AppStoreDetailHeader.tsx
+++ b/frontend/src/components/connections/AppStoreDetailHeader.tsx
@@ -29,31 +29,17 @@ export function AppStoreDetailHeader({
             <div className="flex flex-row items-center">
               <img
                 src={appStoreApp.logo}
-                className="w-14 h-14 rounded-lg mr-4"
+                className="w-14 h-14 rounded-lg mr-4 shrink-0"
               />
-              <div className="flex flex-col">
-                <div className="flex items-center gap-2">
+              <div className="flex gap-2 min-w-0">
+                <h2
+                  title={appStoreApp.title}
+                  className="text-xl font-semibold overflow-hidden text-ellipsis whitespace-nowrap"
+                >
                   {appStoreApp.title}
-                  {!!connectedApps.length && (
-                    <Badge
-                      variant="positive"
-                      className="hidden md:flex items-center gap-1"
-                    >
-                      <CheckCircleIcon className="w-3 h-3" />{" "}
-                      {connectedApps.length > 1
-                        ? `${connectedApps.length} Connections`
-                        : "Connected"}
-                    </Badge>
-                  )}
-                </div>
-                <div className="text-sm font-normal text-muted-foreground">
-                  {appStoreApp.description}
-                </div>
+                </h2>
                 {!!connectedApps.length && (
-                  <Badge
-                    variant="positive"
-                    className="md:hidden flex items-center gap-1 w-fit" // Only shows on small screens
-                  >
+                  <Badge variant="positive" className="flex items-center gap-1">
                     <CheckCircleIcon className="w-3 h-3" />{" "}
                     {connectedApps.length > 1
                       ? `${connectedApps.length} Connections`

--- a/frontend/src/components/connections/AppStoreDetailHeader.tsx
+++ b/frontend/src/components/connections/AppStoreDetailHeader.tsx
@@ -37,7 +37,7 @@ export function AppStoreDetailHeader({
                   {!!connectedApps.length && (
                     <Badge
                       variant="positive"
-                      className="flex items-center gap-1"
+                      className="hidden md:flex items-center gap-1"
                     >
                       <CheckCircleIcon className="w-3 h-3" />{" "}
                       {connectedApps.length > 1
@@ -49,6 +49,17 @@ export function AppStoreDetailHeader({
                 <div className="text-sm font-normal text-muted-foreground">
                   {appStoreApp.description}
                 </div>
+                {!!connectedApps.length && (
+                  <Badge
+                    variant="positive"
+                    className="md:hidden flex items-center gap-1 w-fit" // Only shows on small screens
+                  >
+                    <CheckCircleIcon className="w-3 h-3" />{" "}
+                    {connectedApps.length > 1
+                      ? `${connectedApps.length} Connections`
+                      : "Connected"}
+                  </Badge>
+                )}
               </div>
             </div>
           </>

--- a/frontend/src/screens/internal-apps/ZapPlanner.tsx
+++ b/frontend/src/screens/internal-apps/ZapPlanner.tsx
@@ -49,6 +49,7 @@ import {
 import { Textarea } from "src/components/ui/textarea";
 import { SUPPORT_ALBY_LIGHTNING_ADDRESS } from "src/constants";
 import { request } from "src/utils/request";
+import ResponsiveButton from "src/components/ResponsiveButton";
 
 type Recipient = {
   name: string;
@@ -352,10 +353,10 @@ export function ZapPlanner() {
           <>
             <Dialog open={open} onOpenChange={setOpen}>
               <DialogTrigger asChild>
-                <Button>
-                  <PlusCircleIcon />
-                  New Recurring Payment
-                </Button>
+                <ResponsiveButton
+                  icon={PlusCircleIcon}
+                  text="New Recurring Payment"
+                />
               </DialogTrigger>
               <DialogContent className="sm:max-w-[600px] max-h-[85vh] overflow-y-auto">
                 <form onSubmit={handleSubmit}>

--- a/frontend/src/screens/internal-apps/ZapPlanner.tsx
+++ b/frontend/src/screens/internal-apps/ZapPlanner.tsx
@@ -357,7 +357,7 @@ export function ZapPlanner() {
                   New Recurring Payment
                 </Button>
               </DialogTrigger>
-              <DialogContent className="sm:max-w-[600px]">
+              <DialogContent className="sm:max-w-[600px] max-h-[85vh] overflow-y-auto">
                 <form onSubmit={handleSubmit}>
                   <DialogHeader>
                     <DialogTitle>New Recurring Payment</DialogTitle>
@@ -373,8 +373,8 @@ export function ZapPlanner() {
                   </DialogHeader>
 
                   <div className="grid gap-4 py-4">
-                    <div className="grid grid-cols-4 items-center gap-4">
-                      <Label htmlFor="name" className="text-right">
+                    <div className="grid md:grid-cols-4 items-center gap-2 md:gap-4">
+                      <Label htmlFor="name" className="md:text-right">
                         Recipient Name
                       </Label>
                       <Input
@@ -382,11 +382,11 @@ export function ZapPlanner() {
                         value={recipientName}
                         required
                         onChange={(e) => setRecipientName(e.target.value)}
-                        className="col-span-3 w-70"
+                        className="md:col-span-3"
                       />
                     </div>
-                    <div className="grid grid-cols-4 items-center gap-4">
-                      <Label htmlFor="name" className="text-right">
+                    <div className="grid md:grid-cols-4 items-center gap-2 md:gap-4">
+                      <Label htmlFor="receiver" className="md:text-right">
                         Recipient Lightning Address
                       </Label>
                       <Input
@@ -396,14 +396,14 @@ export function ZapPlanner() {
                         onChange={(e) =>
                           setRecipientLightningAddress(e.target.value)
                         }
-                        className="col-span-3 w-70"
+                        className="md:col-span-3"
                       />
                     </div>
-                    <div className="grid grid-cols-4 items-center gap-4">
-                      <Label htmlFor="amount" className="text-right">
+                    <div className="grid md:grid-cols-4 items-center gap-2 md:gap-4">
+                      <Label htmlFor="amount" className="md:text-right">
                         Amount
                       </Label>
-                      <div className="col-span-3 flex items-center gap-2">
+                      <div className="md:col-span-3 flex items-center gap-2">
                         <div className="relative flex-1">
                           <Input
                             id="amount"
@@ -413,7 +413,7 @@ export function ZapPlanner() {
                             inputMode="decimal"
                             value={amount}
                             onChange={(e) => setAmount(e.target.value)}
-                            className="col-span-3 w-70"
+                            className="md:col-span-3"
                           />
 
                           {convertedAmount && (
@@ -424,7 +424,7 @@ export function ZapPlanner() {
                         </div>
 
                         <Select value={currency} onValueChange={setCurrency}>
-                          <SelectTrigger className="w-1/2">
+                          <SelectTrigger className="w-auto">
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent>
@@ -438,11 +438,11 @@ export function ZapPlanner() {
                       </div>
                     </div>
 
-                    <div className="grid grid-cols-4 items-start gap-4">
-                      <Label htmlFor="frequency" className="text-right pt-2">
+                    <div className="grid md:grid-cols-4 items-start gap-2 md:gap-4">
+                      <Label htmlFor="frequency" className="md:text-right pt-2">
                         Frequency
                       </Label>
-                      <div className="col-span-3 flex flex-col gap-1 w-full max-w-[450px]">
+                      <div className="md:col-span-3 flex flex-col gap-1 w-full">
                         <div className="flex items-center gap-2 w-full">
                           <Input
                             id="frequency"
@@ -452,13 +452,12 @@ export function ZapPlanner() {
                             inputMode="numeric"
                             value={frequencyValue}
                             onChange={(e) => setFrequencyValue(e.target.value)}
-                            className="col-span-3 w-70"
                           />
                           <Select
                             value={frequencyUnit}
                             onValueChange={setFrequencyUnit}
                           >
-                            <SelectTrigger className="w-1/2">
+                            <SelectTrigger className="w-full">
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
@@ -475,8 +474,8 @@ export function ZapPlanner() {
                       </div>
                     </div>
 
-                    <div className="grid grid-cols-4 gap-4">
-                      <Label htmlFor="comment" className="text-right pt-2">
+                    <div className="grid md:grid-cols-4 gap-2 md:gap-4">
+                      <Label htmlFor="comment" className="md:text-right pt-2">
                         Comment
                       </Label>
                       <Textarea
@@ -484,11 +483,11 @@ export function ZapPlanner() {
                         value={comment}
                         onChange={(e) => setComment(e.target.value)}
                         placeholder="Optional comment"
-                        className="col-span-3 w-70"
+                        className="md:col-span-3"
                       />
                     </div>
-                    <div className="grid grid-cols-4 items-center gap-4">
-                      <Label htmlFor="comment" className="text-right">
+                    <div className="grid md:grid-cols-4 items-center gap-2 md:gap-4">
+                      <Label htmlFor="comment" className="md:text-right">
                         Your Name
                       </Label>
                       <Input
@@ -496,7 +495,7 @@ export function ZapPlanner() {
                         value={senderName}
                         onChange={(e) => setSenderName(e.target.value)}
                         placeholder={`Let ${recipientName || "them"} know it was from you`}
-                        className="col-span-3 w-70"
+                        className="md:col-span-3"
                       />
                     </div>
                   </div>


### PR DESCRIPTION
## fixes #1816 and fixes #1817
<img width="351" height="495" alt="header on small scrren" src="https://github.com/user-attachments/assets/cab7587e-8917-469c-b696-835ccff35621" />

also noticed irresponsiveness of the modal on small screens.
## before
<img width="364" height="431" alt="zapplanner modal before" src="https://github.com/user-attachments/assets/d7a267f9-4ff2-40da-b5d9-cd7727aea44c" />

## after
<img width="579" height="512" alt="zapplanner modal after" src="https://github.com/user-attachments/assets/630dd46f-8d38-48ff-8dbc-992a4857784e" />

