### PR TITLE
fix: Remove balance check from auto-swap limit

### DIFF
--- a/frontend/src/screens/wallet/swap/AutoSwap.tsx
+++ b/frontend/src/screens/wallet/swap/AutoSwap.tsx
@@ -71,6 +71,13 @@ function AutoSwapOutForm() {
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
+    if (swapAmount > balanceThreshold) {
+      toast.info(
+        "Balance threshold must be greater than or equal to swap amount"
+      );
+      return;
+    }
+
     try {
       setLoading(true);
       await request("/api/autoswap", {

--- a/http/http_service.go
+++ b/http/http_service.go
@@ -1510,12 +1510,6 @@ func (httpSvc *HttpService) enableAutoSwapOutHandler(c echo.Context) error {
 		})
 	}
 
-	if enableAutoSwapRequest.SwapAmount > enableAutoSwapRequest.BalanceThreshold {
-        return c.JSON(http.StatusBadRequest, ErrorResponse{
-            Message: "Swap amount cannot be greater than the balance threshold",
-        })
-    }
-
 	err := httpSvc.api.EnableAutoSwapOut(c.Request().Context(), &enableAutoSwapRequest)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{


### PR DESCRIPTION
Fixes #1822

Another thing worth considering is a potential logic flaw I've identified. Presently, there is no validation to ensure the `Spending balance threshold` is greater than or equal to the `Swap amount`.

This allows a user to create a configuration that will always fail. For example:

1.  Set **Balance Threshold** to `10,000` sats.
2.  Set **Swap Amount** to `25,000` sats.

The system will trigger the swap when the Lightning balance reaches 10,000 sats, but the action to swap 25,000 sats will immediately fail due to insufficient funds. This could lead to a confusing user experience with perpetually failing transactions.

**Suggestion:**
We should add a validation rule to the form that prevents saving if the `Swap amount` is greater than the `Balance threshold`.