### PR TITLE
fix: next payment description on supporter toast

### DIFF
--- a/frontend/src/screens/alby/SupportAlby.tsx
+++ b/frontend/src/screens/alby/SupportAlby.tsx
@@ -139,7 +139,7 @@ function SupportAlby() {
       });
 
       toast("Thank you for becoming a supporter", {
-        description: "The first payment is scheduled immediately.",
+        description: "Payment will be made at the start of each month",
       });
 
       navigate("/");


### PR DESCRIPTION
fixes #1818
<img width="541" height="302" alt="being a supporter2" src="https://github.com/user-attachments/assets/fd3f8cd9-7adf-4210-a999-f1b92c0c8cd4" />

