### PR TITLE
fix: make channel peer selector more discoverable. Fixes #1833

### DIFF
--- a/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
@@ -347,7 +347,7 @@ function NewChannelInternal({
               <div className="flex flex-col gap-3">
                 {selectedPeer && (
                   <div className="grid gap-1.5">
-                    <Label>Channel peer</Label>
+                    <Label>Choose your channel peer:</Label>
                     <Select
                       value={getPeerKey(selectedPeer)}
                       onValueChange={(value) =>

--- a/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
@@ -311,7 +311,7 @@ function NewChannelInternal({
                 order.paymentMethod === "onchain" &&
                 selectedPeer.pubkey === order.pubkey && (
                   <div className="grid gap-1.5">
-                    <Label>Channel peer</Label>
+                    <Label>Choose your channel peer:</Label>
                     <Select
                       value={getPeerKey(selectedPeer)}
                       onValueChange={(value) =>


### PR DESCRIPTION
## Description
Changes the label from "Channel peer" to "Choose your channel peer:" to help users understand this is an interactive selector where they can choose from different LSP providers.

## Changes
- Updated label in `IncreaseIncomingCapacity.tsx`
- Updated label in `IncreaseOutgoingCapacity.tsx`

Fixes #1833