### PR TITLE
fix: update Alby Go link to use appstore route instead of internal-apps

### DIFF
--- a/frontend/src/screens/Home.tsx
+++ b/frontend/src/screens/Home.tsx
@@ -102,7 +102,7 @@ function Home() {
             </ExternalLink>
           )}
 
-          <Link to="/internal-apps/alby-go">
+          <Link to="/appstore/alby-go">
             <Card>
               <CardHeader>
                 <div className="flex flex-row items-center">


### PR DESCRIPTION
The Alby Go card on the Home page was linking to /internal-apps/alby-go which doesn't exist. Alby Go is an external mobile app, not an internal web app, so it should link to /appstore/alby-go to show the app store detail page with installation instructions.

Fixes the 'Page not found' error when clicking 'Open' on Alby Go card.


Fixes #1849