### PR TITLE
chore: add new ai app links

### DIFF
--- a/frontend/src/components/connections/SuggestedAppData.tsx
+++ b/frontend/src/components/connections/SuggestedAppData.tsx
@@ -192,41 +192,6 @@ export const appStoreApps: AppStoreApp[] = (
       webLink: "https://claude.ai/",
     },
     {
-      id: "goose-memory-mcp",
-      title: "Goose - Memory MCP",
-      description: "Add persistent memory to your Goose AI agent",
-      extendedDescription:
-        "Set up Memory MCP to give your Goose AI agent persistent memory across sessions",
-      internal: false,
-      logo: goose,
-      categories: ["ai"],
-      webLink:
-        "https://github.com/toverux/mcp-memory-service?tab=readme-ov-file#goose",
-    },
-    {
-      id: "claude-memory-mcp",
-      title: "Claude - Memory MCP",
-      description: "Add persistent memory to Claude Desktop",
-      extendedDescription:
-        "Set up Memory MCP to give Claude Desktop persistent memory across sessions",
-      internal: false,
-      logo: claude,
-      categories: ["ai"],
-      webLink:
-        "https://github.com/toverux/mcp-memory-service?tab=readme-ov-file#claude-desktop",
-    },
-    {
-      id: "bitrefill-mcp",
-      title: "Bitrefill MCP",
-      description: "Buy gift cards with Bitcoin using AI agents",
-      extendedDescription:
-        "Enable your AI agents to purchase gift cards with Bitcoin through Bitrefill's MCP server",
-      internal: false,
-      logo: bitrefill,
-      categories: ["ai"],
-      webLink: "https://www.bitrefill.com/account/developers/mcp-server",
-    },
-    {
       id: "lnmarkets-mcp",
       title: "LNMarkets MCP",
       description: "Trade Bitcoin futures with AI-powered automation",

--- a/frontend/src/screens/internal-apps/Bitrefill.tsx
+++ b/frontend/src/screens/internal-apps/Bitrefill.tsx
@@ -86,7 +86,20 @@ export function Bitrefill() {
       <div className="flex flex-col gap-5 h-full">
         <AppHeader
           title="Bitrefill"
-          description="Live on bitcoin by purchasing digital gift cards, eSIMs, and phone refills"
+          description={
+            <>
+              Live on bitcoin by purchasing digital gift cards, eSIMs, and phone
+              refills. Set up{" "}
+              <a
+                href="https://www.bitrefill.com/account/developers/mcp-server"
+                target="_blank"
+                className="underline"
+              >
+                Bitrefill MCP
+              </a>{" "}
+              to enable AI agents to purchase gift cards with Bitcoin.
+            </>
+          }
         />
         <iframe
           width="100%"

--- a/frontend/src/screens/internal-apps/Claude.tsx
+++ b/frontend/src/screens/internal-apps/Claude.tsx
@@ -181,6 +181,17 @@ export function Claude() {
                 allows Claude to help you with payments, balance checks, and
                 more.
               </p>
+              <p className="text-muted-foreground">
+                Set up{" "}
+                <a
+                  href="https://docs.claude.com/en/docs/claude-code/memory"
+                  target="_blank"
+                  className="underline"
+                >
+                  Memory MCP
+                </a>{" "}
+                to give Claude persistent memory.
+              </p>
               <div className=" flex flex-col gap-5">
                 <p className="text-muted-foreground">
                   Connect your hub to Claude to:

--- a/frontend/src/screens/internal-apps/Goose.tsx
+++ b/frontend/src/screens/internal-apps/Goose.tsx
@@ -210,6 +210,17 @@ export function Goose() {
                 </a>{" "}
                 - an MCP server that connects to NWC wallets.
               </p>
+              <p className="text-muted-foreground">
+                Set up{" "}
+                <a
+                  href="https://block.github.io/goose/docs/mcp/memory-mcp/"
+                  target="_blank"
+                  className="underline"
+                >
+                  Memory MCP
+                </a>{" "}
+                to give Goose persistent memory.
+              </p>
               <div className=" flex flex-col gap-5">
                 <p className="text-muted-foreground">
                   Connect your hub to goose to:


### PR DESCRIPTION
fixes #1861

<img width="1234" height="400" alt="Screenshot 2025-10-25 at 3 59 28 PM" src="https://github.com/user-attachments/assets/de8da7cf-1efc-41f4-bb07-43de16e574f3" />

currently I have just added the memory mcp for both claude and goose as separate apps and used Lnbits logo for LNMarkets, I wanted to confirm these changes and am willing to refactor it, if memory mcps need to be inside the app already there claude and goose.

Thanks!