### PR TITLE
a11y: improve disabled and labeling support in ResponsiveButton

### DIFF
--- a/frontend/src/components/ResponsiveButton.tsx
+++ b/frontend/src/components/ResponsiveButton.tsx
@@ -5,7 +5,7 @@ import { Button } from "./ui/button";
 import { buttonVariants } from "./ui/buttonVariants";
 
 type Props = {
-  icon: React.ComponentType;
+  icon: React.ComponentType<{ className?: string }>;
   text: string;
 } & React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
@@ -19,11 +19,12 @@ const ResponsiveButton = ({
   asChild,
   children,
   className,
+  disabled,
   ...props
 }: Props) => {
   const content = (
     <>
-      <Icon />
+      <Icon aria-hidden="true" />
       <span className="hidden lg:inline">{text}</span>
     </>
   );
@@ -33,9 +34,12 @@ const ResponsiveButton = ({
       {...props}
       variant={variant}
       asChild={asChild}
+      disabled={disabled}
+      aria-disabled={disabled}
+      aria-label={text}
       className={cn(
         className,
-        "max-lg:size-9" /* apply size="icon" only for mobile */
+        "max-lg:size-9" /* apply size=\"icon\" only for mobile */
       )}
     >
       {asChild


### PR DESCRIPTION
Improves accessibility semantics for `ResponsiveButton`.

- Adds accessible labeling for icon-only buttons on smaller screens
- Ensures `aria-disabled` is set when the button is disabled
- Marks decorative icons as `aria-hidden`

This keeps visual behavior unchanged while improving keyboard and
screen-reader support, especially when `asChild` is used.
