### PR TITLE
fix: max amount when swapping in from external wallet

### DIFF
--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -162,7 +162,9 @@ function SwapInForm() {
           min={swapInfo.minAmount}
           max={Math.min(
             swapInfo.maxAmount,
-            spendableOnchainBalanceWithAnchorReserves,
+            ...(isInternalSwap
+              ? [spendableOnchainBalanceWithAnchorReserves]
+              : []),
             (balances.lightning.totalReceivable / 1000) * 0.99
           )}
           onChange={(e) => setSwapAmount(e.target.value)}


### PR DESCRIPTION
There is a bug right now that you cannot swap in from an external wallet more than your current internal on-chain wallet balance (which doesn't make sense)