### PR TITLE
feat: add alert to node page when user has any large LDK channel monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ _To configure via env, the following parameters must be provided:_
 - `LDK_MAX_CHANNEL_SATURATION`: Sets the maximum portion of a channel's total capacity that may be used for sending a payment, expressed as a power of 1/2. See `max_channel_saturation_power_of_half` in [LDK docs](https://docs.rs/lightning/latest/lightning/routing/router/struct.PaymentParameters.html#structfield.max_channel_saturation_power_of_half).
 - `LDK_MAX_PATH_COUNT`: Maximum number of paths that may be used by MPP payments.
 - `LDK_LOG_LEVEL`: Log level for the LDK node. Higher is more verbose. Default: 3. This is separate from the main application log level, allowing you to enable more verbose LDK logging (e.g., level 4, 5 or 6) without enabling verbose logging for the entire application.
+- `LDK_CHANNEL_MONITOR_WARNING_SIZE_BYTES`: If a channel monitor is larger than this value, a performance warning will be shown on the node page.
 
 #### LDK Network Configuration
 

--- a/config/models.go
+++ b/config/models.go
@@ -34,6 +34,7 @@ type AppConfig struct {
 	LDKLogLevel                        string `envconfig:"LDK_LOG_LEVEL" default:"3"`
 	LDKMaxChannelSaturationPowerOfHalf uint8  `envconfig:"LDK_MAX_CHANNEL_SATURATION" default:"2"`
 	LDKMaxPathCount                    uint8  `envconfig:"LDK_MAX_PATH_COUNT" default:"5"`
+	LDKChannelMonitorWarningSizeBytes  uint64 `envconfig:"LDK_CHANNEL_MONITOR_WARNING_SIZE_BYTES" default:"5000000"`
 	LDKVssUrl                          string `envconfig:"LDK_VSS_URL" default:"https://vss.getalbypro.com/vss"`
 	LDKListeningAddresses              string `envconfig:"LDK_LISTENING_ADDRESSES" default:"[::]:9735"`
 	LDKAnnouncementAddresses           string `envconfig:"LDK_ANNOUNCEMENT_ADDRESSES"`

--- a/frontend/src/components/channels/LDKChannelMonitorSizeAlert.tsx
+++ b/frontend/src/components/channels/LDKChannelMonitorSizeAlert.tsx
@@ -1,0 +1,86 @@
+import { AlertTriangleIcon } from "lucide-react";
+import React from "react";
+import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
+import { useInfo } from "src/hooks/useInfo";
+import { useNodeDetails } from "src/hooks/useNodeDetails";
+import { request } from "src/utils/request";
+
+export function LDKChannelMonitorSizeAlert() {
+  const { data: info } = useInfo();
+
+  if (info?.backendType !== "LDK") {
+    return null;
+  }
+  return ChannelMonitorSizeAlert();
+}
+
+function ChannelMonitorSizeAlert() {
+  const [channelMonitorSizes, setChannelMonitorSizes] =
+    React.useState<
+      { remotePubkey: string; sizeBytes: number; hasWarning: boolean }[]
+    >();
+  React.useEffect(() => {
+    (async () => {
+      try {
+        const requestOptions: RequestInit = {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ command: "list_channel_monitor_sizes" }),
+        };
+
+        const data = await request("/api/command", requestOptions);
+
+        setChannelMonitorSizes(data as typeof channelMonitorSizes);
+      } catch (error) {
+        console.error(error);
+      }
+    })();
+  }, []);
+
+  if (!channelMonitorSizes) {
+    return null;
+  }
+
+  const largestChannelMonitor = channelMonitorSizes.find(
+    (c1) => !channelMonitorSizes.find((c2) => c2.sizeBytes > c1.sizeBytes)
+  );
+  if (!largestChannelMonitor) {
+    return null;
+  }
+
+  if (!largestChannelMonitor.hasWarning) {
+    return;
+  }
+  return (
+    <ChannelMonitorSizeAlertForPubkey
+      remotePubkey={largestChannelMonitor.remotePubkey}
+      sizeBytes={largestChannelMonitor.sizeBytes}
+    />
+  );
+}
+
+function ChannelMonitorSizeAlertForPubkey({
+  remotePubkey,
+  sizeBytes,
+}: {
+  remotePubkey: string;
+  sizeBytes: number;
+}) {
+  const { data: peerDetails } = useNodeDetails(remotePubkey);
+  return (
+    <>
+      <Alert>
+        <AlertTriangleIcon className="h-4 w-4" />
+        <AlertTitle>Large channel state detected</AlertTitle>
+        <AlertDescription>
+          The channel state for your channel with{" "}
+          {peerDetails?.alias || remotePubkey} is over{" "}
+          {Math.floor(sizeBytes / 1_000_000)} MB. Consider closing this channel
+          and opening a new one to improve your node performance.
+        </AlertDescription>
+      </Alert>
+    </>
+  );
+}

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -20,6 +20,7 @@ import AppHeader from "src/components/AppHeader.tsx";
 import { ChannelsCards } from "src/components/channels/ChannelsCards.tsx";
 import { ChannelsTable } from "src/components/channels/ChannelsTable.tsx";
 import { HealthCheckAlert } from "src/components/channels/HealthcheckAlert";
+import { LDKChannelMonitorSizeAlert } from "src/components/channels/LDKChannelMonitorSizeAlert";
 import { LDKChannelWithoutPeerAlert } from "src/components/channels/LDKChannelWithoutPeerAlert";
 import { OnchainTransactionsTable } from "src/components/channels/OnchainTransactionsTable.tsx";
 import EmptyState from "src/components/EmptyState.tsx";
@@ -611,6 +612,7 @@ export default function Channels() {
             />
           )}
 
+          <LDKChannelMonitorSizeAlert />
           <LDKChannelWithoutPeerAlert />
 
           <ChannelsTable

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/btcsuite/btcd v0.24.3-0.20250318170759-4f4ea81776d6
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/elnosh/gonuts v0.4.2
-	github.com/getAlby/ldk-node-go v0.0.0-20260105120609-eaf05d8a8fcd
+	github.com/getAlby/ldk-node-go v0.0.0-20260106083454-34a77eb123bb
 	github.com/go-gormigrate/gormigrate/v2 v2.1.5
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/mattn/go-sqlite3 v1.14.32

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
-github.com/getAlby/ldk-node-go v0.0.0-20260105120609-eaf05d8a8fcd h1:irCN8P42eNPARxihk4rxDfP/lGR5XT+9X+Z+/1/A+FQ=
-github.com/getAlby/ldk-node-go v0.0.0-20260105120609-eaf05d8a8fcd/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20260106083454-34a77eb123bb h1:ilevBkWdRmk63ach1UBrPwbMKvbK65njlnS0VO+1daw=
+github.com/getAlby/ldk-node-go v0.0.0-20260106083454-34a77eb123bb/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gormigrate/gormigrate/v2 v2.1.5 h1:1OyorA5LtdQw12cyJDEHuTrEV3GiXiIhS4/QTTa/SM8=
 github.com/go-gormigrate/gormigrate/v2 v2.1.5/go.mod h1:mj9ekk/7CPF3VjopaFvWKN2v7fN3D9d3eEOAXRhi/+M=


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/2006 (also see https://github.com/getAlby/ldk-node/pull/88)
Fixes https://github.com/getAlby/hub/issues/2003 (see https://github.com/getAlby/ldk-node/pull/87)

<img width="2345" height="1064" alt="image" src="https://github.com/user-attachments/assets/20366f91-486d-4dd1-a53b-b625f92a6de8" />

For now there is no automated alert. This could be a follow-up improvement, by checking the channel sizes once per day.
