### PR TITLE
chore: reduce alby oauth permissions

### DIFF
--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -61,7 +61,7 @@ func NewAlbyOAuthService(db *gorm.DB, cfg config.Config, keys keys.Keys, eventPu
 	conf := &oauth2.Config{
 		ClientID:     cfg.GetEnv().AlbyClientId,
 		ClientSecret: cfg.GetEnv().AlbyClientSecret,
-		Scopes:       []string{"account:read", "balance:read", "payments:send"},
+		Scopes:       []string{"account:read"},
 		Endpoint: oauth2.Endpoint{
 			TokenURL:  albyOAuthAPIURL + "/oauth/token",
 			AuthURL:   albyOAuthAuthUrl,


### PR DESCRIPTION
custodial alby account service is shut down so there is no need to fetch balance or transfer funds now