### PR TITLE
fix: conditional query param in swap in status navigation

### DIFF
--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -113,7 +113,7 @@ function SwapInForm() {
         throw new Error("Error swapping in");
       }
       navigate(
-        `/wallet/swap/in/status/${swapInResponse.swapId}${isInternalSwap && `?internal=true`}`
+        `/wallet/swap/in/status/${swapInResponse.swapId}${isInternalSwap ? "?internal=true" : ""}`
       );
       toast("Initiated swap");
     } catch (error) {


### PR DESCRIPTION
The problem was it was appending `false` to the swap id which pollutes the swap info request, resulting in this screen

<img width="100%" src="https://github.com/user-attachments/assets/cde49e83-6278-43c7-a1d2-bc4a906bf449" />
