### PR TITLE
Fix: adjust button layout to prevent overlap in ZapPlanner

### DIFF
--- a/frontend/src/screens/internal-apps/ZapPlanner.tsx
+++ b/frontend/src/screens/internal-apps/ZapPlanner.tsx
@@ -355,7 +355,10 @@ export function ZapPlanner() {
           <>
             <Dialog open={open} onOpenChange={setOpen}>
               <DialogTrigger asChild>
-                <Button className="max-lg:size-9">
+                <Button
+                  className="max-lg:size-9"
+                  aria-label="New Recurring Payment"
+                >
                   <PlusCircleIcon />
                   <span className="hidden lg:inline">
                     New Recurring Payment


### PR DESCRIPTION
Fixes #1816 
Makes the "New Recurring Payment" button responsive by showing only the icon on smaller screens to prevent layout overlap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the ZapPlanner dialog trigger button’s responsive sizing and label visibility to better suit different screen sizes while preserving the icon.

* **Chores**
  * Added an accessibility label to the trigger for improved screen reader support and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->