### PR TITLE
feat: add clickable hyperlinks in transaction memos

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,7 @@
     "react-day-picker": "^9.11.0",
     "react-dom": "18.3.1",
     "react-hook-form": "^7.60.0",
+    "react-linkify-it": "^2.0.0",
     "react-lottie": "^1.2.4",
     "react-qr-code": "^2.0.12",
     "react-resizable-panels": "^3.0.6",

--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { nip19 } from "nostr-tools";
 import React from "react";
+import { LinkIt } from "react-linkify-it";
 import { Link } from "react-router-dom";
 import AppAvatar from "src/components/AppAvatar";
 import ExternalLink from "src/components/ExternalLink";
@@ -46,6 +47,34 @@ function safeNpubEncode(hex: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+const URL_REGEX =
+  /(https?:\/\/[^\s]+|(?:www\.)?[a-zA-Z0-9][-a-zA-Z0-9]*\.[a-zA-Z]{2,}(?:\/[^\s]*)?)/gi;
+
+function LinkifyUrls({ children }: { children: string }) {
+  return (
+    <LinkIt
+      regex={URL_REGEX}
+      component={(match, key) => {
+        const href = match.startsWith("http") ? match : `https://${match}`;
+        return (
+          <a
+            key={key}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline hover:no-underline"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {match}
+          </a>
+        );
+      }}
+    >
+      {children}
+    </LinkIt>
+  );
 }
 
 function TransactionItem({ tx }: Props) {
@@ -183,7 +212,7 @@ function TransactionItem({ tx }: Props) {
               </span>
             </div>
             <p className="text-sm md:text-base text-muted-foreground break-all line-clamp-1">
-              {description}
+              <LinkifyUrls>{description || ""}</LinkifyUrls>
             </p>
           </div>
           <div className="flex ml-auto space-x-3 shrink-0">
@@ -285,7 +314,7 @@ function TransactionItem({ tx }: Props) {
               <div className="mt-6">
                 <p>Description</p>
                 <p className="text-muted-foreground break-all">
-                  {tx.description}
+                  <LinkifyUrls>{tx.description}</LinkifyUrls>
                 </p>
               </div>
             )}
@@ -293,7 +322,7 @@ function TransactionItem({ tx }: Props) {
               <div className="mt-6">
                 <p>Comment</p>
                 <p className="text-muted-foreground break-all">
-                  {tx.metadata.comment}
+                  <LinkifyUrls>{tx.metadata.comment}</LinkifyUrls>
                 </p>
               </div>
             )}
@@ -301,7 +330,7 @@ function TransactionItem({ tx }: Props) {
               <div className="mt-6">
                 <p>Payer Note</p>
                 <p className="text-muted-foreground break-all">
-                  {bolt12Offer.payer_note}
+                  <LinkifyUrls>{bolt12Offer.payer_note}</LinkifyUrls>
                 </p>
               </div>
             )}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5300,6 +5300,11 @@ react-is@^18.3.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
+react-linkify-it@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-linkify-it/-/react-linkify-it-2.0.0.tgz#337222fb3d718ab0f48796a4def8c2946eae527d"
+  integrity sha512-L9FY853JgBL+HXyXUZMvMin95WZ/lHNrpBs28P8WYk7B4zC2z7e0j/BrDfjIqB8ZeDCpcBgcWi+Cwjbd4/OlyQ==
+
 react-lottie@^1.2.4:
   version "1.2.10"
   resolved "https://registry.yarnpkg.com/react-lottie/-/react-lottie-1.2.10.tgz#399f78a448a7833b2380d74fc489ecf15f8d18c7"


### PR DESCRIPTION
Fixes: #1515 

Makes URLs in transaction memos clickable. Links open in a new tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction descriptions, comments, and payer notes now render clickable external links.
  * Link detection works in both compact transaction rows and detailed transaction panels, making embedded URLs easy to open.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->