### PR TITLE
Fix: limit stored request events to 1000 per app

### DIFF
--- a/nip47/event_handler.go
+++ b/nip47/event_handler.go
@@ -91,8 +91,6 @@ func (svc *nip47Service) HandleEvent(ctx context.Context, pool nostrmodels.Simpl
 		logger.Logger.WithFields(logrus.Fields{
 			"it": app.ID,
 		}).WithError(err).Error("Failed to update app last used time")
-	} else {
-		go svc.pruneRequestEvents(app.ID)
 	}
 
 	logger.Logger.WithFields(logrus.Fields{
@@ -177,6 +175,9 @@ func (svc *nip47Service) HandleEvent(ctx context.Context, pool nostrmodels.Simpl
 		Model(&requestEvent).
 		Update("app_id", app.ID).
 		Error
+	if err == nil {
+		go svc.pruneRequestEvents(app.ID)
+	}
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
 			"appPubkey": event.PubKey,

--- a/nip47/prune_test.go
+++ b/nip47/prune_test.go
@@ -45,4 +45,11 @@ func TestPruneRequestEvents(t *testing.T) {
 
 	svc.DB.Model(&db.RequestEvent{}).Where("app_id = ?", app.ID).Count(&count)
 	assert.Equal(t, int64(MaxRequestEventsPerApp), count)
+
+	
+	var remaining []db.RequestEvent
+	svc.DB.Where("app_id = ?", app.ID).Order("id asc").Find(&remaining)
+	assert.Equal(t, MaxRequestEventsPerApp, len(remaining))
+	assert.Equal(t, "event_5", remaining[0].NostrId)
+	assert.Equal(t, "event_1004", remaining[len(remaining)-1].NostrId)
 }


### PR DESCRIPTION
Fixes #21
Implemented automatic pruning to limit stored request events to 1000 per app. 
Old events are automatically deleted in the background when new requests come in, preventing disk space issues from spammy apps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request events are automatically pruned; each application retains only the most recent 1,000 request events.

* **Tests**
  * Added test coverage validating that request event pruning keeps the expected 1,000 most recent entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->