### PR TITLE
fix: handle invalid zap data in transaction list

### DIFF
--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -48,7 +48,6 @@ function safeNpubEncode(hex: string): string | undefined {
   }
 }
 
-
 function safeNeventEncode(id: string): string | undefined {
   try {
     return nip19.neventEncode({


### PR DESCRIPTION

This PR fixes an issue where the transaction list could crash if it receives invalid Nostr zap data (specifically an invalid event ID).

 Changes
- Wrapped nip19.neventEncode in a safe helper function safeNeventEncode (similar to safeNpubEncode).
- Updated TransactionItem to use this safe wrapper and only render the Zap link if a valid nevent is generated.

Fixes #2032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Nostr Zap links by adding safe event encoding and ensuring links are only shown when encoding succeeds.

* **Performance**
  * Moved event encoding earlier in the flow to avoid doing work during rendering, reducing potential UI delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->