### PR TITLE
fix: show total subwallet count instead of page count

### DIFF
--- a/frontend/src/screens/subwallets/SubwalletList.tsx
+++ b/frontend/src/screens/subwallets/SubwalletList.tsx
@@ -168,7 +168,7 @@ export function SubwalletList() {
           <CardContent className="grow flex flex-col gap-4">
             <div className="flex flex-col gap-2">
               <span className="text-2xl font-medium">
-                {subwalletApps.length} /{" "}
+                {appsData.totalCount} /{" "}
                 {albyMe?.subscription.plan_code ? "∞" : 3}
               </span>
               {isSufficientlyBacked ? (


### PR DESCRIPTION
Fixes #2031 
The "Number of Sub-wallets" card was displaying only the count of the current page (max 20) instead of the total count. Changed from `subwalletApps.length` to `appsData.totalCount`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved accuracy of the sub-wallets count display by updating the data source used for calculating the total number of sub-wallets shown to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->