### PR TITLE
fix: add error handling for invalid zap data in transaction list

### DIFF
--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -48,6 +48,14 @@ function safeNpubEncode(hex: string): string | undefined {
   }
 }
 
+function safeNeventEncode(eventId: string): string | undefined {
+  try {
+    return nip19.neventEncode({ id: eventId });
+  } catch {
+    return undefined;
+  }
+}
+
 function TransactionItem({ tx }: Props) {
   const { data: app } = useApp(tx.appId);
   const swapId = tx.metadata?.swap_id;
@@ -307,23 +315,25 @@ function TransactionItem({ tx }: Props) {
             )}
             {/* for Alby lightning addresses the content of the zap request is
             automatically extracted and already displayed above as description */}
-            {tx.metadata?.nostr && eventId && npub && (
-              <div className="mt-6">
-                <p>
-                  <ExternalLink
-                    to={`https://njump.me/${nip19.neventEncode({
-                      id: eventId,
-                    })}`}
-                    className="underline"
-                  >
-                    Nostr Zap
-                  </ExternalLink>{" "}
-                  <span className="text-muted-foreground break-all">
-                    from {npub}
-                  </span>
-                </p>
-              </div>
-            )}
+            {tx.metadata?.nostr && eventId && npub && (() => {
+              const nevent = safeNeventEncode(eventId);
+              if (!nevent) return null;
+              return (
+                <div className="mt-6">
+                  <p>
+                    <ExternalLink
+                      to={`https://njump.me/${nevent}`}
+                      className="underline"
+                    >
+                      Nostr Zap
+                    </ExternalLink>{" "}
+                    <span className="text-muted-foreground break-all">
+                      from {npub}
+                    </span>
+                  </p>
+                </div>
+              );
+            })()}
             {tx.state === "failed" && (
               <div className="mt-6">
                 <PaymentFailedAlert


### PR DESCRIPTION
## Description

If a user received an invalid nostr zap (with a malformed event ID), the transaction list would crash because `nip19.neventEncode` throws an exception when given an invalid hex string.

## Root Cause

At line 314 in `TransactionItem.tsx`, `nip19.neventEncode({ id: eventId })` is called directly without error handling. If `eventId` is not a valid 64-character hex string, this throws an exception and crashes the entire transaction list.

## Changes

- Added `safeNeventEncode` helper function (similar to the existing `safeNpubEncode`) that catches encoding errors and returns `undefined`
- Updated the Nostr Zap section to use the safe encoder and gracefully handle invalid event IDs by simply not rendering the section instead of crashing

## Related Issue

Fixes #2032

## Testing

- The fix follows the same pattern as `safeNpubEncode` which already exists in the codebase
- Invalid event IDs will now cause the Nostr Zap section to not render, instead of crashing the entire transaction list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced error handling for Nostr Zap transactions. The application now gracefully manages encoding failures when processing transaction events, ensuring stable display without rendering interruptions. This improvement increases application reliability when handling Zap transactions, providing users with a more consistent and stable experience throughout the transaction view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->