### PR TITLE
feat: add HIDE_UPDATE_BANNER environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ FRONTEND_URL=http://localhost:5173
 
 #LOG_DB_QUERIES=true
 
+# Hide the new version update banner (useful for managed deployments like Start9)
+#HIDE_UPDATE_BANNER=true
+
 # Alby OAuth configuration
 #ALBY_OAUTH_CLIENT_SECRET=
 #ALBY_OAUTH_CLIENT_ID=

--- a/api/api.go
+++ b/api/api.go
@@ -1230,6 +1230,7 @@ func (api *api) GetInfo(ctx context.Context) (*InfoResponse, error) {
 	}
 
 	info.MempoolUrl = api.cfg.GetMempoolUrl()
+	info.HideUpdateBanner = api.cfg.GetEnv().HideUpdateBanner
 	info.AlbyAccountConnected = api.albyOAuthSvc.IsConnected(ctx)
 
 	albyUserIdentifier, err := api.albyOAuthSvc.GetUserIdentifier()

--- a/api/models.go
+++ b/api/models.go
@@ -297,6 +297,7 @@ type InfoResponse struct {
 	Relays                      []InfoResponseRelay `json:"relays"`
 	NodeAlias                   string              `json:"nodeAlias"`
 	MempoolUrl                  string              `json:"mempoolUrl"`
+	HideUpdateBanner            bool                `json:"hideUpdateBanner"`
 }
 
 type UpdateSettingsRequest struct {

--- a/config/models.go
+++ b/config/models.go
@@ -58,6 +58,7 @@ type AppConfig struct {
 	AutoUnlockPassword                 string `envconfig:"AUTO_UNLOCK_PASSWORD"`
 	LogDBQueries                       bool   `envconfig:"LOG_DB_QUERIES" default:"false"`
 	BoltzApi                           string `envconfig:"BOLTZ_API" default:"https://api.boltz.exchange"`
+	HideUpdateBanner                   bool   `envconfig:"HIDE_UPDATE_BANNER" default:"false"`
 }
 
 func (c *AppConfig) IsDefaultClientId() bool {

--- a/frontend/src/hooks/useBanner.tsx
+++ b/frontend/src/hooks/useBanner.tsx
@@ -16,6 +16,11 @@ export function useBanner() {
       return;
     }
 
+    if (info.hideUpdateBanner) {
+      setShowBanner(false);
+      return;
+    }
+
     // vss migration (alby cloud only)
     // TODO: remove after 2026-01-01
     const vssMigrationRequired =

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -164,6 +164,7 @@ export interface InfoResponse {
   nodeAlias: string;
   mempoolUrl: string;
   bitcoinDisplayFormat: BitcoinDisplayFormat;
+  hideUpdateBanner: boolean;
 }
 
 export type BitcoinDisplayFormat = "sats" | "bip177";


### PR DESCRIPTION
## Summary

Closes #2048

Adds a `HIDE_UPDATE_BANNER` environment variable that suppresses the new version update banner. Useful for managed deployments like Start9 that provide their own update notifications.

## Changes

- `config/models.go`: Add `HideUpdateBanner bool` to `AppConfig` (`HIDE_UPDATE_BANNER` env var, defaults to `false`)
- `api/models.go`: Add `HideUpdateBanner` field to `InfoResponse`
- `api/api.go`: Populate from env config in `GetInfo()`
- `frontend/src/types.ts`: Add `hideUpdateBanner` to `InfoResponse` interface
- `frontend/src/hooks/useBanner.tsx`: Early return with `showBanner: false` when flag is set
- `.env.example`: Document the new variable

## Test plan

- [x] \`go vet\` passes
- [x] \`go test ./api/...\` passes
- [x] \`npx tsc --noEmit\` passes (frontend)
- [x] ESLint + Prettier pass (via lint-staged pre-commit hook)
- [x] Commitlint passes
- [ ] Verify banner hidden when \`HIDE_UPDATE_BANNER=true\`
- [ ] Verify banner shown as normal when env var is unset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration option to hide the update banner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->