### PR TITLE
fix: show total subwallet count instead of current page count

### DIFF
--- a/frontend/src/screens/subwallets/SubwalletList.tsx
+++ b/frontend/src/screens/subwallets/SubwalletList.tsx
@@ -168,7 +168,7 @@ export function SubwalletList() {
           <CardContent className="grow flex flex-col gap-4">
             <div className="flex flex-col gap-2">
               <span className="text-2xl font-medium">
-                {subwalletApps.length} /{" "}
+                {appsData.totalCount} /{" "}
                 {albyMe?.subscription.plan_code ? "∞" : 3}
               </span>
               {isSufficientlyBacked ? (


### PR DESCRIPTION
## Summary

- Uses `appsData.totalCount` instead of `subwalletApps.length` for the "Number of Sub-wallets" card
- With pagination (page size 20), the count was showing 20 instead of the actual total (e.g. 600)

## Before
Shows `20 / ∞` with 600 wallets

## After
Shows `600 / ∞` with 600 wallets

Closes #2031