### PR TITLE
fix: update no-token API tests to expect 401

### DIFF
--- a/http/http_service_test.go
+++ b/http/http_service_test.go
@@ -116,7 +116,7 @@ func TestGetApps_NoToken(t *testing.T) {
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
 func TestGetApps_ReadonlyPermission(t *testing.T) {
@@ -254,7 +254,7 @@ func TestCreateApp_NoToken(t *testing.T) {
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
 func TestCreateApp_FullPermission(t *testing.T) {


### PR DESCRIPTION
The JWT library's new update reverts the status code to be 401 from 400 ([release notes](https://github.com/labstack/echo-jwt/releases/tag/v4.4.0)), so this updates the tests so we expect the correct code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tests to verify API returns proper HTTP response codes when authentication credentials are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->