### PR TITLE
fix: sidebar not full height on mobile

### DIFF
--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -58,9 +58,9 @@ function SheetContent({
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
-            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 max-h-full h-full w-3/4 border-l sm:max-w-sm",
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right top-0 right-0 h-svh w-3/4 border-l sm:max-w-sm",
           side === "left" &&
-            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 max-h-full h-full w-3/4 border-r sm:max-w-sm",
+            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left top-0 left-0 h-svh w-3/4 border-r sm:max-w-sm",
           side === "top" &&
             "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
           side === "bottom" &&


### PR DESCRIPTION
## Summary
- Replaces `inset-y-0` with `top-0` for left/right Sheet sides
- Uses `h-svh` (small viewport height) instead of `max-h-full h-full`

## Problem
The previous combination of `inset-y-0` with `h-full max-h-full` could cause height calculation conflicts on mobile browsers, resulting in the sidebar not extending to the full screen height.

## Solution
Using `h-svh` ensures the sheet takes the full small viewport height, which properly accounts for mobile browser UI (address bar, navigation controls).

Fixes #2067

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved the positioning and sizing behavior of side sheets when sliding in from the left or right edges, ensuring they align properly to the top of the screen and adapt better to viewport height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->