### PR TITLE
fix: convert spaces to underscores in subwallet lightning address suggestion

### DIFF
--- a/frontend/src/screens/subwallets/SubwalletCreated.tsx
+++ b/frontend/src/screens/subwallets/SubwalletCreated.tsx
@@ -66,7 +66,11 @@ export function SubwalletCreated() {
   const { data: app } = useApp(createAppResponse?.id, true);
   const [intendedLightningAddress, setIntendedLightningAddress] =
     React.useState(
-      createAppResponse?.name.toLowerCase().replace(/[^a-z0-9]/g, "") || ""
+      createAppResponse?.name
+        .toLowerCase()
+        .trim()
+        .replace(/\s+/g, "_")
+        .replace(/[^a-z0-9_]/g, "") || ""
     );
 
   const { data: albyMe } = useAlbyMe();


### PR DESCRIPTION
fixes #2070

This PR improves the subwallet creation UX by updating the lightning address suggestion logic to support underscores. Instead of stripping all non-alphanumeric characters, the code now converts spaces to underscores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced lightning address generation to properly handle whitespace and support underscore characters in addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->