### PR TITLE
fix: detect confirmed onchain deposits after tab switch

### DIFF
--- a/frontend/src/screens/onchain/DepositBitcoin.tsx
+++ b/frontend/src/screens/onchain/DepositBitcoin.tsx
@@ -5,7 +5,7 @@ import {
   ExternalLinkIcon,
   RefreshCwIcon,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import AppHeader from "src/components/AppHeader";
 import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
@@ -46,9 +46,20 @@ export default function DepositBitcoin() {
   const [txId, setTxId] = useState("");
   const [confirmedAmount, setConfirmedAmount] = useState<number | null>(null);
   const [pendingAmount, setPendingAmount] = useState<number | null>(null);
+  const startTimeRef = useRef(0);
 
   useEffect(() => {
-    if (!mempoolAddressUtxos || mempoolAddressUtxos.length === 0) {
+    if (startTimeRef.current === 0) {
+      startTimeRef.current = Math.floor(Date.now() / 1000);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (
+      !mempoolAddressUtxos ||
+      mempoolAddressUtxos.length === 0 ||
+      startTimeRef.current === 0
+    ) {
       return;
     }
 
@@ -70,7 +81,10 @@ export default function DepositBitcoin() {
       }
 
       const confirmed = mempoolAddressUtxos.find(
-        (utxo) => utxo.status.confirmed
+        (utxo) =>
+          utxo.status.confirmed &&
+          !!utxo.status.block_time &&
+          utxo.status.block_time >= startTimeRef.current
       );
       if (confirmed) {
         setTxId(confirmed.txid);

--- a/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
@@ -6,7 +6,7 @@ import {
   RefreshCwIcon,
 } from "lucide-react";
 import TickSVG from "public/images/illustrations/tick.svg";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
@@ -101,9 +101,20 @@ function ReceiveToOnchain() {
   const [txId, setTxId] = useState("");
   const [confirmedAmount, setConfirmedAmount] = useState<number | null>(null);
   const [pendingAmount, setPendingAmount] = useState<number | null>(null);
+  const startTimeRef = useRef(0);
 
   useEffect(() => {
-    if (!mempoolAddressUtxos || mempoolAddressUtxos.length === 0) {
+    if (startTimeRef.current === 0) {
+      startTimeRef.current = Math.floor(Date.now() / 1000);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (
+      !mempoolAddressUtxos ||
+      mempoolAddressUtxos.length === 0 ||
+      startTimeRef.current === 0
+    ) {
       return;
     }
 
@@ -125,7 +136,10 @@ function ReceiveToOnchain() {
       }
 
       const confirmed = mempoolAddressUtxos.find(
-        (utxo) => utxo.status.confirmed
+        (utxo) =>
+          utxo.status.confirmed &&
+          !!utxo.status.block_time &&
+          utxo.status.block_time >= startTimeRef.current
       );
       if (confirmed) {
         setTxId(confirmed.txid);


### PR DESCRIPTION
Fixes #2087

Adds logic to also check for `confirmed` transactions in case the user never goes to the page after copying address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bitcoin deposit and receive flows to prioritize unconfirmed transactions so pending TXs remain visible and aren't overwritten during the same update cycle.
  * When a transaction becomes confirmed, the UI now reliably updates to show the confirmed amount and clears pending state only for confirmations that occurred after the screen was opened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->