### PR TITLE
feat: add second relay to default config

### DIFF
--- a/config/models.go
+++ b/config/models.go
@@ -16,7 +16,7 @@ const (
 )
 
 type AppConfig struct {
-	Relay                              string `envconfig:"RELAY" default:"wss://relay.getalby.com/v1"`
+	Relay                              string `envconfig:"RELAY" default:"wss://relay.getalby.com,wss://relay2.getalby.com"`
 	LNBackendType                      string `envconfig:"LN_BACKEND_TYPE"`
 	LNDAddress                         string `envconfig:"LND_ADDRESS"`
 	LNDCertFile                        string `envconfig:"LND_CERT_FILE"`


### PR DESCRIPTION
Closes https://github.com/getAlby/hub/issues/1887

This improves reliability for clients (less impact from relay restarts / network reconnections)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default relay configuration to connect to multiple endpoints for improved redundancy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->