### PR TITLE
feat: 404 page

### DIFF
--- a/frontend/src/screens/NotFound.tsx
+++ b/frontend/src/screens/NotFound.tsx
@@ -1,33 +1,20 @@
-import { SearchXIcon } from "lucide-react";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "src/components/ui/card";
+import { AlbyHubIcon } from "src/components/icons/AlbyHubIcon";
 import { LinkButton } from "src/components/ui/custom/link-button";
 
 function NotFound() {
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>
-          <div className="flex flex-row items-center gap-2">
-            <SearchXIcon className="w-10 h-10" />
-            Page Not Found
-          </div>
-        </CardTitle>
-        <CardDescription>
-          The page you are looking for does not exist.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <LinkButton to="/" variant="outline">
-          Return Home
-        </LinkButton>
-      </CardContent>
-    </Card>
+    <div className="flex flex-col items-center justify-center min-h-screen gap-6 text-center px-4">
+      <AlbyHubIcon className="w-16 h-16 opacity-60" />
+      <div>
+        <h1 className="text-3xl font-semibold">Page not found</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          The page you're looking for doesn't exist
+        </p>
+      </div>
+      <LinkButton to="/" variant="outline">
+        Return Home
+      </LinkButton>
+    </div>
   );
 }
 


### PR DESCRIPTION
Minimalistic styles for the 404 page, currently looks a bit broken.

Before
<img width="1843" height="957" alt="image" src="https://github.com/user-attachments/assets/0349278e-9d63-4eaa-a7fa-e1268818fe67" />

After
<img width="1843" height="957" alt="image" src="https://github.com/user-attachments/assets/f5bdec0a-39c5-4880-bd96-ab321de3c5d6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned the 404 page not found screen with a cleaner, centered layout and simplified design. Updated messaging text for consistency. Improved visual presentation for a better user experience when encountering missing pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->