### PR TITLE
feat: add Alby Hub Name to settings about page

### DIFF
--- a/frontend/src/screens/settings/About.tsx
+++ b/frontend/src/screens/settings/About.tsx
@@ -60,6 +60,14 @@ export function About() {
             </p>
           </div>
         )}
+        {info.albyAccountConnected && albyMe?.hub.name && (
+          <div className="grid gap-2">
+            <p className="font-medium text-sm">Alby Hub Name</p>
+            <p className="text-muted-foreground text-sm slashed-zero">
+              {albyMe.hub.name}
+            </p>
+          </div>
+        )}
         {info.albyAccountConnected && (
           <div className="grid gap-2">
             <p className="font-medium text-sm">Alby Account Plan</p>


### PR DESCRIPTION
## Fixes #2121

Adds the Alby Hub Name to the Settings > About page for Alby Cloud users. This allows agents to identify the hub instance they're managing without needing a developer token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display of Alby Hub Name in the settings About screen when an Alby account is connected, showing the associated hub name alongside other account details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->