### PR TITLE
fix: increase the default Alby Account budget from 150k to 250k

### DIFF
--- a/frontend/src/components/connections/AlbyConnectionCard.tsx
+++ b/frontend/src/components/connections/AlbyConnectionCard.tsx
@@ -140,7 +140,6 @@ function AlbyConnectionCard() {
                             25000 /* the minimum should be a bit more than the Alby monthly fee */
                           }
                           budgetOptions={{
-                            "150k": 150_000,
                             "250k": 250_000,
                             "500k": 500_000,
                             "1M": 1_000_000,


### PR DESCRIPTION
Fixes #2134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default maximum amount for Alby connections from 150,000 to 250,000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->