### PR TITLE
fix: register swap listeners before websocket subscribe

### DIFF
--- a/swaps/swaps_service.go
+++ b/swaps/swaps_service.go
@@ -1167,6 +1167,10 @@ func (svc *swapsService) startSwapOutListener(swap *db.Swap) {
 						logger.Logger.WithField("swapId", swap.SwapId).Info("Already initiated swap invoice payment")
 						return
 					}
+					if !errors.Is(err, transactions.NewNotFoundError()) {
+						logger.Logger.WithError(err).WithField("swapId", swap.SwapId).Warn("Failed to lookup transaction")
+						return
+					}
 					metadata := map[string]interface{}{
 						"swap_id": swap.SwapId,
 					}


### PR DESCRIPTION
Fixes #2140 

We might miss boltz updates if we don't register the listeners before we subscribe, also removes the weird `err == transactions.NewNotFoundError()` check (why would we return if there's no tx found 🤔 Funny that it worked till now even with this check there)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust swap invoice payment handling to avoid duplicate attempts and better handle missing/incomplete payment states.
  * Improved per-swap update tracking and cleanup to prevent stale listeners and ensure pending swaps are consistently managed.
  * Increased stability during lifecycle transitions, reducing unexpected failures and improving overall swap reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->