### PR TITLE
Add Nix flake and systemd deployment for Alby Hub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ glalby
 *.db-shm
 *.db-wal
 *.db-journal
-albyhub-data
+albyhub-dataresult

--- a/FUNDING.md
+++ b/FUNDING.md
@@ -1,0 +1,48 @@
+# Funding Alby Hub from Coinbase
+
+## Quick Start
+
+```bash
+./fund-from-coinbase.sh
+```
+
+## Manual Steps
+
+### 1. Get On-Chain Address
+
+Open Alby Hub at http://localhost:8087 and navigate to:
+- **Channels** → **Deposit**
+- Copy your Bitcoin address
+
+### 2. Withdraw from Coinbase
+
+1. Log into [Coinbase](https://www.coinbase.com)
+2. Go to **Assets** → **Bitcoin** → **Send**
+3. Paste your Alby Hub address
+4. Enter amount (minimum 50,000 sats / 0.0005 BTC recommended)
+5. Complete 2FA and confirm withdrawal
+
+### 3. Wait for Confirmation
+
+- Track transaction: https://mempool.space
+- Wait for 1-3 confirmations (~10-30 minutes)
+- Your Alby Hub balance updates automatically
+
+### 4. Open Lightning Channel
+
+Once funds arrive:
+1. Go to **Channels** → **Open Channel**
+2. Choose a well-connected node or use Alby's recommendations
+3. Set channel capacity (leave some for on-chain fees)
+4. Confirm and wait for channel to open (~10 minutes)
+
+## Recommended Nodes
+
+- **Alby**: `031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581@hub.getalby.com:9735`
+- **ACINQ**: `03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f@3.33.236.230:9735`
+
+## Fees
+
+- Coinbase withdrawal: ~$1-5 (varies)
+- Channel open: ~1000-5000 sats (depends on mempool)
+- Keep 10-20% of funds for future on-chain operations

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,39 @@
+# Alby Hub Nix Installation
+
+## Quick Start
+
+```bash
+./deploy.sh
+```
+
+This will:
+- Build Alby Hub with Nix
+- Install as user systemd service
+- Run on port 8087
+- Store data in `~/.local/share/albyhub`
+
+## Access
+
+Open browser to: `http://localhost:8087`
+
+## Manage Service
+
+```bash
+# Check status
+systemctl --user status albyhub
+
+# View logs
+journalctl --user -u albyhub -f
+
+# Stop service
+systemctl --user stop albyhub
+
+# Restart service
+systemctl --user restart albyhub
+```
+
+## Files
+
+- `flake.nix` - Nix flake configuration
+- `albyhub.service` - Systemd service template
+- `deploy.sh` - Build and deploy script

--- a/albyhub.service
+++ b/albyhub.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Alby Hub - Lightning Wallet Service
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/.local/share/albyhub
+ExecStart=STORE_PATH_PLACEHOLDER/bin/albyhub
+Restart=always
+RestartSec=10
+
+Environment="WORK_DIR=%h/.local/share/albyhub"
+Environment="PORT=8087"
+
+[Install]
+WantedBy=default.target

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+
+echo "=== Deploying Alby Hub ==="
+
+# Build with Nix
+nix build --impure
+
+# Get Nix store path
+STORE_PATH=$(readlink -f result)
+echo "Built: $STORE_PATH"
+
+# Create data directory
+mkdir -p ~/.local/share/albyhub
+
+# Generate systemd service
+sed "s|STORE_PATH_PLACEHOLDER|$STORE_PATH|g" albyhub.service > albyhub-generated.service
+
+echo ""
+echo "=== Install ==="
+echo "1. Systemd:"
+mkdir -p ~/.config/systemd/user/
+cp albyhub-generated.service ~/.config/systemd/user/albyhub.service
+systemctl --user daemon-reload
+systemctl --user enable albyhub
+systemctl --user restart albyhub
+echo "   ✅ Service restarted"
+echo ""
+echo "2. Status:"
+systemctl --user status albyhub --no-pager
+echo ""
+echo "3. Access:"
+echo "   http://localhost:8087"
+echo ""
+echo "View logs: journalctl --user -u albyhub -f"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773282481,
+        "narHash": "sha256-b/GV2ysM8mKHhinse2wz+uP37epUrSE+sAKXy/xvBY4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fe416aaedd397cacb33a610b33d60ff2b431b127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "Alby Hub - Your Own Center for Internet Money";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages.default = pkgs.callPackage /mnt/data1/time2/time/2023/07/06/nixpkgs/pkgs/by-name/al/albyhub/package.nix { };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            go
+            nodejs
+            yarn
+            wails
+          ];
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/albyhub";
+        };
+      }
+    );
+}

--- a/fund-from-coinbase.sh
+++ b/fund-from-coinbase.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+
+echo "=== Alby Hub Channel Funding from Coinbase ==="
+echo ""
+echo "Step 1: Get your on-chain Bitcoin address"
+echo "  1. Open http://localhost:8087"
+echo "  2. Navigate to Channels → Deposit"
+echo "  3. Copy your on-chain Bitcoin address"
+echo ""
+read -p "Paste your Bitcoin address here: " BTC_ADDRESS
+
+if [ -z "$BTC_ADDRESS" ]; then
+    echo "Error: No address provided"
+    exit 1
+fi
+
+echo ""
+echo "Step 2: Withdraw from Coinbase"
+echo "  1. Log into Coinbase"
+echo "  2. Go to Assets → Bitcoin → Send"
+echo "  3. Paste address: $BTC_ADDRESS"
+echo "  4. Enter amount (minimum ~50,000 sats recommended)"
+echo "  5. Complete withdrawal"
+echo ""
+echo "Step 3: Wait for confirmation"
+echo "  - Check transaction: https://mempool.space/address/$BTC_ADDRESS"
+echo "  - Wait for 1-3 confirmations (~10-30 minutes)"
+echo "  - Your Alby Hub balance will update automatically"
+echo ""
+echo "Step 4: Open a Lightning channel"
+echo "  1. Go to Channels → Open Channel"
+echo "  2. Choose a node (or use Alby's recommended nodes)"
+echo "  3. Set channel capacity"
+echo "  4. Confirm and wait for channel to open"
+echo ""
+echo "Your address: $BTC_ADDRESS"


### PR DESCRIPTION
- flake.nix: Build configuration using existing nixpkgs package
- albyhub.service: User systemd service template
- deploy.sh: Automated build and deployment script
- INSTALL.md: Installation and usage documentation
- Runs on port 8087 to avoid conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Nix installation guide with quick start, service management, and access details
  * Added funding guide with Coinbase-to-channel instructions

* **Chores**
  * Added Nix flake configuration for build/dev environments
  * Added automated deploy script and systemd service for running the app
  * Added helper script for funding from Coinbase
  * Updated .gitignore to reflect new data output path
<!-- end of auto-generated comment: release notes by coderabbit.ai -->