### PR TITLE
fix: avoid blocking startup on boltz websocket

### DIFF
--- a/swaps/swaps_service.go
+++ b/swaps/swaps_service.go
@@ -105,18 +105,6 @@ func NewSwapsService(ctx context.Context, db *gorm.DB, cfg config.Config, keys k
 	boltzApi := &boltz.Api{URL: cfg.GetEnv().BoltzApi}
 	boltzWs := boltzApi.NewWebsocket()
 
-	for {
-		err := boltzWs.Connect()
-		if err != nil {
-			logger.Logger.WithError(err).Error("Failed to connect to boltz websocket, retrying in 2s...")
-			time.Sleep(2 * time.Second)
-			continue
-		}
-		break
-	}
-
-	logger.Logger.Info("Connected to boltz websocket")
-
 	svc := &swapsService{
 		ctx:                 ctx,
 		cfg:                 cfg,


### PR DESCRIPTION
Fixes #2166 

Stops Alby Hub startup from blocking when Boltz is offline since the retries in `startSwapInListener` and `startSwapOutListener` already do a for loop on `boltzWs.Subscribe` which checks if it is connected and connects if not. That is the only place we need the connection so the `boltzWs.Connect()` step is unnecessary and hence removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved swaps service initialization by removing blocking connection operations. The service now handles connection establishment asynchronously in the background, enabling faster startup times while maintaining all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->