### PR TITLE
feat: add endpoint-driven Alby Blog widget

### DIFF
--- a/alby/alby_service.go
+++ b/alby/alby_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/getAlby/hub/config"
@@ -206,5 +207,65 @@ func (svc *albyService) GetInfo(ctx context.Context) (*AlbyInfo, error) {
 		Healthy:          info.Healthy,
 		AccountAvailable: info.AccountAvailable,
 		Incidents:        incidents,
+	}, nil
+}
+
+func (svc *albyService) GetLatestBlogPost(ctx context.Context) (*BlogPost, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	url := fmt.Sprintf("%s/hub/blog/latest", albyInternalAPIURL)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		logger.Logger.WithError(err).Error("Error creating request to blog endpoint")
+		return nil, err
+	}
+	setDefaultRequestHeaders(req)
+
+	res, err := client.Do(req)
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to fetch blog endpoint")
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to read response body")
+		return nil, errors.New("failed to read response body")
+	}
+
+	if res.StatusCode >= 300 {
+		logger.Logger.WithFields(logrus.Fields{
+			"body":        string(body),
+			"status_code": res.StatusCode,
+		}).Error("Blog endpoint returned non-success code")
+		return nil, fmt.Errorf("blog endpoint returned non-success code: %s", string(body))
+	}
+
+	var post struct {
+		ID          string `json:"id"`
+		Title       string `json:"title"`
+		Lead        string `json:"lead"`
+		URL         string `json:"url"`
+		ImageURL    string `json:"imageUrl"`
+		PublishedAt string `json:"publishedAt"`
+	}
+	err = json.Unmarshal(body, &post)
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to decode blog API response")
+		return nil, err
+	}
+
+	if post.Title == "" || post.URL == "" {
+		return nil, errors.New("no blog post found")
+	}
+
+	return &BlogPost{
+		ID:          post.ID,
+		Title:       post.Title,
+		Description: post.Lead,
+		URL:         post.URL,
+		ImageURL:    strings.ReplaceAll(post.ImageURL, "&amp;", "&"),
 	}, nil
 }

--- a/alby/models.go
+++ b/alby/models.go
@@ -11,6 +11,15 @@ type AlbyService interface {
 	GetInfo(ctx context.Context) (*AlbyInfo, error)
 	GetBitcoinRate(ctx context.Context) (*BitcoinRate, error)
 	GetChannelPeerSuggestions(ctx context.Context) ([]ChannelPeerSuggestion, error)
+	GetLatestBlogPost(ctx context.Context) (*BlogPost, error)
+}
+
+type BlogPost struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+	ImageURL    string `json:"imageUrl,omitempty"`
 }
 
 type AlbyOAuthService interface {

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,2 +1,5 @@
 # set a custom messageboard wallet (should be a sub-wallet with only make invoice and list transactions permissions)
 #VITE_LIGHTNING_MESSAGEBOARD_NWC_URL="nostr+walletconnect://5f8e7c098137ccca853327be44a9b2e956cf79a8e2336e27a4f27b3fb55325b6?relay=wss://relay.getalby.com&relay=wss://relay2.getalby.com&secret=ace5c4b9e08138a2ef91b4ccf1379952c77c651866b29f5872b5165134417894"
+
+# optional blog endpoint used by Home Alby Blog widget
+#VITE_ALBY_BLOG_ENDPOINT=https://getalby.com/api/hub/blog/latest

--- a/frontend/src/components/home/widgets/AlbyBlogWidget.tsx
+++ b/frontend/src/components/home/widgets/AlbyBlogWidget.tsx
@@ -1,0 +1,176 @@
+import { SquareArrowOutUpRightIcon } from "lucide-react";
+import React from "react";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "src/components/ui/card";
+import { ExternalLinkButton } from "src/components/ui/custom/external-link-button";
+import { cn } from "src/lib/utils";
+
+type BlogPost = {
+  id: string;
+  title: string;
+  description: string;
+  url: string;
+  imageUrl?: string;
+  publishedAt?: string;
+};
+
+const ALBY_BLOG_ENDPOINT =
+  import.meta.env.VITE_ALBY_BLOG_ENDPOINT ||
+  "https://getalby.com/api/hub/blog/latest";
+
+const fallbackThemes = [
+  "from-emerald-200 via-cyan-200 to-yellow-200",
+  "from-orange-200 via-amber-100 to-pink-100",
+  "from-slate-200 via-zinc-100 to-lime-100",
+  "from-sky-200 via-indigo-100 to-violet-100",
+];
+
+function toStringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizePost(input: unknown): BlogPost | null {
+  if (!input || typeof input !== "object") {
+    return null;
+  }
+  const item = input as Record<string, unknown>;
+  const id = toStringValue(item.id) || toStringValue(item.slug) || "latest";
+  const title = toStringValue(item.title);
+  const description =
+    toStringValue(item.lead) ||
+    toStringValue(item.description) ||
+    toStringValue(item.excerpt);
+  const url = toStringValue(item.url) || toStringValue(item.link);
+  const imageUrl =
+    toStringValue(item.imageUrl) ||
+    toStringValue(item.image_url) ||
+    toStringValue(item.coverImage) ||
+    toStringValue(item.cover_image);
+  const publishedAt =
+    toStringValue(item.publishedAt) || toStringValue(item.published_at);
+
+  if (!title || !url || !description) {
+    return null;
+  }
+
+  return {
+    id,
+    title,
+    description,
+    url,
+    imageUrl,
+    publishedAt,
+  };
+}
+
+function pickLatestPost(posts: BlogPost[]): BlogPost {
+  const dated = posts.filter((p) => p.publishedAt);
+  if (dated.length > 0) {
+    return [...dated].sort(
+      (a, b) =>
+        new Date(b.publishedAt || "").getTime() -
+        new Date(a.publishedAt || "").getTime()
+    )[0];
+  }
+  return posts[0];
+}
+
+async function fetchBlogPosts(): Promise<BlogPost[]> {
+  const response = await fetch(ALBY_BLOG_ENDPOINT);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch blog posts: ${response.status}`);
+  }
+
+  const payload = (await response.json()) as unknown;
+  const candidates = Array.isArray(payload)
+    ? payload
+    : Array.isArray((payload as { posts?: unknown[] })?.posts)
+      ? (payload as { posts: unknown[] }).posts
+      : [payload];
+
+  return candidates
+    .map(normalizePost)
+    .filter((post): post is BlogPost => !!post);
+}
+
+export function AlbyBlogWidget() {
+  const [post, setPost] = React.useState<BlogPost | null>(null);
+  const [themeClassName, setThemeClassName] = React.useState(fallbackThemes[0]);
+
+  React.useEffect(() => {
+    const loadPost = async () => {
+      try {
+        const posts = await fetchBlogPosts();
+        if (!posts.length) {
+          setPost(null);
+          return;
+        }
+        const latest = pickLatestPost(posts);
+        setPost(latest);
+        const themeIndex = Math.abs(
+          [...latest.id].reduce((sum, ch) => sum + ch.charCodeAt(0), 0)
+        );
+        setThemeClassName(fallbackThemes[themeIndex % fallbackThemes.length]);
+      } catch {
+        setPost(null);
+      }
+    };
+
+    void loadPost();
+  }, []);
+
+  if (!post) {
+    return null;
+  }
+
+  return (
+    <Card className="overflow-hidden rounded-[14px] shadow-none">
+      <CardHeader className="px-6 pb-0">
+        <CardTitle className="text-base font-semibold">Alby Blog</CardTitle>
+      </CardHeader>
+      <CardContent className="px-6 pt-0">
+        <div className="relative h-[247px] overflow-hidden rounded-xl border">
+          {post.imageUrl ? (
+            <img
+              src={post.imageUrl}
+              alt={post.title}
+              className="absolute inset-0 size-full object-cover"
+            />
+          ) : (
+            <div
+              className={cn(
+                "absolute inset-0 bg-gradient-to-br",
+                themeClassName
+              )}
+            >
+              <div className="absolute -left-10 top-6 size-36 rounded-full bg-white/35 blur-3xl" />
+              <div className="absolute -right-8 bottom-2 size-40 rounded-full bg-white/20 blur-3xl" />
+              <div className="absolute inset-0 bg-white/10" />
+            </div>
+          )}
+        </div>
+      </CardContent>
+      <CardFooter className="flex flex-col items-start gap-4 px-6 pb-6 pt-0">
+        <div className="space-y-1">
+          <p className="text-xl font-semibold leading-7 text-foreground">
+            {post.title}
+          </p>
+          <p className="text-base leading-6 text-muted-foreground">
+            {post.description}
+          </p>
+        </div>
+        <div className="flex w-full justify-end">
+          <ExternalLinkButton to={post.url} variant="outline">
+            Read on Alby Blog
+            <SquareArrowOutUpRightIcon />
+          </ExternalLinkButton>
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/frontend/src/components/home/widgets/AlbyBlogWidget.tsx
+++ b/frontend/src/components/home/widgets/AlbyBlogWidget.tsx
@@ -1,27 +1,15 @@
 import { SquareArrowOutUpRightIcon } from "lucide-react";
-import React from "react";
 import {
   Card,
   CardContent,
+  CardDescription,
   CardFooter,
   CardHeader,
   CardTitle,
 } from "src/components/ui/card";
 import { ExternalLinkButton } from "src/components/ui/custom/external-link-button";
+import { useAlbyBlog } from "src/hooks/useAlbyBlog";
 import { cn } from "src/lib/utils";
-
-type BlogPost = {
-  id: string;
-  title: string;
-  description: string;
-  url: string;
-  imageUrl?: string;
-  publishedAt?: string;
-};
-
-const ALBY_BLOG_ENDPOINT =
-  import.meta.env.VITE_ALBY_BLOG_ENDPOINT ||
-  "https://getalby.com/api/hub/blog/latest";
 
 const fallbackThemes = [
   "from-emerald-200 via-cyan-200 to-yellow-200",
@@ -30,111 +18,25 @@ const fallbackThemes = [
   "from-sky-200 via-indigo-100 to-violet-100",
 ];
 
-function toStringValue(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function normalizePost(input: unknown): BlogPost | null {
-  if (!input || typeof input !== "object") {
-    return null;
-  }
-  const item = input as Record<string, unknown>;
-  const id = toStringValue(item.id) || toStringValue(item.slug) || "latest";
-  const title = toStringValue(item.title);
-  const description =
-    toStringValue(item.lead) ||
-    toStringValue(item.description) ||
-    toStringValue(item.excerpt);
-  const url = toStringValue(item.url) || toStringValue(item.link);
-  const imageUrlValue =
-    toStringValue(item.imageUrl) ||
-    toStringValue(item.image_url) ||
-    toStringValue(item.coverImage) ||
-    toStringValue(item.cover_image);
-  const imageUrl = imageUrlValue?.replace(/&amp;/g, "&");
-  const publishedAt =
-    toStringValue(item.publishedAt) || toStringValue(item.published_at);
-
-  if (!title || !url || !description) {
-    return null;
-  }
-
-  return {
-    id,
-    title,
-    description,
-    url,
-    imageUrl,
-    publishedAt,
-  };
-}
-
-function pickLatestPost(posts: BlogPost[]): BlogPost {
-  const dated = posts.filter((p) => p.publishedAt);
-  if (dated.length > 0) {
-    return [...dated].sort(
-      (a, b) =>
-        new Date(b.publishedAt || "").getTime() -
-        new Date(a.publishedAt || "").getTime()
-    )[0];
-  }
-  return posts[0];
-}
-
-async function fetchBlogPosts(): Promise<BlogPost[]> {
-  const response = await fetch(ALBY_BLOG_ENDPOINT);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch blog posts: ${response.status}`);
-  }
-
-  const payload = (await response.json()) as unknown;
-  const candidates = Array.isArray(payload)
-    ? payload
-    : Array.isArray((payload as { posts?: unknown[] })?.posts)
-      ? (payload as { posts: unknown[] }).posts
-      : [payload];
-
-  return candidates
-    .map(normalizePost)
-    .filter((post): post is BlogPost => !!post);
+function hashString(str: string): number {
+  return Math.abs([...str].reduce((sum, ch) => sum + ch.charCodeAt(0), 0));
 }
 
 export function AlbyBlogWidget() {
-  const [post, setPost] = React.useState<BlogPost | null>(null);
-  const [themeClassName, setThemeClassName] = React.useState(fallbackThemes[0]);
-
-  React.useEffect(() => {
-    const loadPost = async () => {
-      try {
-        const posts = await fetchBlogPosts();
-        if (!posts.length) {
-          setPost(null);
-          return;
-        }
-        const latest = pickLatestPost(posts);
-        setPost(latest);
-        const themeIndex = Math.abs(
-          [...latest.id].reduce((sum, ch) => sum + ch.charCodeAt(0), 0)
-        );
-        setThemeClassName(fallbackThemes[themeIndex % fallbackThemes.length]);
-      } catch {
-        setPost(null);
-      }
-    };
-
-    void loadPost();
-  }, []);
+  const { data: post } = useAlbyBlog();
 
   if (!post) {
     return null;
   }
 
+  const theme = fallbackThemes[hashString(post.id) % fallbackThemes.length];
+
   return (
-    <Card className="overflow-hidden rounded-[14px] shadow-none">
-      <CardHeader className="px-6 pb-0">
-        <CardTitle className="text-base font-semibold">Alby Blog</CardTitle>
+    <Card>
+      <CardHeader>
+        <CardTitle>Alby Blog</CardTitle>
       </CardHeader>
-      <CardContent className="px-6 pt-0">
+      <CardContent>
         <div className="relative h-[247px] overflow-hidden rounded-xl border">
           {post.imageUrl ? (
             <img
@@ -143,12 +45,7 @@ export function AlbyBlogWidget() {
               className="absolute inset-0 size-full object-cover"
             />
           ) : (
-            <div
-              className={cn(
-                "absolute inset-0 bg-gradient-to-br",
-                themeClassName
-              )}
-            >
+            <div className={cn("absolute inset-0 bg-gradient-to-br", theme)}>
               <div className="absolute -left-10 top-6 size-36 rounded-full bg-white/35 blur-3xl" />
               <div className="absolute -right-8 bottom-2 size-40 rounded-full bg-white/20 blur-3xl" />
               <div className="absolute inset-0 bg-white/10" />
@@ -156,14 +53,12 @@ export function AlbyBlogWidget() {
           )}
         </div>
       </CardContent>
-      <CardFooter className="flex flex-col items-start gap-4 px-6 pb-6 pt-0">
+      <CardFooter className="flex flex-col items-start gap-4">
         <div className="space-y-1">
-          <p className="text-xl font-semibold leading-7 text-foreground">
-            {post.title}
-          </p>
-          <p className="text-base leading-6 text-muted-foreground">
+          <CardTitle className="text-xl leading-7">{post.title}</CardTitle>
+          <CardDescription className="text-base leading-6">
             {post.description}
-          </p>
+          </CardDescription>
         </div>
         <div className="flex w-full justify-end">
           <ExternalLinkButton to={post.url} variant="outline">

--- a/frontend/src/components/home/widgets/AlbyBlogWidget.tsx
+++ b/frontend/src/components/home/widgets/AlbyBlogWidget.tsx
@@ -46,11 +46,12 @@ function normalizePost(input: unknown): BlogPost | null {
     toStringValue(item.description) ||
     toStringValue(item.excerpt);
   const url = toStringValue(item.url) || toStringValue(item.link);
-  const imageUrl =
+  const imageUrlValue =
     toStringValue(item.imageUrl) ||
     toStringValue(item.image_url) ||
     toStringValue(item.coverImage) ||
     toStringValue(item.cover_image);
+  const imageUrl = imageUrlValue?.replace(/&amp;/g, "&");
   const publishedAt =
     toStringValue(item.publishedAt) || toStringValue(item.published_at);
 

--- a/frontend/src/hooks/useAlbyBlog.ts
+++ b/frontend/src/hooks/useAlbyBlog.ts
@@ -1,0 +1,17 @@
+import useSWR from "swr";
+
+import { swrFetcher } from "src/utils/swr";
+
+type BlogPost = {
+  id: string;
+  title: string;
+  description: string;
+  url: string;
+  imageUrl?: string;
+};
+
+export function useAlbyBlog() {
+  return useSWR<BlogPost>("/api/alby/blog/latest", swrFetcher, {
+    dedupingInterval: 5 * 60 * 1000, // 5 minutes
+  });
+}

--- a/frontend/src/screens/Home.tsx
+++ b/frontend/src/screens/Home.tsx
@@ -163,7 +163,6 @@ function Home() {
         {/* RIGHT */}
         <div className="grid gap-3">
           <LatestUsedAppsWidget />
-          <AlbyBlogWidget />
           <LightningMessageboardWidget />
           <AppOfTheDayWidget />
 
@@ -194,6 +193,8 @@ function Home() {
               </CardContent>
             </Card>
           </Link>
+
+          <AlbyBlogWidget />
 
           <Card>
             <CardHeader>

--- a/frontend/src/screens/Home.tsx
+++ b/frontend/src/screens/Home.tsx
@@ -22,6 +22,7 @@ import React from "react";
 import albyGo from "src/assets/suggested-apps/alby-go.png";
 import zapplanner from "src/assets/suggested-apps/zapplanner.png";
 import { AppOfTheDayWidget } from "src/components/home/widgets/AppOfTheDayWidget";
+import { AlbyBlogWidget } from "src/components/home/widgets/AlbyBlogWidget";
 import { BlockHeightWidget } from "src/components/home/widgets/BlockHeightWidget";
 import { ForwardsWidget } from "src/components/home/widgets/ForwardsWidget";
 import { LatestUsedAppsWidget } from "src/components/home/widgets/LatestUsedAppsWidget";
@@ -162,6 +163,7 @@ function Home() {
         {/* RIGHT */}
         <div className="grid gap-3">
           <LatestUsedAppsWidget />
+          <AlbyBlogWidget />
           <LightningMessageboardWidget />
           <AppOfTheDayWidget />
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -98,7 +98,7 @@ const insertDevCSPPlugin: Plugin = {
         "<head>",
         `<head>
         <!-- DEV-ONLY CSP - when making changes here, also update the CSP header in http_service.go (without the nonce!) -->
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self' ${DEVELOPMENT_NONCE}; img-src 'self' https://uploads.getalby-assets.com https://getalby.com; connect-src 'self' https://api.getalby.com https://getalby.com https://zapplanner.albylabs.com wss://relay.getalby.com wss://relay2.getalby.com; frame-src https://embed.bitrefill.com" />`
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self' ${DEVELOPMENT_NONCE}; img-src 'self' https://uploads.getalby-assets.com https://getalby.com https://framerusercontent.com; connect-src 'self' https://api.getalby.com https://getalby.com https://zapplanner.albylabs.com wss://relay.getalby.com wss://relay2.getalby.com; frame-src https://embed.bitrefill.com" />`
       );
     },
   },

--- a/http/alby_http_service.go
+++ b/http/alby_http_service.go
@@ -32,6 +32,7 @@ func (albyHttpSvc *AlbyHttpService) RegisterSharedRoutes(readOnlyApiGroup *echo.
 	e.GET("/api/alby/callback", albyHttpSvc.albyCallbackHandler)
 	e.GET("/api/alby/info", albyHttpSvc.albyInfoHandler)
 	e.GET("/api/alby/rates", albyHttpSvc.albyBitcoinRateHandler)
+	e.GET("/api/alby/blog/latest", albyHttpSvc.albyBlogLatestHandler)
 	readOnlyApiGroup.GET("/alby/me", albyHttpSvc.albyMeHandler)
 	fullAccessApiGroup.POST("/alby/link-account", albyHttpSvc.albyLinkAccountHandler)
 	fullAccessApiGroup.POST("/alby/auto-channel", albyHttpSvc.autoChannelHandler)
@@ -94,6 +95,17 @@ func (albyHttpSvc *AlbyHttpService) albyBitcoinRateHandler(c echo.Context) error
 		})
 	}
 	return c.JSON(http.StatusOK, rate)
+}
+
+func (albyHttpSvc *AlbyHttpService) albyBlogLatestHandler(c echo.Context) error {
+	post, err := albyHttpSvc.albySvc.GetLatestBlogPost(c.Request().Context())
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to get latest blog post")
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Message: fmt.Sprintf("Failed to get latest blog post: %s", err.Error()),
+		})
+	}
+	return c.JSON(http.StatusOK, post)
 }
 
 func (albyHttpSvc *AlbyHttpService) albyCallbackHandler(c echo.Context) error {

--- a/http/http_service.go
+++ b/http/http_service.go
@@ -66,7 +66,7 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	e.Use(middleware.SecureWithConfig(middleware.SecureConfig{
 		ContentTypeNosniff:    "nosniff",
 		XFrameOptions:         "DENY",
-		ContentSecurityPolicy: "default-src 'self'; img-src 'self' https://uploads.getalby-assets.com https://getalby.com; connect-src 'self' https://api.getalby.com https://getalby.com https://zapplanner.albylabs.com wss://relay.getalby.com wss://relay2.getalby.com; frame-src https://embed.bitrefill.com",
+		ContentSecurityPolicy: "default-src 'self'; img-src 'self' https://uploads.getalby-assets.com https://getalby.com https://framerusercontent.com; connect-src 'self' https://api.getalby.com https://getalby.com https://zapplanner.albylabs.com wss://relay.getalby.com wss://relay2.getalby.com; frame-src https://embed.bitrefill.com",
 		ReferrerPolicy:        "no-referrer",
 	}))
 	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{

--- a/tests/mocks/AlbyService.go
+++ b/tests/mocks/AlbyService.go
@@ -162,6 +162,67 @@ func (_c *MockAlbyService_GetChannelPeerSuggestions_Call) RunAndReturn(run func(
 	return _c
 }
 
+func (_mock *MockAlbyService) GetLatestBlogPost(ctx context.Context) (*alby.BlogPost, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLatestBlogPost")
+	}
+
+	var r0 *alby.BlogPost
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (*alby.BlogPost, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) *alby.BlogPost); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*alby.BlogPost)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockAlbyService_GetLatestBlogPost_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLatestBlogPost'
+type MockAlbyService_GetLatestBlogPost_Call struct {
+	*mock.Call
+}
+
+// GetLatestBlogPost is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockAlbyService_Expecter) GetLatestBlogPost(ctx interface{}) *MockAlbyService_GetLatestBlogPost_Call {
+	return &MockAlbyService_GetLatestBlogPost_Call{Call: _e.mock.On("GetLatestBlogPost", ctx)}
+}
+
+func (_c *MockAlbyService_GetLatestBlogPost_Call) Run(run func(ctx context.Context)) *MockAlbyService_GetLatestBlogPost_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockAlbyService_GetLatestBlogPost_Call) Return(blogPost *alby.BlogPost, err error) *MockAlbyService_GetLatestBlogPost_Call {
+	_c.Call.Return(blogPost, err)
+	return _c
+}
+
+func (_c *MockAlbyService_GetLatestBlogPost_Call) RunAndReturn(run func(ctx context.Context) (*alby.BlogPost, error)) *MockAlbyService_GetLatestBlogPost_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetInfo provides a mock function for the type MockAlbyService
 func (_mock *MockAlbyService) GetInfo(ctx context.Context) (*alby.AlbyInfo, error) {
 	ret := _mock.Called(ctx)

--- a/wails/wails_handlers.go
+++ b/wails/wails_handlers.go
@@ -409,6 +409,17 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
 		return WailsRequestRouterResponse{Body: rate, Error: ""}
+	case "/api/alby/blog/latest":
+		post, err := app.svc.GetAlbySvc().GetLatestBlogPost(ctx)
+		if err != nil {
+			logger.Logger.WithFields(logrus.Fields{
+				"route":  route,
+				"method": method,
+				"body":   body,
+			}).WithError(err).Error("Failed to get latest blog post")
+			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
+		}
+		return WailsRequestRouterResponse{Body: post, Error: ""}
 	case "/api/apps":
 		switch method {
 		case "POST":


### PR DESCRIPTION
## Summary
- add a new Home `AlbyBlogWidget` driven by a future getalby.com blog endpoint
- parse a flexible endpoint payload (`array`, `{ posts: [] }`, or single object) and render the latest valid post
- place the blog card above `Stats for nerds` in the right column
- document optional env override in `frontend/.env.local.example`

## Test plan
- [x] Run `cd frontend && yarn tsc:compile`
- [x] Verify Home layout placement (blog card above stats widget)
- [x] Verify widget hides cleanly when endpoint is unavailable or payload is invalid

## getalby.com endpoint requirements
Endpoint: `GET https://getalby.com/api/hub/blog/latest`

The widget accepts any of:
- `BlogPost[]`
- `{ posts: BlogPost[] }`
- `BlogPost`

Required per post:
- `id` or `slug`
- `title`
- one of `lead` / `description` / `excerpt`
- `url` or `link`

Optional per post:
- `imageUrl` (or `image_url` / `coverImage` / `cover_image`)
- `publishedAt` (or `published_at`) for latest-post sorting

CORS: allow Hub frontend origins (dev and production) for `GET`.
No auth or secrets in the URL; response should be public-safe metadata only.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Alby Blog widget to the Home page that surfaces the latest blog post with image/placeholder, title, description, and an external "read" link.

* **Chores**
  * Updated development content-security policy for image sources.
  * Added an optional environment example entry for the Alby blog endpoint and fixed trailing-newline formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->