### PR TITLE
chore: remove Home Alby Go and extension cards

### DIFF
--- a/frontend/src/screens/Home.tsx
+++ b/frontend/src/screens/Home.tsx
@@ -19,7 +19,6 @@ import { useInfo } from "src/hooks/useInfo";
 import OnboardingChecklist from "src/screens/wallet/OnboardingChecklist";
 
 import React from "react";
-import albyGo from "src/assets/suggested-apps/alby-go.png";
 import zapplanner from "src/assets/suggested-apps/zapplanner.png";
 import { AppOfTheDayWidget } from "src/components/home/widgets/AppOfTheDayWidget";
 import { BlockHeightWidget } from "src/components/home/widgets/BlockHeightWidget";
@@ -52,8 +51,6 @@ function Home() {
   const { data: balances } = useBalances();
   const { data: albyMe } = useAlbyMe();
   const [isNerd, setNerd] = React.useState(false);
-  /* eslint-disable  @typescript-eslint/no-explicit-any */
-  const extensionInstalled = (window as any).alby !== undefined;
 
   if (!info || !balances) {
     return <Loading />;
@@ -95,62 +92,6 @@ function Home() {
                 <CardContent className="text-right">
                   <Button variant="outline">
                     Open Alby Account
-                    <ExternalLinkIcon className="size-4 ml-2" />
-                  </Button>
-                </CardContent>
-              </Card>
-            </ExternalLink>
-          )}
-
-          <Link to="/appstore/alby-go">
-            <Card>
-              <CardHeader>
-                <div className="flex flex-row items-center">
-                  <div className="shrink-0">
-                    <img src={albyGo} className="w-12 h-12 rounded-xl border" />
-                  </div>
-                  <div>
-                    <CardTitle>
-                      <div className="flex-1 leading-5 font-semibold text-xl whitespace-nowrap text-ellipsis overflow-hidden ml-4">
-                        Alby Go
-                      </div>
-                    </CardTitle>
-                    <CardDescription className="ml-4">
-                      The easiest Bitcoin mobile app that works great with Alby
-                      Hub.
-                    </CardDescription>
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent className="text-right">
-                <Button variant="outline">Open</Button>
-              </CardContent>
-            </Card>
-          </Link>
-          {!extensionInstalled && (
-            <ExternalLink to="https://getalby.com/products/browser-extension">
-              <Card>
-                <CardHeader>
-                  <div className="flex flex-row items-center">
-                    <div className="shrink-0">
-                      <AlbyHead className="w-12 h-12 rounded-xl p-1 border bg-[#FFDF6F]" />
-                    </div>
-                    <div>
-                      <CardTitle>
-                        <div className="flex-1 leading-5 font-semibold text-xl whitespace-nowrap text-ellipsis overflow-hidden ml-4">
-                          Alby Browser Extension
-                        </div>
-                      </CardTitle>
-                      <CardDescription className="ml-4">
-                        Seamless bitcoin payments in your favorite internet
-                        browser.
-                      </CardDescription>
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent className="text-right">
-                  <Button variant="outline">
-                    Install Alby Extension
                     <ExternalLinkIcon className="size-4 ml-2" />
                   </Button>
                 </CardContent>


### PR DESCRIPTION
## Summary
- remove `Alby Go` promo card from the Home left column
- remove `Alby Browser Extension` promo card from the Home left column
- keep all other Home cards and widgets unchanged

## Merge condition
- merge only after the Stories PR is merged **and** Stories include both:
  - Alby Go story
  - Alby Extension story

## Test plan
- [x] `cd frontend && yarn tsc:compile`
- [x] confirm Home renders without the two removed cards

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the "Alby Go" card from the home screen.
  * Removed browser extension detection and related UI prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->