### PR TITLE
chore: remove Home What's New card

### DIFF
--- a/frontend/src/screens/Home.tsx
+++ b/frontend/src/screens/Home.tsx
@@ -29,7 +29,6 @@ import { LightningMessageboardWidget } from "src/components/home/widgets/Lightni
 import { NodeStatusWidget } from "src/components/home/widgets/NodeStatusWidget";
 import { OnchainFeesWidget } from "src/components/home/widgets/OnchainFeesWidget";
 import { SupportAlbyWidget } from "src/components/home/widgets/SupportAlbyWidget";
-import { WhatsNewWidget } from "src/components/home/widgets/WhatsNewWidget";
 import { SearchInput } from "src/components/ui/search-input";
 
 function getGreeting(name: string | undefined) {
@@ -69,7 +68,6 @@ function Home() {
         {/* LEFT */}
         <div className="grid gap-3">
           <OnboardingChecklist />
-          <WhatsNewWidget />
           <SupportAlbyWidget />
           {info.albyAccountConnected && (
             <ExternalLink to="https://www.getalby.com/dashboard">


### PR DESCRIPTION
## Summary
- remove the standalone `What's New in Alby Hub` card from the Home left column
- keep all other Home cards and widgets unchanged

## Merge condition
- merge only after the Stories PR is merged **and** includes an update story

## Test plan
- [x] `cd frontend && yarn tsc:compile`
- [x] confirm Home renders without the What’s New card

Made with [Cursor](https://cursor.com)