### PR TITLE
fix: LND payments made externally from the hub are not visible

### DIFF
--- a/transactions/notifications_test.go
+++ b/transactions/notifications_test.go
@@ -201,8 +201,41 @@ func TestNotifications_SentUnknownPayment(t *testing.T) {
 
 	transactionType := constants.TRANSACTION_TYPE_OUTGOING
 	outgoingTransaction, err := transactionsService.LookupTransaction(ctx, tests.MockLNClientTransaction.PaymentHash, &transactionType, svc.LNClient, nil)
-	assert.Nil(t, outgoingTransaction)
-	assert.ErrorIs(t, err, NewNotFoundError())
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(tests.MockLNClientTransaction.Amount), outgoingTransaction.AmountMsat)
+	assert.Equal(t, constants.TRANSACTION_STATE_SETTLED, outgoingTransaction.State)
+	assert.Equal(t, tests.MockLNClientTransaction.Preimage, *outgoingTransaction.Preimage)
+	assert.Zero(t, outgoingTransaction.FeeReserveMsat)
+	assert.Nil(t, outgoingTransaction.AppId)
+
+	transactions = []db.Transaction{}
+	result = svc.DB.Find(&transactions)
+	assert.Equal(t, int64(1), result.RowsAffected)
+}
+
+func TestNotifications_SentUnknownPaymentIdempotent(t *testing.T) {
+	ctx := context.TODO()
+
+	svc, err := tests.CreateTestService(t)
+	require.NoError(t, err)
+	defer svc.Remove()
+
+	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
+
+	for range 2 {
+		transactionsService.ConsumeEvent(ctx, &events.Event{
+			Event:      "nwc_lnclient_payment_sent",
+			Properties: tests.MockLNClientTransaction,
+		}, map[string]interface{}{})
+	}
+
+	transactions := []db.Transaction{}
+	result := svc.DB.Find(&transactions, &db.Transaction{
+		Type:        constants.TRANSACTION_TYPE_OUTGOING,
+		PaymentHash: tests.MockLNClientTransaction.PaymentHash,
+	})
+	assert.Equal(t, int64(1), result.RowsAffected)
+	assert.Equal(t, constants.TRANSACTION_STATE_SETTLED, transactions[0].State)
 }
 
 func TestNotifications_FailedKnownPendingPayment(t *testing.T) {

--- a/transactions/transactions_service.go
+++ b/transactions/transactions_service.go
@@ -854,10 +854,40 @@ func (svc *transactionsService) ConsumeEvent(ctx context.Context, event *events.
 				}
 
 				if result.RowsAffected == 0 {
-					// Note: payments made from outside cannot be associated with an app
-					// for now this is disabled as it only applies to LND, and we do not import LND transactions either.
-					logger.Logger.WithField("payment_hash", lnClientTransaction.PaymentHash).Error("failed to mark payment as sent: payment not found")
-					return NewNotFoundError()
+					result := tx.Limit(1).Find(&dbTransaction, &db.Transaction{
+						Type:        constants.TRANSACTION_TYPE_OUTGOING,
+						PaymentHash: lnClientTransaction.PaymentHash,
+					})
+
+					if result.Error != nil {
+						return result.Error
+					}
+
+					if result.RowsAffected == 0 {
+						dbTransaction = db.Transaction{
+							Type:            constants.TRANSACTION_TYPE_OUTGOING,
+							State:           constants.TRANSACTION_STATE_PENDING,
+							AmountMsat:      uint64(lnClientTransaction.Amount),
+							FeeReserveMsat:  0,
+							PaymentRequest:  lnClientTransaction.Invoice,
+							PaymentHash:     lnClientTransaction.PaymentHash,
+							Description:     lnClientTransaction.Description,
+							DescriptionHash: lnClientTransaction.DescriptionHash,
+						}
+
+						if lnClientTransaction.ExpiresAt != nil {
+							expiresAtValue := time.Unix(*lnClientTransaction.ExpiresAt, 0)
+							dbTransaction.ExpiresAt = &expiresAtValue
+						}
+
+						err := tx.Create(&dbTransaction).Error
+						if err != nil {
+							logger.Logger.WithFields(logrus.Fields{
+								"payment_hash": lnClientTransaction.PaymentHash,
+							}).WithError(err).Error("Failed to create outgoing transaction")
+							return err
+						}
+					}
 				}
 			}
 


### PR DESCRIPTION
fixes #2044 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unknown payment sent notifications. The system now correctly records outgoing transactions for payment events without prior records, instead of returning errors.
  * Enhanced idempotency in payment event processing to ensure duplicate payment notifications don't create multiple transaction records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->