### PR TITLE
feat: increase default app budget to 100k sats / month

### DIFF
--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -20,7 +20,7 @@ export const SUPPORT_ALBY_LIGHTNING_ADDRESS = "hub@getalby.com";
 export const SUBWALLET_APPSTORE_APP_ID = "uncle-jim";
 export const ALBY_ACCOUNT_APP_NAME = "getalby.com";
 
-export const DEFAULT_APP_BUDGET_SATS = 10_000;
+export const DEFAULT_APP_BUDGET_SATS = 100_000;
 export const DEFAULT_APP_BUDGET_RENEWAL = "monthly";
 
 export const BITCOIN_DISPLAY_FORMAT_BIP177 = "bip177";


### PR DESCRIPTION
## Summary

- Increases the default app connection budget from 10,000 to 100,000 sats (monthly)

At current prices, 10k sats ≈ $7 — barely enough for a single real-world transaction. A gift card, an API call for video generation, or even a Lightning payment to a friend can easily exceed that. For any economically relevant use case the old default was effectively unusable without manual adjustment.

100k sats (~$70) is a more practical monthly starting point that actually lets users do something meaningful out of the box, while still being conservative enough as a default budget.

## Test plan
- [ ] Create a new app connection and verify the default budget shows 100,000 sats

🤖 Generated with [Claude Code](https://claude.com/claude-code)