### PR TITLE
feat(frontend): add on-chain transaction details dialog

### DIFF
--- a/frontend/src/components/TransactionsListMenu.tsx
+++ b/frontend/src/components/TransactionsListMenu.tsx
@@ -1,5 +1,7 @@
 import type { VariantProps } from "class-variance-authority";
 import { DownloadIcon, EllipsisVerticalIcon } from "lucide-react";
+import { Link } from "react-router-dom";
+import ExternalLink from "src/components/ExternalLink";
 import { toast } from "sonner";
 import { Button } from "src/components/ui/button";
 import { buttonVariants } from "src/components/ui/buttonVariants";
@@ -93,22 +95,54 @@ const handleExportTransactions = async (appId?: number) => {
 type TransactionsListMenuProps = {
   appId?: number;
   buttonVariant?: VariantProps<typeof buttonVariants>["variant"];
+  buttonClassName?: string;
+  menuItems?: {
+    id: string;
+    label: string;
+    icon: React.ReactNode;
+    to: string;
+    external?: boolean;
+  }[];
 };
 
 export const TransactionsListMenu = ({
   appId,
   buttonVariant = "secondary",
+  buttonClassName,
+  menuItems = [],
 }: TransactionsListMenuProps) => {
   const { data: albyMe } = useAlbyMe();
 
   return (
     <DropdownMenu>
-      <Button asChild size="icon" variant={buttonVariant}>
+      <Button
+        asChild
+        size="icon"
+        variant={buttonVariant}
+        className={buttonClassName}
+      >
         <DropdownMenuTrigger>
           <EllipsisVerticalIcon className="h-4 w-4" />
         </DropdownMenuTrigger>
       </Button>
       <DropdownMenuContent align="end">
+        {menuItems.map((item) =>
+          item.external ? (
+            <DropdownMenuItem key={item.id} asChild>
+              <ExternalLink to={item.to} className="w-full cursor-pointer">
+                {item.icon}
+                {item.label}
+              </ExternalLink>
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem key={item.id} asChild>
+              <Link to={item.to} className="w-full cursor-pointer">
+                {item.icon}
+                {item.label}
+              </Link>
+            </DropdownMenuItem>
+          )
+        )}
         {!albyMe?.subscription.plan_code ? (
           <UpgradeDialog>
             <div className="cursor-pointer">

--- a/frontend/src/components/TransactionsListMenu.tsx
+++ b/frontend/src/components/TransactionsListMenu.tsx
@@ -1,6 +1,8 @@
-import { DownloadIcon, MoreHorizontalIcon } from "lucide-react";
+import type { VariantProps } from "class-variance-authority";
+import { DownloadIcon, EllipsisVerticalIcon } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "src/components/ui/button";
+import { buttonVariants } from "src/components/ui/buttonVariants";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -88,14 +90,22 @@ const handleExportTransactions = async (appId?: number) => {
   }
 };
 
-export const TransactionsListMenu = ({ appId }: { appId?: number }) => {
+type TransactionsListMenuProps = {
+  appId?: number;
+  buttonVariant?: VariantProps<typeof buttonVariants>["variant"];
+};
+
+export const TransactionsListMenu = ({
+  appId,
+  buttonVariant = "secondary",
+}: TransactionsListMenuProps) => {
   const { data: albyMe } = useAlbyMe();
 
   return (
     <DropdownMenu>
-      <Button asChild size="icon" variant="secondary">
+      <Button asChild size="icon" variant={buttonVariant}>
         <DropdownMenuTrigger>
-          <MoreHorizontalIcon className="h-4 w-4" />
+          <EllipsisVerticalIcon className="h-4 w-4" />
         </DropdownMenuTrigger>
       </Button>
       <DropdownMenuContent align="end">

--- a/frontend/src/components/channels/OnchainTransactionsTable.tsx
+++ b/frontend/src/components/channels/OnchainTransactionsTable.tsx
@@ -17,6 +17,7 @@ import {
   CardTitle,
 } from "src/components/ui/card";
 import { Button } from "src/components/ui/button";
+import { ExternalLinkButton } from "src/components/ui/custom/external-link-button";
 import {
   Dialog,
   DialogContent,
@@ -31,7 +32,6 @@ import { copyToClipboard } from "src/lib/clipboard";
 import { useOnchainTransactions } from "src/hooks/useOnchainTransactions";
 import { cn } from "src/lib/utils";
 import { OnchainTransaction } from "src/types";
-import { openLink } from "src/utils/openLink";
 
 dayjs.extend(relativeTime);
 
@@ -220,17 +220,12 @@ function OnchainTransactionRow({
             <CopyIcon className="size-4" />
             Copy Transaction ID
           </Button>
-          <Button
-            type="button"
-            onClick={() => {
-              if (mempoolUrl) {
-                openLink(`${mempoolUrl}/tx/${tx.txId}`);
-              }
-            }}
-          >
-            <ExternalLinkIcon className="size-4" />
-            View on Mempool
-          </Button>
+          {mempoolUrl && (
+            <ExternalLinkButton to={`${mempoolUrl}/tx/${tx.txId}`}>
+              <ExternalLinkIcon className="size-4" />
+              View on Mempool
+            </ExternalLinkButton>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/channels/OnchainTransactionsTable.tsx
+++ b/frontend/src/components/channels/OnchainTransactionsTable.tsx
@@ -1,6 +1,12 @@
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
-import { ArrowDownIcon, ArrowUpIcon, LinkIcon } from "lucide-react";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  CopyIcon,
+  ExternalLinkIcon,
+  LinkIcon,
+} from "lucide-react";
 import EmptyState from "src/components/EmptyState";
 import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
@@ -10,7 +16,18 @@ import {
   CardHeader,
   CardTitle,
 } from "src/components/ui/card";
+import { Button } from "src/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "src/components/ui/dialog";
 import { useInfo } from "src/hooks/useInfo";
+import { copyToClipboard } from "src/lib/clipboard";
 import { useOnchainTransactions } from "src/hooks/useOnchainTransactions";
 import { cn } from "src/lib/utils";
 import { OnchainTransaction } from "src/types";
@@ -37,6 +54,10 @@ function typeStateLabel(tx: OnchainTransaction) {
   return tx.state === "confirmed" ? "Received" : "Receiving";
 }
 
+function transactionStatusLabel(tx: OnchainTransaction) {
+  return tx.state === "confirmed" ? "Confirmed" : "Unconfirmed";
+}
+
 function OnchainTransactionRow({
   tx,
   mempoolUrl,
@@ -47,6 +68,8 @@ function OnchainTransactionRow({
   const Icon = tx.type === "outgoing" ? ArrowUpIcon : ArrowDownIcon;
   const isUnconfirmed = tx.state === "unconfirmed";
   const typeStateText = typeStateLabel(tx);
+  const statusText = transactionStatusLabel(tx);
+  const createdAt = dayjs(tx.createdAt * 1000).local();
 
   const icon = (
     <div className="flex items-center">
@@ -82,61 +105,135 @@ function OnchainTransactionRow({
       : tx.txId;
 
   return (
-    <button
-      type="button"
-      className="transaction sensitive slashed-zero mb-4 w-full cursor-pointer rounded-md p-3 text-left hover:bg-muted/50"
-      onClick={() => {
-        if (mempoolUrl) {
-          openLink(`${mempoolUrl}/tx/${tx.txId}`);
-        }
-      }}
-    >
-      <div className={cn("flex gap-3", isUnconfirmed && "animate-pulse")}>
-        {icon}
-        <div className="mr-3 flex max-w-full flex-col items-start justify-center overflow-hidden text-left">
-          <div className="flex items-center gap-2">
-            <span className="line-clamp-1 break-all font-semibold md:text-xl">
-              {typeStateText}
-            </span>
-            <span
-              className="shrink-0 text-xs text-muted-foreground md:text-base"
-              title={dayjs(tx.createdAt * 1000)
-                .local()
-                .format("D MMMM YYYY, HH:mm")}
-            >
-              {dayjs(tx.createdAt * 1000)
-                .local()
-                .fromNow()}
-            </span>
-          </div>
-          <p className="line-clamp-1 break-all font-mono text-sm text-muted-foreground md:text-base">
-            {subtitle}
-          </p>
-        </div>
-        <div className="ml-auto flex shrink-0 space-x-3">
-          <div className="flex flex-col items-end md:text-xl">
-            <div className="flex flex-row gap-1">
-              <p
-                className={cn(
-                  tx.type === "incoming" &&
-                    "text-green-600 dark:text-emerald-500"
-                )}
-              >
-                {tx.type === "outgoing" ? "-" : "+"}
-                <FormattedBitcoinAmount
-                  amount={tx.amountSat * 1000}
-                  className="font-medium"
-                />
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="transaction sensitive slashed-zero mb-4 w-full cursor-pointer rounded-md p-3 text-left hover:bg-muted/50"
+        >
+          <div className={cn("flex gap-3", isUnconfirmed && "animate-pulse")}>
+            {icon}
+            <div className="mr-3 flex max-w-full flex-col items-start justify-center overflow-hidden text-left">
+              <div className="flex items-center gap-2">
+                <span className="line-clamp-1 break-all font-semibold md:text-xl">
+                  {typeStateText}
+                </span>
+                <span
+                  className="shrink-0 text-xs text-muted-foreground md:text-base"
+                  title={createdAt.format("D MMMM YYYY, HH:mm")}
+                >
+                  {createdAt.fromNow()}
+                </span>
+              </div>
+              <p className="line-clamp-1 break-all font-mono text-sm text-muted-foreground md:text-base">
+                {subtitle}
               </p>
             </div>
-            <FormattedFiatAmount
-              className="text-xs md:text-base"
-              amount={tx.amountSat}
-            />
+            <div className="ml-auto flex shrink-0 space-x-3">
+              <div className="flex flex-col items-end md:text-xl">
+                <div className="flex flex-row gap-1">
+                  <p
+                    className={cn(
+                      tx.type === "incoming" &&
+                        "text-green-600 dark:text-emerald-500"
+                    )}
+                  >
+                    {tx.type === "outgoing" ? "-" : "+"}
+                    <FormattedBitcoinAmount
+                      amount={tx.amountSat * 1000}
+                      className="font-medium"
+                    />
+                  </p>
+                </div>
+                <FormattedFiatAmount
+                  className="text-xs md:text-base"
+                  amount={tx.amountSat}
+                />
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
-    </button>
+        </button>
+      </DialogTrigger>
+      <DialogContent className="slashed-zero">
+        <DialogHeader>
+          <DialogTitle
+            className={cn(isUnconfirmed && "animate-pulse")}
+          >{`${typeStateText} On-chain Transaction`}</DialogTitle>
+          <DialogDescription className="max-h-[90vh] overflow-y-auto pr-2 text-start text-foreground">
+            <div
+              className={cn(
+                "mt-6 flex items-center",
+                isUnconfirmed && "animate-pulse"
+              )}
+            >
+              {icon}
+              <div className="ml-4">
+                <p className="sensitive text-xl font-semibold md:text-2xl">
+                  {tx.type === "outgoing" ? "-" : "+"}
+                  <FormattedBitcoinAmount amount={tx.amountSat * 1000} />
+                </p>
+                <FormattedFiatAmount amount={tx.amountSat} />
+              </div>
+            </div>
+
+            <div className="mt-8">
+              <p>Status</p>
+              <p className="text-muted-foreground">{statusText}</p>
+            </div>
+
+            <div className="mt-6">
+              <p>Confirmations</p>
+              <p className="text-muted-foreground">{tx.numConfirmations}</p>
+            </div>
+
+            <div className="mt-6">
+              <p>Date & Time</p>
+              <p className="text-muted-foreground">
+                {createdAt.format("D MMMM YYYY, HH:mm")}
+              </p>
+            </div>
+
+            <div className="mt-6">
+              <p>Transaction ID</p>
+              <div className="mt-1 flex items-start gap-3">
+                <p className="break-all font-mono text-muted-foreground">
+                  {tx.txId}
+                </p>
+                <button
+                  type="button"
+                  className="shrink-0 cursor-pointer text-muted-foreground"
+                  onClick={() => copyToClipboard(tx.txId)}
+                >
+                  <CopyIcon className="size-4" />
+                  <span className="sr-only">Copy transaction ID</span>
+                </button>
+              </div>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="sm:justify-between">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => copyToClipboard(tx.txId)}
+          >
+            <CopyIcon className="size-4" />
+            Copy Transaction ID
+          </Button>
+          <Button
+            type="button"
+            onClick={() => {
+              if (mempoolUrl) {
+                openLink(`${mempoolUrl}/tx/${tx.txId}`);
+              }
+            }}
+          >
+            <ExternalLinkIcon className="size-4" />
+            View on Mempool
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/frontend/src/components/channels/OnchainTransactionsTable.tsx
+++ b/frontend/src/components/channels/OnchainTransactionsTable.tsx
@@ -1,5 +1,7 @@
 import dayjs from "dayjs";
-import { ArrowDownIcon, ArrowUpIcon } from "lucide-react";
+import relativeTime from "dayjs/plugin/relativeTime";
+import { ArrowDownIcon, ArrowUpIcon, LinkIcon } from "lucide-react";
+import EmptyState from "src/components/EmptyState";
 import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
 import {
@@ -8,113 +10,206 @@ import {
   CardHeader,
   CardTitle,
 } from "src/components/ui/card";
-import { Table, TableBody, TableCell, TableRow } from "src/components/ui/table";
 import { useInfo } from "src/hooks/useInfo";
 import { useOnchainTransactions } from "src/hooks/useOnchainTransactions";
 import { cn } from "src/lib/utils";
+import { OnchainTransaction } from "src/types";
+import { openLink } from "src/utils/openLink";
 
-export function OnchainTransactionsTable() {
+dayjs.extend(relativeTime);
+
+type OnchainTransactionsTableProps = {
+  wrapInCard?: boolean;
+  title?: string;
+  className?: string;
+  contentClassName?: string;
+  showEmptyState?: boolean;
+  emptyStateTitle?: string;
+  emptyStateDescription?: string;
+  emptyStateButtonText?: string;
+  emptyStateButtonLink?: string;
+};
+
+function typeStateLabel(tx: OnchainTransaction) {
+  if (tx.type === "outgoing") {
+    return tx.state === "confirmed" ? "Sent" : "Sending";
+  }
+  return tx.state === "confirmed" ? "Received" : "Receiving";
+}
+
+function OnchainTransactionRow({
+  tx,
+  mempoolUrl,
+}: {
+  tx: OnchainTransaction;
+  mempoolUrl?: string;
+}) {
+  const Icon = tx.type === "outgoing" ? ArrowUpIcon : ArrowDownIcon;
+  const isUnconfirmed = tx.state === "unconfirmed";
+  const typeStateText = typeStateLabel(tx);
+
+  const icon = (
+    <div className="flex items-center">
+      <div
+        className={cn(
+          "relative flex h-10 w-10 items-center justify-center rounded-full md:h-14 md:w-14",
+          isUnconfirmed
+            ? "bg-blue-100 dark:bg-sky-950"
+            : tx.type === "outgoing"
+              ? "bg-orange-100 dark:bg-amber-950"
+              : "bg-green-100 dark:bg-emerald-950"
+        )}
+        title={`${tx.numConfirmations} confirmations`}
+      >
+        <Icon
+          strokeWidth={3}
+          className={cn(
+            "size-6 md:h-8 md:w-8",
+            isUnconfirmed
+              ? "stroke-blue-500 dark:stroke-sky-500"
+              : tx.type === "outgoing"
+                ? "stroke-orange-500 dark:stroke-amber-500"
+                : "stroke-green-500 dark:stroke-teal-500"
+          )}
+        />
+      </div>
+    </div>
+  );
+
+  const subtitle =
+    tx.txId.length > 22
+      ? `${tx.txId.slice(0, 10)}…${tx.txId.slice(-8)}`
+      : tx.txId;
+
+  return (
+    <button
+      type="button"
+      className="transaction sensitive slashed-zero mb-4 w-full cursor-pointer rounded-md p-3 text-left hover:bg-muted/50"
+      onClick={() => {
+        if (mempoolUrl) {
+          openLink(`${mempoolUrl}/tx/${tx.txId}`);
+        }
+      }}
+    >
+      <div className={cn("flex gap-3", isUnconfirmed && "animate-pulse")}>
+        {icon}
+        <div className="mr-3 flex max-w-full flex-col items-start justify-center overflow-hidden text-left">
+          <div className="flex items-center gap-2">
+            <span className="line-clamp-1 break-all font-semibold md:text-xl">
+              {typeStateText}
+            </span>
+            <span
+              className="shrink-0 text-xs text-muted-foreground md:text-base"
+              title={dayjs(tx.createdAt * 1000)
+                .local()
+                .format("D MMMM YYYY, HH:mm")}
+            >
+              {dayjs(tx.createdAt * 1000)
+                .local()
+                .fromNow()}
+            </span>
+          </div>
+          <p className="line-clamp-1 break-all font-mono text-sm text-muted-foreground md:text-base">
+            {subtitle}
+          </p>
+        </div>
+        <div className="ml-auto flex shrink-0 space-x-3">
+          <div className="flex flex-col items-end md:text-xl">
+            <div className="flex flex-row gap-1">
+              <p
+                className={cn(
+                  tx.type === "incoming" &&
+                    "text-green-600 dark:text-emerald-500"
+                )}
+              >
+                {tx.type === "outgoing" ? "-" : "+"}
+                <FormattedBitcoinAmount
+                  amount={tx.amountSat * 1000}
+                  className="font-medium"
+                />
+              </p>
+            </div>
+            <FormattedFiatAmount
+              className="text-xs md:text-base"
+              amount={tx.amountSat}
+            />
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+export function OnchainTransactionsTable({
+  wrapInCard = true,
+  title = "On-Chain Transactions",
+  className,
+  contentClassName,
+  showEmptyState = false,
+  emptyStateTitle = "No on-chain transactions yet",
+  emptyStateDescription = "Your most recent incoming and outgoing on-chain payments will show up here.",
+  emptyStateButtonText = "Receive to On-chain Balance",
+  emptyStateButtonLink = "/wallet/receive/onchain?type=onchain",
+}: OnchainTransactionsTableProps) {
   const { data: info } = useInfo();
   const { data: transactions } = useOnchainTransactions();
 
   if (!transactions?.length) {
-    return null;
+    if (!showEmptyState) {
+      return null;
+    }
+
+    const emptyState = (
+      <EmptyState
+        icon={LinkIcon}
+        title={emptyStateTitle}
+        description={emptyStateDescription}
+        buttonText={emptyStateButtonText}
+        buttonLink={emptyStateButtonLink}
+        showBorder={false}
+      />
+    );
+
+    if (!wrapInCard) {
+      return (
+        <div className={cn("flex flex-1 flex-col", className)}>
+          {emptyState}
+        </div>
+      );
+    }
+
+    return (
+      <Card className={cn("mt-6", className)}>
+        {title && (
+          <CardHeader>
+            <CardTitle className="text-2xl">{title}</CardTitle>
+          </CardHeader>
+        )}
+        <CardContent className={contentClassName}>{emptyState}</CardContent>
+      </Card>
+    );
+  }
+
+  const rows = transactions.map((tx) => (
+    <OnchainTransactionRow
+      key={tx.txId}
+      tx={tx}
+      mempoolUrl={info?.mempoolUrl}
+    />
+  ));
+
+  if (!wrapInCard) {
+    return <div className={cn("flex flex-1 flex-col", className)}>{rows}</div>;
   }
 
   return (
-    <Card className="mt-6">
-      <CardHeader>
-        <CardTitle className="text-2xl">On-Chain Transactions</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <Table>
-          <TableBody>
-            {transactions.map((tx) => {
-              const Icon = tx.type == "outgoing" ? ArrowUpIcon : ArrowDownIcon;
-              return (
-                <TableRow
-                  key={tx.txId}
-                  className="cursor-pointer"
-                  onClick={() => {
-                    window.open(`${info?.mempoolUrl}/tx/${tx.txId}`, "_blank");
-                  }}
-                >
-                  <TableCell className="flex items-center gap-2">
-                    <div
-                      className={cn(
-                        "flex justify-center items-center rounded-full w-10 h-10 relative",
-                        tx.state === "unconfirmed"
-                          ? "bg-blue-100 dark:bg-sky-950 animate-pulse"
-                          : tx.type === "outgoing"
-                            ? "bg-orange-100 dark:bg-amber-950"
-                            : "bg-green-100 dark:bg-emerald-950"
-                      )}
-                      title={`${tx.numConfirmations} confirmations`}
-                    >
-                      <Icon
-                        strokeWidth={3}
-                        className={cn(
-                          "size-6",
-                          tx.state === "unconfirmed"
-                            ? "stroke-blue-500 dark:stroke-sky-500"
-                            : tx.type === "outgoing"
-                              ? "stroke-orange-500 dark:stroke-amber-500"
-                              : "stroke-green-500 dark:stroke-teal-500"
-                        )}
-                      />
-                    </div>
-                    <div className="md:flex md:gap-2 md:items-center">
-                      <p className="font-semibold text-lg">
-                        {tx.type == "outgoing"
-                          ? tx.state === "confirmed"
-                            ? "Sent"
-                            : "Sending"
-                          : tx.state === "confirmed"
-                            ? "Received"
-                            : "Receiving"}
-                      </p>
-                      <p
-                        className="text-muted-foreground"
-                        title={dayjs(tx.createdAt * 1000)
-                          .local()
-                          .format("D MMMM YYYY, HH:mm")}
-                      >
-                        {dayjs(tx.createdAt * 1000)
-                          .local()
-                          .fromNow()}
-                      </p>
-                    </div>
-                  </TableCell>
-
-                  <TableCell>
-                    <div className="flex flex-col items-end">
-                      <div className="flex flex-row gap-1">
-                        <p
-                          className={cn(
-                            tx.type == "incoming" &&
-                              "text-green-600 dark:text-emerald-500"
-                          )}
-                        >
-                          {tx.type == "outgoing" ? "-" : "+"}
-                          <span className="font-medium">
-                            <FormattedBitcoinAmount
-                              amount={tx.amountSat * 1000}
-                            />
-                          </span>
-                        </p>
-                      </div>
-                      <FormattedFiatAmount
-                        className="text-xs"
-                        amount={tx.amountSat}
-                      />
-                    </div>
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </CardContent>
+    <Card className={cn("mt-6", className)}>
+      {title && (
+        <CardHeader>
+          <CardTitle className="text-2xl">{title}</CardTitle>
+        </CardHeader>
+      )}
+      <CardContent className={contentClassName}>{rows}</CardContent>
     </Card>
   );
 }

--- a/frontend/src/components/wallet/OnchainBalanceSummary.tsx
+++ b/frontend/src/components/wallet/OnchainBalanceSummary.tsx
@@ -1,0 +1,80 @@
+import { AlertTriangleIcon } from "lucide-react";
+import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
+import FormattedFiatAmount from "src/components/FormattedFiatAmount";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "src/components/ui/tooltip";
+import { cn } from "src/lib/utils";
+import { OnchainBalanceResponse } from "src/types";
+
+type OnchainBalanceSummaryProps = {
+  balance: OnchainBalanceResponse;
+  hasChannels: boolean;
+  className?: string;
+  amountClassName?: string;
+  amountRowClassName?: string;
+  fiatClassName?: string;
+  incomingClassName?: string;
+};
+
+export function OnchainBalanceSummary({
+  balance,
+  hasChannels,
+  className,
+  amountClassName,
+  amountRowClassName,
+  fiatClassName,
+  incomingClassName,
+}: OnchainBalanceSummaryProps) {
+  const showReserveWarning =
+    hasChannels && balance.reserved + balance.spendable < 25_000;
+  const incomingAmount = balance.total - balance.spendable;
+
+  return (
+    <div className={cn("flex flex-col gap-3", className)}>
+      <div className={cn(amountRowClassName)}>
+        <span
+          className={cn(
+            "mr-1 text-xl font-medium balance sensitive",
+            amountClassName
+          )}
+        >
+          <FormattedBitcoinAmount amount={balance.spendable * 1000} />
+        </span>
+        {showReserveWarning && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger>
+                <AlertTriangleIcon className="size-3 text-muted-foreground" />
+              </TooltipTrigger>
+              <TooltipContent>
+                You have insufficient funds in reserve to close channels or bump
+                on-chain transactions and currently rely on the counterparty. It
+                is recommended to deposit at least{" "}
+                <FormattedBitcoinAmount amount={25_000 * 1000} /> to your
+                on-chain balance.
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      </div>
+      <FormattedFiatAmount
+        amount={balance.spendable}
+        className={fiatClassName}
+      />
+      {incomingAmount > 0 && (
+        <p
+          className={cn(
+            "text-xs text-muted-foreground animate-pulse",
+            incomingClassName
+          )}
+        >
+          +<FormattedBitcoinAmount amount={incomingAmount * 1000} /> incoming
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/wallet/PendingClosedChannelsAlert.tsx
+++ b/frontend/src/components/wallet/PendingClosedChannelsAlert.tsx
@@ -1,0 +1,90 @@
+import { ExternalLinkIcon, HourglassIcon } from "lucide-react";
+import ExternalLink from "src/components/ExternalLink";
+import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
+import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
+import { useInfo } from "src/hooks/useInfo";
+import { useNodeDetails } from "src/hooks/useNodeDetails";
+import { OnchainBalanceResponse, PendingBalancesDetails } from "src/types";
+
+type PendingClosedChannelsAlertProps = {
+  balance: OnchainBalanceResponse;
+};
+
+export function PendingClosedChannelsAlert({
+  balance,
+}: PendingClosedChannelsAlertProps) {
+  if (balance.pendingBalancesFromChannelClosures <= 0) {
+    return null;
+  }
+
+  const pendingDetails = [
+    ...balance.pendingBalancesDetails,
+    ...balance.pendingSweepBalancesDetails,
+  ];
+
+  return (
+    <Alert>
+      <HourglassIcon />
+      <AlertTitle>Pending Closed Channels</AlertTitle>
+      <AlertDescription className="block">
+        You have{" "}
+        <FormattedBitcoinAmount
+          amount={balance.pendingBalancesFromChannelClosures * 1000}
+        />{" "}
+        pending from closed channels with
+        {pendingDetails.map((details, index) => (
+          <PendingBalancesDetailsItem
+            key={`${details.fundingTxId}:${details.fundingTxVout}:${details.nodeId}:${index}`}
+            details={details}
+            isLast={index < pendingDetails.length - 1}
+          />
+        ))}
+        . Once spendable again these will become available in your on-chain
+        balance. Funds from channels that were force closed may take up to 2
+        weeks to become available.{" "}
+        <ExternalLink
+          to="https://guides.getalby.com/user-guide/alby-hub/faq/why-was-my-lightning-channel-closed-and-what-to-do-next"
+          className="underline"
+        >
+          Learn more
+        </ExternalLink>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+type PendingBalancesDetailsItemProps = {
+  details: PendingBalancesDetails;
+  isLast: boolean;
+};
+
+function PendingBalancesDetailsItem({
+  details,
+  isLast,
+}: PendingBalancesDetailsItemProps) {
+  const { data: info } = useInfo();
+  const { data: nodeDetails } = useNodeDetails(details.nodeId);
+
+  return (
+    <span className="inline">
+      &nbsp;
+      <ExternalLink
+        to={`https://amboss.space/node/${details.nodeId}`}
+        className="underline"
+      >
+        {nodeDetails?.alias || "Unknown"}
+        <ExternalLinkIcon className="ml-1 inline h-4 w-4" />
+      </ExternalLink>{" "}
+      (<FormattedBitcoinAmount amount={details.amount * 1000} />
+      )&nbsp;
+      <ExternalLink
+        to={`${info?.mempoolUrl}/tx/${details.fundingTxId}#flow=&vout=${details.fundingTxVout}`}
+        className="underline"
+      >
+        funding tx
+        <ExternalLinkIcon className="ml-1 inline h-4 w-4" />
+      </ExternalLink>
+      {isLast && ","}
+    </span>
+  );
+}

--- a/frontend/src/screens/Home.tsx
+++ b/frontend/src/screens/Home.tsx
@@ -4,7 +4,6 @@ import AppHeader from "src/components/AppHeader";
 import ExternalLink from "src/components/ExternalLink";
 import { AlbyHead } from "src/components/images/AlbyHead";
 import Loading from "src/components/Loading";
-import { Badge } from "src/components/ui/badge";
 import { Button } from "src/components/ui/button";
 import {
   Card,
@@ -20,7 +19,6 @@ import OnboardingChecklist from "src/screens/wallet/OnboardingChecklist";
 
 import React from "react";
 import albyGo from "src/assets/suggested-apps/alby-go.png";
-import zapplanner from "src/assets/suggested-apps/zapplanner.png";
 import { AppOfTheDayWidget } from "src/components/home/widgets/AppOfTheDayWidget";
 import { BlockHeightWidget } from "src/components/home/widgets/BlockHeightWidget";
 import { ForwardsWidget } from "src/components/home/widgets/ForwardsWidget";
@@ -165,34 +163,6 @@ function Home() {
           <SupportAlbyWidget />
           <LightningMessageboardWidget />
           <AppOfTheDayWidget />
-
-          <Link to="/internal-apps/zapplanner">
-            <Card>
-              <CardHeader>
-                <div className="flex flex-row items-center">
-                  <div className="shrink-0">
-                    <img
-                      src={zapplanner}
-                      className="w-12 h-12 rounded-xl border"
-                    />
-                  </div>
-                  <div>
-                    <CardTitle>
-                      <div className="flex-1 leading-5 font-semibold text-xl whitespace-nowrap text-ellipsis overflow-hidden ml-4 flex gap-2">
-                        ZapPlanner <Badge>NEW</Badge>
-                      </div>
-                    </CardTitle>
-                    <CardDescription className="ml-4">
-                      Schedule automatic recurring lightning payments.
-                    </CardDescription>
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent className="text-right">
-                <Button variant="outline">Open</Button>
-              </CardContent>
-            </Card>
-          </Link>
 
           <Card>
             <CardHeader>

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -1,12 +1,9 @@
 import dayjs from "dayjs";
 import {
-  AlertTriangleIcon,
   ArrowDownUpIcon,
   ArrowRightIcon,
   CopyIcon,
-  ExternalLinkIcon,
   HeartIcon,
-  HourglassIcon,
   InfoIcon,
   LinkIcon,
   Settings2Icon,
@@ -29,11 +26,8 @@ import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
 import LowReceivingCapacityAlert from "src/components/LowReceivingCapacityAlert";
 import ResponsiveButton from "src/components/ResponsiveButton";
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from "src/components/ui/alert.tsx";
+import { PendingClosedChannelsAlert } from "src/components/wallet/PendingClosedChannelsAlert";
+import { OnchainBalanceSummary } from "src/components/wallet/OnchainBalanceSummary";
 import {
   Card,
   CardContent,
@@ -64,7 +58,6 @@ import { useBalances } from "src/hooks/useBalances.ts";
 import { useChannels } from "src/hooks/useChannels";
 import { useInfo } from "src/hooks/useInfo";
 import { useNodeConnectionInfo } from "src/hooks/useNodeConnectionInfo.ts";
-import { useNodeDetails } from "src/hooks/useNodeDetails";
 import { useSyncWallet } from "src/hooks/useSyncWallet.ts";
 import { copyToClipboard } from "src/lib/clipboard.ts";
 import { cn } from "src/lib/utils.ts";
@@ -72,7 +65,6 @@ import {
   Channel,
   LongUnconfirmedZeroConfChannel,
   MempoolTransaction,
-  PendingBalancesDetails,
 } from "src/types";
 import { request } from "src/utils/request";
 
@@ -507,101 +499,19 @@ export default function Channels() {
                 )}
                 <div>
                   {balances && (
-                    <>
-                      <div className="mb-1">
-                        <span className="text-xl font-medium balance sensitive mb-1 mr-1">
-                          <FormattedBitcoinAmount
-                            amount={balances.onchain.spendable * 1000}
-                          />
-                        </span>
-                        {!!channels?.length &&
-                          balances.onchain.reserved +
-                            balances.onchain.spendable <
-                            25_000 && (
-                            <TooltipProvider>
-                              <Tooltip>
-                                <TooltipTrigger>
-                                  <AlertTriangleIcon className="size-3 text-muted-foreground" />
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                  You have insufficient funds in reserve to
-                                  close channels or bump on-chain transactions
-                                  and currently rely on the counterparty. It is
-                                  recommended to deposit at least{" "}
-                                  <FormattedBitcoinAmount
-                                    amount={25_000 * 1000}
-                                  />{" "}
-                                  to your on-chain balance.
-                                </TooltipContent>
-                              </Tooltip>
-                            </TooltipProvider>
-                          )}
-                      </div>
-                      <FormattedFiatAmount
-                        amount={balances.onchain.spendable}
-                        className="mb-1"
-                      />
-                      {balances &&
-                        balances.onchain.spendable !==
-                          balances.onchain.total && (
-                          <p className="text-xs text-muted-foreground animate-pulse">
-                            +
-                            <FormattedBitcoinAmount
-                              amount={
-                                (balances.onchain.total -
-                                  balances.onchain.spendable) *
-                                1000
-                              }
-                            />{" "}
-                            incoming
-                          </p>
-                        )}
-                    </>
+                    <OnchainBalanceSummary
+                      balance={balances.onchain}
+                      hasChannels={!!channels?.length}
+                    />
                   )}
                 </div>
               </CardContent>
             </Card>
           </div>
 
-          {balances &&
-            balances.onchain.pendingBalancesFromChannelClosures > 0 && (
-              <Alert>
-                <HourglassIcon />
-                <AlertTitle>Pending Closed Channels</AlertTitle>
-                <AlertDescription className="block">
-                  You have{" "}
-                  <FormattedBitcoinAmount
-                    amount={
-                      balances.onchain.pendingBalancesFromChannelClosures * 1000
-                    }
-                  />{" "}
-                  pending from closed channels with
-                  {[
-                    ...balances.onchain.pendingBalancesDetails,
-                    ...balances.onchain.pendingSweepBalancesDetails,
-                  ].map((details, index) => {
-                    const isLast =
-                      index <
-                      balances.onchain.pendingBalancesDetails.length - 1;
-                    return (
-                      <PendingBalancesDetailsItem
-                        details={details}
-                        isLast={isLast}
-                      />
-                    );
-                  })}
-                  . Once spendable again these will become available in your
-                  on-chain balance. Funds from channels that were force closed
-                  may take up to 2 weeks to become available.{" "}
-                  <ExternalLink
-                    to="https://guides.getalby.com/user-guide/alby-hub/faq/why-was-my-lightning-channel-closed-and-what-to-do-next"
-                    className="underline"
-                  >
-                    Learn more
-                  </ExternalLink>
-                </AlertDescription>
-              </Alert>
-            )}
+          {balances && (
+            <PendingClosedChannelsAlert balance={balances.onchain} />
+          )}
 
           {channels && channels.length === 0 && (
             <EmptyState
@@ -664,40 +574,4 @@ function getNodeHealth(channels: Channel[]) {
   }
 
   return nodeHealth;
-}
-
-type PendingBalancesDetailsItemProps = {
-  details: PendingBalancesDetails;
-  isLast: boolean;
-};
-
-function PendingBalancesDetailsItem({
-  details,
-  isLast,
-}: PendingBalancesDetailsItemProps) {
-  const { data: info } = useInfo();
-  const { data: nodeDetails } = useNodeDetails(details.nodeId);
-
-  return (
-    <div key={details.channelId} className="inline">
-      &nbsp;
-      <ExternalLink
-        to={`https://amboss.space/node/${details.nodeId}`}
-        className="underline"
-      >
-        {nodeDetails?.alias || "Unknown"}
-        <ExternalLinkIcon className="ml-1 w-4 h-4 inline" />
-      </ExternalLink>{" "}
-      (<FormattedBitcoinAmount amount={details.amount * 1000} />
-      )&nbsp;
-      <ExternalLink
-        to={`${info?.mempoolUrl}/tx/${details.fundingTxId}#flow=&vout=${details.fundingTxVout}`}
-        className="underline"
-      >
-        funding tx
-        <ExternalLinkIcon className="ml-1 w-4 h-4 inline" />
-      </ExternalLink>
-      {isLast && ","}
-    </div>
-  );
 }

--- a/frontend/src/screens/wallet/index.tsx
+++ b/frontend/src/screens/wallet/index.tsx
@@ -4,6 +4,7 @@ import {
   ArrowDownIcon,
   ArrowDownUpIcon,
   ArrowUpIcon,
+  CalendarSyncIcon,
   CreditCardIcon,
   ExternalLinkIcon,
   LightbulbIcon,
@@ -45,21 +46,68 @@ function Wallet() {
         description=""
         contentRight={
           <div className="flex items-center gap-1 sm:gap-2">
+            {hasChannelManagement && (
+              <LinkButton
+                to="/wallet/swap"
+                variant="ghost"
+                size="sm"
+                className="hidden sm:inline-flex"
+              >
+                <ArrowDownUpIcon />
+                Swap
+              </LinkButton>
+            )}
+            <LinkButton
+              to="/internal-apps/zapplanner"
+              variant="ghost"
+              size="sm"
+              className="hidden sm:inline-flex"
+            >
+              <CalendarSyncIcon />
+              Recurring
+            </LinkButton>
             <ExternalLinkButton
               to="https://www.getalby.com/topup"
               variant="ghost"
               size="sm"
+              className="hidden sm:inline-flex"
             >
               <CreditCardIcon />
-              <span className="hidden sm:inline">Buy Bitcoin</span>
+              Buy
             </ExternalLinkButton>
-            {hasChannelManagement && (
-              <LinkButton to="/wallet/swap" variant="ghost" size="sm">
-                <ArrowDownUpIcon />
-                <span className="hidden sm:inline">Swap</span>
-              </LinkButton>
-            )}
-            <TransactionsListMenu buttonVariant="ghost" />
+            <TransactionsListMenu
+              buttonVariant="ghost"
+              buttonClassName="sm:hidden"
+              menuItems={[
+                ...(hasChannelManagement
+                  ? [
+                      {
+                        id: "swap",
+                        label: "Swap",
+                        icon: <ArrowDownUpIcon className="h-4 w-4" />,
+                        to: "/wallet/swap",
+                      },
+                    ]
+                  : []),
+                {
+                  id: "recurring",
+                  label: "Recurring",
+                  icon: <CalendarSyncIcon className="h-4 w-4" />,
+                  to: "/internal-apps/zapplanner",
+                },
+                {
+                  id: "buy",
+                  label: "Buy",
+                  icon: <CreditCardIcon className="h-4 w-4" />,
+                  to: "https://www.getalby.com/topup",
+                  external: true,
+                },
+              ]}
+            />
+            <TransactionsListMenu
+              buttonVariant="ghost"
+              buttonClassName="hidden sm:inline-flex"
+            />
           </div>
         }
       />

--- a/frontend/src/screens/wallet/index.tsx
+++ b/frontend/src/screens/wallet/index.tsx
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import {
   AlertTriangleIcon,
   ArrowDownIcon,
@@ -6,17 +5,19 @@ import {
   ArrowUpIcon,
   CalendarSyncIcon,
   CreditCardIcon,
-  ExternalLinkIcon,
-  LightbulbIcon,
 } from "lucide-react";
+import React from "react";
 import { Link } from "react-router-dom";
 import AppHeader from "src/components/AppHeader";
+import { OnchainTransactionsTable } from "src/components/channels/OnchainTransactionsTable";
 import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
 import Loading from "src/components/Loading";
 import LowReceivingCapacityAlert from "src/components/LowReceivingCapacityAlert";
 import TransactionsList from "src/components/TransactionsList";
 import { TransactionsListMenu } from "src/components/TransactionsListMenu";
+import { OnchainBalanceSummary } from "src/components/wallet/OnchainBalanceSummary";
+import { PendingClosedChannelsAlert } from "src/components/wallet/PendingClosedChannelsAlert";
 import {
   Alert,
   AlertDescription,
@@ -27,12 +28,26 @@ import { LinkButton } from "src/components/ui/custom/link-button";
 import { useBalances } from "src/hooks/useBalances";
 import { useChannels } from "src/hooks/useChannels";
 import { useInfo } from "src/hooks/useInfo";
-import { useOnchainTransactions } from "src/hooks/useOnchainTransactions";
+import { useSyncWallet } from "src/hooks/useSyncWallet";
+
+type BalanceMode = "lightning" | "onchain";
 
 function Wallet() {
+  useSyncWallet();
   const { data: info, hasChannelManagement } = useInfo();
-  const { data: balances } = useBalances();
+  const { data: balances } = useBalances(true);
   const { data: channels } = useChannels();
+  const [activeBalanceMode, setActiveBalanceMode] =
+    React.useState<BalanceMode>("lightning");
+
+  const isOnchainMode = activeBalanceMode === "onchain";
+  const hasChannelsOpen = !!channels?.length;
+
+  const toggleBalanceMode = () => {
+    setActiveBalanceMode((currentMode) =>
+      currentMode === "lightning" ? "onchain" : "lightning"
+    );
+  };
 
   if (!info || !balances) {
     return <Loading />;
@@ -111,8 +126,9 @@ function Wallet() {
           </div>
         }
       />
-      {hasChannelManagement &&
-        !!channels?.length &&
+      {!isOnchainMode &&
+        hasChannelManagement &&
+        hasChannelsOpen &&
         channels?.every(
           (channel) =>
             channel.localBalance < channel.unspendablePunishmentReserve * 1000
@@ -129,13 +145,14 @@ function Wallet() {
             </AlertDescription>
           </Alert>
         )}
-      {hasChannelManagement &&
-        !!channels?.length &&
+      {!isOnchainMode &&
+        hasChannelManagement &&
+        hasChannelsOpen &&
         balances.lightning.totalReceivable <
           balances.lightning.totalSpendable * 0.1 && (
           <LowReceivingCapacityAlert />
         )}
-      {hasChannelManagement && !channels?.length && (
+      {!isOnchainMode && hasChannelManagement && !hasChannelsOpen && (
         <Alert>
           <AlertTriangleIcon className="h-4 w-4" />
           <AlertTitle>Open Your First Channel</AlertTitle>
@@ -148,63 +165,76 @@ function Wallet() {
           </AlertDescription>
         </Alert>
       )}
-      <div className="flex flex-col items-center gap-8 py-10 md:py-14 text-center">
-        <div className="flex flex-col gap-2">
-          <div className="text-5xl md:text-6xl font-medium balance sensitive slashed-zero">
-            <FormattedBitcoinAmount
-              amount={balances.lightning.totalSpendable}
+      <div className="flex w-full flex-col items-center gap-8 pt-12 pb-16 text-center">
+        <div className="flex flex-col items-center gap-4">
+          <button
+            type="button"
+            onClick={toggleBalanceMode}
+            className="inline-flex items-center justify-center gap-1 text-xs font-medium leading-none uppercase text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {isOnchainMode ? "On-Chain Balance" : "Spending Balance"}
+            <ArrowDownUpIcon className="size-3 shrink-0" />
+          </button>
+          {isOnchainMode ? (
+            <OnchainBalanceSummary
+              balance={balances.onchain}
+              hasChannels={hasChannelsOpen}
+              className="items-center"
+              amountClassName="text-5xl md:text-6xl font-medium slashed-zero leading-none"
+              fiatClassName="text-3xl font-normal leading-9 text-muted-foreground"
+              incomingClassName="text-sm md:text-base"
             />
-          </div>
-          <FormattedFiatAmount
-            className="text-xl md:text-2xl"
-            amount={balances.lightning.totalSpendable / 1000}
-          />
+          ) : (
+            <div className="flex flex-col items-center gap-3">
+              <div className="text-5xl md:text-6xl font-medium balance sensitive slashed-zero leading-none">
+                <FormattedBitcoinAmount
+                  amount={balances.lightning.totalSpendable}
+                />
+              </div>
+              <FormattedFiatAmount
+                className="text-3xl font-normal leading-9 text-muted-foreground"
+                amount={balances.lightning.totalSpendable / 1000}
+              />
+            </div>
+          )}
         </div>
-        <div className="grid w-full max-w-md grid-cols-2 items-center gap-3">
-          <LinkButton to="/wallet/receive" size="lg" className="!px-12">
+        <div className="grid w-full max-w-[399px] grid-cols-2 items-center gap-3">
+          <LinkButton
+            to={
+              isOnchainMode
+                ? "/wallet/receive/onchain?type=onchain"
+                : "/wallet/receive"
+            }
+            size="lg"
+          >
             <ArrowDownIcon />
             Receive
           </LinkButton>
-          <LinkButton to="/wallet/send" size="lg" className="!px-12">
+          <LinkButton
+            to={isOnchainMode ? "/wallet/send/onchain" : "/wallet/send"}
+            size="lg"
+          >
             <ArrowUpIcon />
             Send
           </LinkButton>
         </div>
       </div>
 
-      <OnchainTransactionsAlert />
-      <TransactionsList />
+      {isOnchainMode && (
+        <PendingClosedChannelsAlert balance={balances.onchain} />
+      )}
+
+      {isOnchainMode ? (
+        <OnchainTransactionsTable
+          wrapInCard={false}
+          className="w-full"
+          showEmptyState={true}
+        />
+      ) : (
+        <TransactionsList />
+      )}
     </>
   );
 }
 
 export default Wallet;
-
-function OnchainTransactionsAlert() {
-  const { data: onchainTransactions } = useOnchainTransactions();
-  if (
-    onchainTransactions?.some(
-      (tx) => dayjs().diff(tx.createdAt * 1000, "hours") < 24
-    )
-  ) {
-    return (
-      <Alert>
-        <AlertTitle className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2 text-sm">
-            <LightbulbIcon className="w-4 h-4" /> On-chain transactions are
-            shown on the Node page
-          </div>
-          <LinkButton
-            to="/channels"
-            variant="secondary"
-            size="sm"
-            className="flex items-center gap-2"
-          >
-            <ExternalLinkIcon className="w-4 h-4" /> View On-chain transactions
-          </LinkButton>
-        </AlertTitle>
-      </Alert>
-    );
-  }
-  return null;
-}

--- a/frontend/src/screens/wallet/index.tsx
+++ b/frontend/src/screens/wallet/index.tsx
@@ -44,24 +44,23 @@ function Wallet() {
         pageTitle="Wallet"
         description=""
         contentRight={
-          <>
-            <LinkButton
-              to="/wallet/receive"
-              size="lg"
-              className="hidden xl:inline-flex !px-12"
+          <div className="flex items-center gap-1 sm:gap-2">
+            <ExternalLinkButton
+              to="https://www.getalby.com/topup"
+              variant="ghost"
+              size="sm"
             >
-              <ArrowDownIcon />
-              Receive
-            </LinkButton>
-            <LinkButton
-              to="/wallet/send"
-              size="lg"
-              className="hidden xl:inline-flex !px-12"
-            >
-              <ArrowUpIcon />
-              Send
-            </LinkButton>
-          </>
+              <CreditCardIcon />
+              <span className="hidden sm:inline">Buy Bitcoin</span>
+            </ExternalLinkButton>
+            {hasChannelManagement && (
+              <LinkButton to="/wallet/swap" variant="ghost" size="sm">
+                <ArrowDownUpIcon />
+                <span className="hidden sm:inline">Swap</span>
+              </LinkButton>
+            )}
+            <TransactionsListMenu buttonVariant="ghost" />
+          </div>
         }
       />
       {hasChannelManagement &&
@@ -101,43 +100,27 @@ function Wallet() {
           </AlertDescription>
         </Alert>
       )}
-      <div className="flex flex-col xl:flex-row justify-between xl:items-start gap-3">
-        <div className="flex flex-col gap-1 p-6 xl:p-0 text-center xl:text-left">
-          <div className="text-5xl font-medium balance sensitive slashed-zero">
+      <div className="flex flex-col items-center gap-8 py-10 md:py-14 text-center">
+        <div className="flex flex-col gap-2">
+          <div className="text-5xl md:text-6xl font-medium balance sensitive slashed-zero">
             <FormattedBitcoinAmount
               amount={balances.lightning.totalSpendable}
             />
           </div>
           <FormattedFiatAmount
-            className="text-xl"
+            className="text-xl md:text-2xl"
             amount={balances.lightning.totalSpendable / 1000}
           />
         </div>
-        <div className="grid grid-cols-2 items-center gap-3 xl:hidden">
-          <LinkButton to="/wallet/receive" size="lg">
+        <div className="grid w-full max-w-md grid-cols-2 items-center gap-3">
+          <LinkButton to="/wallet/receive" size="lg" className="!px-12">
+            <ArrowDownIcon />
             Receive
           </LinkButton>
-          <LinkButton to="/wallet/send" size="lg">
+          <LinkButton to="/wallet/send" size="lg" className="!px-12">
+            <ArrowUpIcon />
             Send
           </LinkButton>
-        </div>
-        <div className="flex items-center gap-3">
-          <ExternalLinkButton
-            to="https://www.getalby.com/topup"
-            variant="secondary"
-          >
-            <CreditCardIcon />
-            Buy Bitcoin
-          </ExternalLinkButton>
-          {hasChannelManagement && (
-            <LinkButton to="/wallet/swap" variant="secondary">
-              <ArrowDownUpIcon />
-              Swap
-            </LinkButton>
-          )}
-          <div>
-            <TransactionsListMenu />
-          </div>
         </div>
       </div>
 

--- a/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
@@ -58,16 +58,27 @@ import {
 import { openLink } from "src/utils/openLink";
 import { request } from "src/utils/request";
 
+type ReceiveOnchainTab = "spending" | "onchain";
+
+function tabFromSearchParam(value: string | null): ReceiveOnchainTab | null {
+  if (value === "spending" || value === "onchain") {
+    return value;
+  }
+  return null;
+}
+
 export default function ReceiveOnchain() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const [tab, setTab] = useState(searchParams.get("type") || "spending");
+  const [tab, setTab] = useState<ReceiveOnchainTab>(() => {
+    return tabFromSearchParam(searchParams.get("type")) ?? "spending";
+  });
 
   useEffect(() => {
-    const newTabValue = searchParams.get("type");
-    if (newTabValue) {
+    const fromParam = tabFromSearchParam(searchParams.get("type"));
+    if (fromParam) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      setTab(newTabValue);
-      setSearchParams({});
+      setTab(fromParam);
+      setSearchParams({}, { replace: true });
     }
   }, [searchParams, setSearchParams]);
 
@@ -79,7 +90,16 @@ export default function ReceiveOnchain() {
       />
       <div className="w-full max-w-lg grid gap-5">
         <MempoolAlert />
-        <Tabs value={tab} onValueChange={setTab} className="w-full">
+        <Tabs
+          value={tab}
+          onValueChange={(value) => {
+            const next = tabFromSearchParam(value);
+            if (next) {
+              setTab(next);
+            }
+          }}
+          className="w-full"
+        >
           <TabsList className="w-full mb-2">
             <TabsTrigger
               value="spending"

--- a/frontend/src/screens/wallet/send/Onchain.tsx
+++ b/frontend/src/screens/wallet/send/Onchain.tsx
@@ -35,7 +35,7 @@ import { request } from "src/utils/request";
 export default function Onchain() {
   const { state } = useLocation();
   const navigate = useNavigate();
-  const [isSwap, setSwap] = React.useState(true);
+  const [isSwap, setSwap] = React.useState(false);
   const [amount, setAmount] = React.useState("");
 
   const address = state?.args?.address as string;


### PR DESCRIPTION
## Summary
- open a lightweight details dialog from on-chain transaction rows instead of navigating directly to Mempool
- show the currently available on-chain transaction fields in the dialog, including status, confirmations, date, amount, and full transaction id
- keep copy and Mempool actions available from inside the dialog while preserving the updated row styling

## Test plan
- [x] cd frontend && yarn tsc:compile
- [ ] Open the Wallet on-chain transaction list and verify row clicks open the dialog
- [ ] Verify copying the transaction id works from both copy actions
- [ ] Verify the Mempool button opens the correct transaction

Made with [Cursor](https://cursor.com)