### PR TITLE
feat(frontend): polish on-chain pending transaction state

### DIFF
--- a/frontend/src/components/channels/OnchainTransactionsTable.tsx
+++ b/frontend/src/components/channels/OnchainTransactionsTable.tsx
@@ -55,7 +55,7 @@ function typeStateLabel(tx: OnchainTransaction) {
 }
 
 function transactionStatusLabel(tx: OnchainTransaction) {
-  return tx.state === "confirmed" ? "Confirmed" : "Unconfirmed";
+  return tx.state === "confirmed" ? "Confirmed" : "Pending";
 }
 
 function OnchainTransactionRow({
@@ -66,7 +66,7 @@ function OnchainTransactionRow({
   mempoolUrl?: string;
 }) {
   const Icon = tx.type === "outgoing" ? ArrowUpIcon : ArrowDownIcon;
-  const isUnconfirmed = tx.state === "unconfirmed";
+  const isPending = tx.state === "unconfirmed";
   const typeStateText = typeStateLabel(tx);
   const statusText = transactionStatusLabel(tx);
   const createdAt = dayjs(tx.createdAt * 1000).local();
@@ -76,7 +76,7 @@ function OnchainTransactionRow({
       <div
         className={cn(
           "relative flex h-10 w-10 items-center justify-center rounded-full md:h-14 md:w-14",
-          isUnconfirmed
+          isPending
             ? "bg-blue-100 dark:bg-sky-950"
             : tx.type === "outgoing"
               ? "bg-orange-100 dark:bg-amber-950"
@@ -88,7 +88,7 @@ function OnchainTransactionRow({
           strokeWidth={3}
           className={cn(
             "size-6 md:h-8 md:w-8",
-            isUnconfirmed
+            isPending
               ? "stroke-blue-500 dark:stroke-sky-500"
               : tx.type === "outgoing"
                 ? "stroke-orange-500 dark:stroke-amber-500"
@@ -111,7 +111,7 @@ function OnchainTransactionRow({
           type="button"
           className="transaction sensitive slashed-zero mb-4 w-full cursor-pointer rounded-md p-3 text-left hover:bg-muted/50"
         >
-          <div className={cn("flex gap-3", isUnconfirmed && "animate-pulse")}>
+          <div className={cn("flex gap-3", isPending && "animate-pulse")}>
             {icon}
             <div className="mr-3 flex max-w-full flex-col items-start justify-center overflow-hidden text-left">
               <div className="flex items-center gap-2">
@@ -157,13 +157,13 @@ function OnchainTransactionRow({
       <DialogContent className="slashed-zero">
         <DialogHeader>
           <DialogTitle
-            className={cn(isUnconfirmed && "animate-pulse")}
+            className={cn(isPending && "animate-pulse")}
           >{`${typeStateText} On-chain Transaction`}</DialogTitle>
           <DialogDescription className="max-h-[90vh] overflow-y-auto pr-2 text-start text-foreground">
             <div
               className={cn(
                 "mt-6 flex items-center",
-                isUnconfirmed && "animate-pulse"
+                isPending && "animate-pulse"
               )}
             >
               {icon}

--- a/frontend/src/components/channels/OnchainTransactionsTable.tsx
+++ b/frontend/src/components/channels/OnchainTransactionsTable.tsx
@@ -244,7 +244,7 @@ export function OnchainTransactionsTable({
   contentClassName,
   showEmptyState = false,
   emptyStateTitle = "No on-chain transactions yet",
-  emptyStateDescription = "Your most recent incoming and outgoing on-chain payments will show up here.",
+  emptyStateDescription = "Your most recent incoming and outgoing on-chain transactions will show up here.",
   emptyStateButtonText = "Receive to On-chain Balance",
   emptyStateButtonLink = "/wallet/receive/onchain?type=onchain",
 }: OnchainTransactionsTableProps) {


### PR DESCRIPTION
## Summary
- treat unconfirmed on-chain transactions as pending in the Wallet UI without changing backend state values
- use the pending label in the details dialog while keeping the existing sending/receiving directional copy
- apply the lightning-style blue pending treatment consistently across the on-chain row and dialog states

## Test plan
- [x] cd frontend && yarn tsc:compile
- [ ] Broadcast an outgoing on-chain transaction and verify it renders with blue pending styling before confirmations
- [ ] Observe an incoming unconfirmed transaction and verify it renders as receiving/pending with blue styling
- [ ] Verify confirmed transactions still render with the existing sent/received colors

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction status labels now display "Pending" instead of "Unconfirmed" for improved clarity.
  * Visual loading indicators and styling now consistently reflect pending transaction states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->