### PR TITLE
chore: ignore google.golang.org/grpc updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: google.golang.org/grpc
   - package-ecosystem: npm
     directory: /frontend
     schedule:


### PR DESCRIPTION
We don't have to keep upgrading this as LND is the only place where we use it, so it only makes sense once LND upgrades it ([currently](https://github.com/lightningnetwork/lnd/blob/master/go.mod) at v.1.59.0 for v0.20.0-beta.rc4) - we are at v1.79.3 already so we should be good, I'll update it whenever we update LND manually :+1:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration for improved dependency management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->