### PR TITLE
fix: use file paths instead of hex during LND onboarding

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -9,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -1529,15 +1531,27 @@ func (api *api) Setup(ctx context.Context, setupRequest *SetupRequest) error {
 			return err
 		}
 	}
-	if setupRequest.LNDCertHex != "" {
-		err = api.cfg.SetUpdate("LNDCertHex", setupRequest.LNDCertHex, setupRequest.UnlockPassword)
+	if setupRequest.LNDCertFile != "" {
+		certBytes, err := os.ReadFile(setupRequest.LNDCertFile)
+		if err != nil {
+			logger.Logger.WithError(err).Error("Failed to read lnd cert file")
+			return err
+		}
+		certHex := hex.EncodeToString(certBytes)
+		err = api.cfg.SetUpdate("LNDCertHex", certHex, setupRequest.UnlockPassword)
 		if err != nil {
 			logger.Logger.WithError(err).Error("Failed to save lnd cert hex")
 			return err
 		}
 	}
-	if setupRequest.LNDMacaroonHex != "" {
-		err = api.cfg.SetUpdate("LNDMacaroonHex", setupRequest.LNDMacaroonHex, setupRequest.UnlockPassword)
+	if setupRequest.LNDMacaroonFile != "" {
+		macaroonBytes, err := os.ReadFile(setupRequest.LNDMacaroonFile)
+		if err != nil {
+			logger.Logger.WithError(err).Error("Failed to read lnd macaroon file")
+			return err
+		}
+		macaroonHex := hex.EncodeToString(macaroonBytes)
+		err = api.cfg.SetUpdate("LNDMacaroonHex", macaroonHex, setupRequest.UnlockPassword)
 		if err != nil {
 			logger.Logger.WithError(err).Error("Failed to save lnd macaroon hex")
 			return err

--- a/api/models.go
+++ b/api/models.go
@@ -248,8 +248,6 @@ type SetupRequest struct {
 	LNDAddress      string `json:"lndAddress"`
 	LNDCertFile     string `json:"lndCertFile"`
 	LNDMacaroonFile string `json:"lndMacaroonFile"`
-	LNDCertHex      string `json:"lndCertHex"`
-	LNDMacaroonHex  string `json:"lndMacaroonHex"`
 
 	// Phoenixd fields
 	PhoenixdAddress       string `json:"phoenixdAddress"`

--- a/frontend/src/screens/setup/node/LNDForm.tsx
+++ b/frontend/src/screens/setup/node/LNDForm.tsx
@@ -14,11 +14,11 @@ export function LNDForm() {
   const [lndAddress, setLndAddress] = React.useState<string>(
     setupStore.nodeInfo.lndAddress || ""
   );
-  const [lndCertHex, setLndCertHex] = React.useState<string>(
-    setupStore.nodeInfo.lndCertHex || ""
+  const [lndCertFile, setLndCertFile] = React.useState<string>(
+    setupStore.nodeInfo.lndCertFile || ""
   );
-  const [lndMacaroonHex, setLndMacaroonHex] = React.useState<string>(
-    setupStore.nodeInfo.lndMacaroonHex || ""
+  const [lndMacaroonFile, setLndMacaroonFile] = React.useState<string>(
+    setupStore.nodeInfo.lndMacaroonFile || ""
   );
 
   // TODO: proper onboarding
@@ -26,8 +26,8 @@ export function LNDForm() {
     e.preventDefault();
     handleSubmit({
       lndAddress,
-      lndCertHex,
-      lndMacaroonHex,
+      lndCertFile,
+      lndMacaroonFile,
     });
   }
 
@@ -58,26 +58,28 @@ export function LNDForm() {
           />
         </div>
         <div className="grid gap-1.5">
-          <Label htmlFor="lnd-macaroon-hex">Admin Macaroon (Hex)</Label>
+          <Label htmlFor="lnd-macaroon-file">Admin Macaroon File Path</Label>
           <Input
             required
-            name="lnd-macaroon-hex"
-            onChange={(e) => setLndMacaroonHex(e.target.value)}
-            value={lndMacaroonHex}
+            name="lnd-macaroon-file"
+            onChange={(e) => setLndMacaroonFile(e.target.value)}
+            value={lndMacaroonFile}
             type="text"
-            id="lnd-macaroon-hex"
+            id="lnd-macaroon-file"
           />
         </div>
         <div className="grid gap-1.5">
-          <Label htmlFor="lnd-cert-hex">TLS Certificate (Hex) (optional)</Label>
+          <Label htmlFor="lnd-cert-file">
+            TLS Certificate File Path (optional)
+          </Label>
           <Input
-            name="lnd-cert-hex"
-            onChange={(e) => setLndCertHex(e.target.value)}
-            value={lndCertHex}
+            name="lnd-cert-file"
+            onChange={(e) => setLndCertFile(e.target.value)}
+            value={lndCertFile}
             type="text"
-            id="lnd-cert-hex"
+            id="lnd-cert-file"
           />
-          {!lndCertHex && (
+          {!lndCertFile && (
             <div className="flex flex-row gap-2 items-center justify-start text-sm text-muted-foreground mt-2">
               <InfoIcon className="h-4 w-4 shrink-0" />
               Skipping TLS certificate is not recommended as it may expose your

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -439,8 +439,8 @@ export type SetupNodeInfo = Partial<{
   nextBackupReminder?: string;
 
   lndAddress?: string;
-  lndCertHex?: string;
-  lndMacaroonHex?: string;
+  lndCertFile?: string;
+  lndMacaroonFile?: string;
 
   phoenixdAddress?: string;
   phoenixdAuthorization?: string;


### PR DESCRIPTION
Fixes #1968 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LND node setup now accepts TLS certificate and admin macaroon credentials as file uploads instead of hex string inputs, streamlining the credential configuration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->