### PR TITLE
fix(frontend): use npx skills add for agent skill install prompts

### DIFF
--- a/frontend/src/screens/ai/AI.tsx
+++ b/frontend/src/screens/ai/AI.tsx
@@ -730,7 +730,8 @@ const inspirationCategories: {
       "build a blog where readers unlock articles for 50 sats each",
     ],
     skill: {
-      prompt: "Install the skill from https://github.com/getAlby/builder-skill",
+      prompt:
+        "Run `npx -y skills add getAlby/builder-skill -y` to install the Builder Skill",
       skillName: "Builder Skill",
       url: "https://github.com/getAlby/builder-skill",
     },
@@ -744,7 +745,8 @@ const inspirationCategories: {
       "what's my node's connection info?",
     ],
     skill: {
-      prompt: "Install the skill from https://github.com/getAlby/hub-skill",
+      prompt:
+        "Run `npx -y skills add getAlby/hub-skill -y` to install the Alby Hub Skill",
       skillName: "Alby Hub Skill",
       url: "https://github.com/getAlby/hub-skill",
     },

--- a/frontend/src/screens/ai/AI.tsx
+++ b/frontend/src/screens/ai/AI.tsx
@@ -688,7 +688,8 @@ const inspirationCategories: {
       "what gift cards are available in the US on bitrefill.com?",
     ],
     skill: {
-      prompt: "Install the skill from https://bitrefill.com/agents",
+      prompt:
+        "Run `npx -y skills add bitrefill/agents -y` to install the Bitrefill Skill",
       skillName: "Bitrefill Skill",
       url: "https://bitrefill.com/agents",
     },


### PR DESCRIPTION
## Summary
- Changed builder-skill and hub-skill install prompts from `"Install the skill from https://..."` to `"Run \`npx -y skills add ...\`"` commands
- Agents were WebFetching the GitHub URLs and summarizing the skill content, losing important details (skills explicitly say "DO NOT SUMMARIZE")
- Now matches the pattern already used for payments-skill on the same page

## Test plan
- [ ] Verify the "Build Apps" and "Node" tabs in the AI & Agents inspiration section show the updated prompt text
- [ ] Copy the prompt and paste into an agent — confirm it runs the npx command instead of fetching a URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions for Builder Skill and Alby Hub Skill with explicit CLI command format for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->