### PR TITLE
Adding explicit Sat/Msat suffixes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -692,15 +692,15 @@ func (api *api) ListChannels(ctx context.Context) ([]Channel, error) {
 		}
 
 		apiChannels = append(apiChannels, Channel{
-			LocalBalance:                             channel.LocalBalance,
-			LocalBalanceSat:                          channel.LocalBalance / 1000,
-			LocalBalanceMsat:                         channel.LocalBalance,
-			LocalSpendableBalance:                    channel.LocalSpendableBalance,
-			LocalSpendableBalanceSat:                 channel.LocalSpendableBalance / 1000,
-			LocalSpendableBalanceMsat:                channel.LocalSpendableBalance,
-			RemoteBalance:                            channel.RemoteBalance,
-			RemoteBalanceSat:                         channel.RemoteBalance / 1000,
-			RemoteBalanceMsat:                        channel.RemoteBalance,
+			LocalBalance:                             channel.LocalBalanceMsat,
+			LocalBalanceSat:                          channel.LocalBalanceMsat / 1000,
+			LocalBalanceMsat:                         channel.LocalBalanceMsat,
+			LocalSpendableBalance:                    channel.LocalSpendableBalanceMsat,
+			LocalSpendableBalanceSat:                 channel.LocalSpendableBalanceMsat / 1000,
+			LocalSpendableBalanceMsat:                channel.LocalSpendableBalanceMsat,
+			RemoteBalance:                            channel.RemoteBalanceMsat,
+			RemoteBalanceSat:                         channel.RemoteBalanceMsat / 1000,
+			RemoteBalanceMsat:                        channel.RemoteBalanceMsat,
 			Id:                                       channel.Id,
 			RemotePubkey:                             channel.RemotePubkey,
 			FundingTxId:                              channel.FundingTxId,
@@ -712,10 +712,10 @@ func (api *api) ListChannels(ctx context.Context) ([]Channel, error) {
 			ConfirmationsRequired:                    channel.ConfirmationsRequired,
 			ForwardingFeeBaseMsat:                    channel.ForwardingFeeBaseMsat,
 			ForwardingFeeProportionalMillionths:      channel.ForwardingFeeProportionalMillionths,
-			UnspendablePunishmentReserve:             channel.UnspendablePunishmentReserve,
-			UnspendablePunishmentReserveSat:          channel.UnspendablePunishmentReserve,
-			CounterpartyUnspendablePunishmentReserve: channel.CounterpartyUnspendablePunishmentReserve,
-			CounterpartyUnspendablePunishmentReserveSat: channel.CounterpartyUnspendablePunishmentReserve,
+			UnspendablePunishmentReserve:             channel.UnspendablePunishmentReserveSat,
+			UnspendablePunishmentReserveSat:          channel.UnspendablePunishmentReserveSat,
+			CounterpartyUnspendablePunishmentReserve: channel.CounterpartyUnspendablePunishmentReserveSat,
+			CounterpartyUnspendablePunishmentReserveSat: channel.CounterpartyUnspendablePunishmentReserveSat,
 			Error:      channel.Error,
 			IsOutbound: channel.IsOutbound,
 			Status:     status,
@@ -913,10 +913,10 @@ func toApiSwap(swap *swaps.Swap) *Swap {
 		Type:               swap.Type,
 		State:              swap.State,
 		Invoice:            swap.Invoice,
-		SendAmount:         swap.SendAmount,
-		SendAmountSat:      swap.SendAmount,
-		ReceiveAmount:      swap.ReceiveAmount,
-		ReceiveAmountSat:   swap.ReceiveAmount,
+		SendAmount:         swap.SendAmountSat,
+		SendAmountSat:      swap.SendAmountSat,
+		ReceiveAmount:      swap.ReceiveAmountSat,
+		ReceiveAmountSat:   swap.ReceiveAmountSat,
 		PaymentHash:        swap.PaymentHash,
 		DestinationAddress: swap.DestinationAddress,
 		RefundAddress:      swap.RefundAddress,
@@ -985,7 +985,7 @@ func (api *api) InitiateSwapOut(ctx context.Context, initiateSwapOutRequest *Ini
 		return nil, errors.New("SwapsService not started")
 	}
 
-	amount := initiateSwapOutRequest.SwapAmount
+	amount := initiateSwapOutRequest.ResolvedSwapAmountSat()
 	destination := initiateSwapOutRequest.Destination
 
 	if amount == 0 {
@@ -1014,7 +1014,7 @@ func (api *api) InitiateSwapIn(ctx context.Context, initiateSwapInRequest *Initi
 		return nil, errors.New("SwapsService not started")
 	}
 
-	amount := initiateSwapInRequest.SwapAmount
+	amount := initiateSwapInRequest.ResolvedSwapAmountSat()
 
 	if amount == 0 {
 		return nil, errors.New("invalid swap amount")
@@ -1056,13 +1056,13 @@ func (api *api) EnableAutoSwapOut(ctx context.Context, enableAutoSwapsRequest *E
 		}
 	}
 
-	err := api.cfg.SetUpdate(config.AutoSwapBalanceThresholdKey, strconv.FormatUint(enableAutoSwapsRequest.BalanceThreshold, 10), "")
+	err := api.cfg.SetUpdate(config.AutoSwapBalanceThresholdKey, strconv.FormatUint(enableAutoSwapsRequest.ResolvedBalanceThresholdSat(), 10), "")
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to save autoswap balance threshold to config")
 		return err
 	}
 
-	err = api.cfg.SetUpdate(config.AutoSwapAmountKey, strconv.FormatUint(enableAutoSwapsRequest.SwapAmount, 10), "")
+	err = api.cfg.SetUpdate(config.AutoSwapAmountKey, strconv.FormatUint(enableAutoSwapsRequest.ResolvedSwapAmountSat(), 10), "")
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to save autoswap amount to config")
 		return err
@@ -1677,7 +1677,7 @@ func (api *api) SendSpontaneousPaymentProbes(ctx context.Context, sendSpontaneou
 	}
 
 	var errMessage string
-	err := lnClient.SendSpontaneousPaymentProbes(ctx, sendSpontaneousPaymentProbesRequest.Amount, sendSpontaneousPaymentProbesRequest.NodeId)
+	err := lnClient.SendSpontaneousPaymentProbes(ctx, sendSpontaneousPaymentProbesRequest.ResolvedAmountMsat(), sendSpontaneousPaymentProbesRequest.NodeId)
 	if err != nil {
 		errMessage = err.Error()
 	}

--- a/api/lsp.go
+++ b/api/lsp.go
@@ -59,7 +59,7 @@ func (api *api) RequestLSPOrder(ctx context.Context, request *LSPOrderRequest) (
 
 	invoice, feeSat, err := api.requestLSPS1Invoice(ctx, lnClient, request, nodeInfo.Network, nodeInfo.Pubkey, lspInfo.MaxChannelExpiryBlocks, lspInfo.MinRequiredChannelConfirmations, lspInfo.MinFundingConfirmsWithinBlocks)
 	invoiceAmountSat := uint64(0)
-	incomingLiquiditySat := request.Amount
+	incomingLiquiditySat := request.ResolvedAmountSat()
 
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to request invoice")
@@ -142,7 +142,7 @@ func (api *api) requestLSPS1Invoice(ctx context.Context, lnClient lnclient.LNCli
 
 	lsps1ChannelRequest := &alby.LSPChannelRequest{
 		PublicKey:                    pubkey,
-		LSPBalanceSat:                strconv.FormatUint(request.Amount, 10),
+		LSPBalanceSat:                strconv.FormatUint(request.ResolvedAmountSat(), 10),
 		ClientBalanceSat:             "0",
 		RequiredChannelConfirmations: requiredChannelConfirmations,
 		FundingConfirmsWithinBlocks:  minFundingConfirmsWithinBlocks,

--- a/api/models.go
+++ b/api/models.go
@@ -167,8 +167,9 @@ type CreateLightningAddressRequest struct {
 }
 
 type InitiateSwapRequest struct {
-	SwapAmount  uint64 `json:"swapAmount"`
-	Destination string `json:"destination"`
+	SwapAmount    uint64 `json:"swapAmount"` // deprecated: use swapAmountSat
+	SwapAmountSat uint64 `json:"swapAmountSat"`
+	Destination   string `json:"destination"`
 }
 
 type RefundSwapRequest struct {
@@ -177,11 +178,13 @@ type RefundSwapRequest struct {
 }
 
 type EnableAutoSwapRequest struct {
-	BalanceThreshold uint64 `json:"balanceThreshold"`
-	SwapAmount       uint64 `json:"swapAmount"`
-	Destination      string `json:"destination"`
-	DestinationType  string `json:"destinationType"`
-	UnlockPassword   string `json:"unlockPassword"`
+	BalanceThreshold    uint64 `json:"balanceThreshold"` // deprecated: use balanceThresholdSat
+	BalanceThresholdSat uint64 `json:"balanceThresholdSat"`
+	SwapAmount          uint64 `json:"swapAmount"` // deprecated: use swapAmountSat
+	SwapAmountSat       uint64 `json:"swapAmountSat"`
+	Destination         string `json:"destination"`
+	DestinationType     string `json:"destinationType"`
+	UnlockPassword      string `json:"unlockPassword"`
 }
 
 type GetAutoSwapConfigResponse struct {
@@ -366,10 +369,12 @@ type RebalanceChannelResponse struct {
 }
 
 type RedeemOnchainFundsRequest struct {
-	ToAddress string  `json:"toAddress"`
-	Amount    uint64  `json:"amount"`
-	FeeRate   *uint64 `json:"feeRate"`
-	SendAll   bool    `json:"sendAll"`
+	ToAddress          string  `json:"toAddress"`
+	Amount             uint64  `json:"amount"` // deprecated: use amountSat (on-chain sats)
+	AmountSat          uint64  `json:"amountSat"`
+	FeeRate            *uint64 `json:"feeRate"` // deprecated: use feeRateSatPerVbyte
+	FeeRateSatPerVbyte *uint64 `json:"feeRateSatPerVbyte"`
+	SendAll            bool    `json:"sendAll"`
 }
 
 type RedeemOnchainFundsResponse struct {
@@ -442,8 +447,9 @@ type SendPaymentProbesResponse struct {
 }
 
 type SendSpontaneousPaymentProbesRequest struct {
-	Amount uint64 `json:"amount"`
-	NodeId string `json:"nodeId"`
+	Amount     uint64 `json:"amount"` // deprecated: use amountMsat
+	AmountMsat uint64 `json:"amountMsat"`
+	NodeId     string `json:"nodeId"`
 }
 
 type SendSpontaneousPaymentProbesResponse struct {
@@ -473,8 +479,9 @@ type SignMessageResponse struct {
 }
 
 type PayInvoiceRequest struct {
-	Amount   *uint64  `json:"amount"`
-	Metadata Metadata `json:"metadata"`
+	Amount     *uint64  `json:"amount"` // deprecated: use amountMsat
+	AmountMsat *uint64  `json:"amountMsat"`
+	Metadata   Metadata `json:"metadata"`
 }
 
 type MakeOfferRequest struct {
@@ -482,8 +489,9 @@ type MakeOfferRequest struct {
 }
 
 type MakeInvoiceRequest struct {
-	Amount      uint64 `json:"amount"`
-	Description string `json:"description"`
+	Amount      uint64  `json:"amount"` // deprecated: use amountMsat when set
+	AmountMsat  *uint64 `json:"amountMsat"`
+	Description string  `json:"description"`
 }
 
 type ResetRouterRequest struct {
@@ -501,7 +509,8 @@ type BasicRestoreWailsRequest struct {
 type NetworkGraphResponse = lnclient.NetworkGraphResponse
 
 type LSPOrderRequest struct {
-	Amount        uint64 `json:"amount"`
+	Amount        uint64 `json:"amount"` // deprecated: use amountSat
+	AmountSat     uint64 `json:"amountSat"`
 	LSPType       string `json:"lspType"`
 	LSPIdentifier string `json:"lspIdentifier"`
 	Public        bool   `json:"public"`

--- a/api/request_resolve.go
+++ b/api/request_resolve.go
@@ -1,0 +1,94 @@
+package api
+
+// Request field resolvers: prefer explicit *Sat / *Msat JSON fields when set,
+// otherwise fall back to deprecated names (issue #2223).
+
+func (r *PayInvoiceRequest) ResolvedAmountMsat() *uint64 {
+	if r == nil {
+		return nil
+	}
+	if r.AmountMsat != nil {
+		return r.AmountMsat
+	}
+	return r.Amount
+}
+
+func (r *MakeInvoiceRequest) ResolvedAmountMsat() uint64 {
+	if r == nil {
+		return 0
+	}
+	if r.AmountMsat != nil {
+		return *r.AmountMsat
+	}
+	return r.Amount
+}
+
+func (r *SendSpontaneousPaymentProbesRequest) ResolvedAmountMsat() uint64 {
+	if r == nil {
+		return 0
+	}
+	if r.AmountMsat != 0 {
+		return r.AmountMsat
+	}
+	return r.Amount
+}
+
+func (r *LSPOrderRequest) ResolvedAmountSat() uint64 {
+	if r == nil {
+		return 0
+	}
+	if r.AmountSat != 0 {
+		return r.AmountSat
+	}
+	return r.Amount
+}
+
+func (r *RedeemOnchainFundsRequest) ResolvedAmountSat() uint64 {
+	if r == nil {
+		return 0
+	}
+	if r.AmountSat != 0 {
+		return r.AmountSat
+	}
+	return r.Amount
+}
+
+func (r *RedeemOnchainFundsRequest) ResolvedFeeRateSatPerVbyte() *uint64 {
+	if r == nil {
+		return nil
+	}
+	if r.FeeRateSatPerVbyte != nil {
+		return r.FeeRateSatPerVbyte
+	}
+	return r.FeeRate
+}
+
+func (r *InitiateSwapRequest) ResolvedSwapAmountSat() uint64 {
+	if r == nil {
+		return 0
+	}
+	if r.SwapAmountSat != 0 {
+		return r.SwapAmountSat
+	}
+	return r.SwapAmount
+}
+
+func (r *EnableAutoSwapRequest) ResolvedBalanceThresholdSat() uint64 {
+	if r == nil {
+		return 0
+	}
+	if r.BalanceThresholdSat != 0 {
+		return r.BalanceThresholdSat
+	}
+	return r.BalanceThreshold
+}
+
+func (r *EnableAutoSwapRequest) ResolvedSwapAmountSat() uint64 {
+	if r == nil {
+		return 0
+	}
+	if r.SwapAmountSat != 0 {
+		return r.SwapAmountSat
+	}
+	return r.SwapAmount
+}

--- a/api/request_resolve_test.go
+++ b/api/request_resolve_test.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/getAlby/hub/swaps"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPayInvoiceRequestResolvedAmountMsat(t *testing.T) {
+	deprecated := uint64(1000)
+	explicit := uint64(2000)
+
+	require.Nil(t, (*PayInvoiceRequest)(nil).ResolvedAmountMsat())
+	require.Equal(t, &deprecated, (&PayInvoiceRequest{Amount: &deprecated}).ResolvedAmountMsat())
+	require.Equal(t, &explicit, (&PayInvoiceRequest{Amount: &deprecated, AmountMsat: &explicit}).ResolvedAmountMsat())
+}
+
+func TestMakeInvoiceRequestResolvedAmountMsat(t *testing.T) {
+	explicit := uint64(2000)
+
+	require.Equal(t, uint64(0), (*MakeInvoiceRequest)(nil).ResolvedAmountMsat())
+	require.Equal(t, uint64(1000), (&MakeInvoiceRequest{Amount: 1000}).ResolvedAmountMsat())
+	require.Equal(t, explicit, (&MakeInvoiceRequest{Amount: 1000, AmountMsat: &explicit}).ResolvedAmountMsat())
+}
+
+func TestSendSpontaneousPaymentProbesRequestResolvedAmountMsat(t *testing.T) {
+	require.Equal(t, uint64(0), (*SendSpontaneousPaymentProbesRequest)(nil).ResolvedAmountMsat())
+	require.Equal(t, uint64(1000), (&SendSpontaneousPaymentProbesRequest{Amount: 1000}).ResolvedAmountMsat())
+	require.Equal(t, uint64(2000), (&SendSpontaneousPaymentProbesRequest{Amount: 1000, AmountMsat: 2000}).ResolvedAmountMsat())
+}
+
+func TestLSPOrderRequestResolvedAmountSat(t *testing.T) {
+	require.Equal(t, uint64(0), (*LSPOrderRequest)(nil).ResolvedAmountSat())
+	require.Equal(t, uint64(1000), (&LSPOrderRequest{Amount: 1000}).ResolvedAmountSat())
+	require.Equal(t, uint64(2000), (&LSPOrderRequest{Amount: 1000, AmountSat: 2000}).ResolvedAmountSat())
+}
+
+func TestRedeemOnchainFundsRequestResolvedFields(t *testing.T) {
+	deprecatedFeeRate := uint64(5)
+	explicitFeeRate := uint64(10)
+
+	require.Equal(t, uint64(0), (*RedeemOnchainFundsRequest)(nil).ResolvedAmountSat())
+	require.Nil(t, (*RedeemOnchainFundsRequest)(nil).ResolvedFeeRateSatPerVbyte())
+
+	req := &RedeemOnchainFundsRequest{
+		Amount:  1000,
+		FeeRate: &deprecatedFeeRate,
+	}
+	require.Equal(t, uint64(1000), req.ResolvedAmountSat())
+	require.Equal(t, &deprecatedFeeRate, req.ResolvedFeeRateSatPerVbyte())
+
+	req.AmountSat = 2000
+	req.FeeRateSatPerVbyte = &explicitFeeRate
+	require.Equal(t, uint64(2000), req.ResolvedAmountSat())
+	require.Equal(t, &explicitFeeRate, req.ResolvedFeeRateSatPerVbyte())
+}
+
+func TestInitiateSwapRequestResolvedSwapAmountSat(t *testing.T) {
+	require.Equal(t, uint64(0), (*InitiateSwapRequest)(nil).ResolvedSwapAmountSat())
+	require.Equal(t, uint64(1000), (&InitiateSwapRequest{SwapAmount: 1000}).ResolvedSwapAmountSat())
+	require.Equal(t, uint64(2000), (&InitiateSwapRequest{SwapAmount: 1000, SwapAmountSat: 2000}).ResolvedSwapAmountSat())
+}
+
+func TestEnableAutoSwapRequestResolvedFields(t *testing.T) {
+	require.Equal(t, uint64(0), (*EnableAutoSwapRequest)(nil).ResolvedBalanceThresholdSat())
+	require.Equal(t, uint64(0), (*EnableAutoSwapRequest)(nil).ResolvedSwapAmountSat())
+
+	req := &EnableAutoSwapRequest{
+		BalanceThreshold: 1000,
+		SwapAmount:       2000,
+	}
+	require.Equal(t, uint64(1000), req.ResolvedBalanceThresholdSat())
+	require.Equal(t, uint64(2000), req.ResolvedSwapAmountSat())
+
+	req.BalanceThresholdSat = 3000
+	req.SwapAmountSat = 4000
+	require.Equal(t, uint64(3000), req.ResolvedBalanceThresholdSat())
+	require.Equal(t, uint64(4000), req.ResolvedSwapAmountSat())
+}
+
+func TestToApiSwapUsesSatFieldsAndKeepsDeprecatedAliases(t *testing.T) {
+	now := time.Now()
+	dbSwap := &swaps.Swap{
+		SwapId:             "swap-id",
+		Type:               "out",
+		State:              "pending",
+		Invoice:            "invoice",
+		SendAmountSat:      123,
+		ReceiveAmountSat:   456,
+		PaymentHash:        "payment-hash",
+		DestinationAddress: "destination",
+		RefundAddress:      "refund",
+		LockupAddress:      "lockup",
+		LockupTxId:         "lockup-tx",
+		ClaimTxId:          "claim-tx",
+		AutoSwap:           true,
+		BoltzPubkey:        "boltz-pubkey",
+		CreatedAt:          now,
+		UpdatedAt:          now,
+		UsedXpub:           true,
+	}
+
+	apiSwap := toApiSwap(dbSwap)
+	require.Equal(t, uint64(123), apiSwap.SendAmount)
+	require.Equal(t, uint64(123), apiSwap.SendAmountSat)
+	require.Equal(t, uint64(456), apiSwap.ReceiveAmount)
+	require.Equal(t, uint64(456), apiSwap.ReceiveAmountSat)
+}

--- a/db/models.go
+++ b/db/models.go
@@ -97,8 +97,8 @@ type Swap struct {
 	Type               string
 	State              string
 	Invoice            string
-	SendAmount         uint64
-	ReceiveAmount      uint64
+	SendAmountSat      uint64 `gorm:"column:send_amount"`
+	ReceiveAmountSat   uint64 `gorm:"column:receive_amount"`
 	Preimage           string
 	PaymentHash        string
 	DestinationAddress string

--- a/http/http_service.go
+++ b/http/http_service.go
@@ -641,7 +641,7 @@ func (httpSvc *HttpService) sendPaymentHandler(c echo.Context) error {
 		})
 	}
 
-	paymentResponse, err := httpSvc.api.SendPayment(ctx, c.Param("invoice"), payInvoiceRequest.Amount, payInvoiceRequest.Metadata)
+	paymentResponse, err := httpSvc.api.SendPayment(ctx, c.Param("invoice"), payInvoiceRequest.ResolvedAmountMsat(), payInvoiceRequest.Metadata)
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{
@@ -681,7 +681,7 @@ func (httpSvc *HttpService) makeInvoiceHandler(c echo.Context) error {
 		})
 	}
 
-	invoice, err := httpSvc.api.CreateInvoice(c.Request().Context(), makeInvoiceRequest.Amount, makeInvoiceRequest.Description)
+	invoice, err := httpSvc.api.CreateInvoice(c.Request().Context(), makeInvoiceRequest.ResolvedAmountMsat(), makeInvoiceRequest.Description)
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{
@@ -979,7 +979,7 @@ func (httpSvc *HttpService) redeemOnchainFundsHandler(c echo.Context) error {
 		})
 	}
 
-	redeemOnchainFundsResponse, err := httpSvc.api.RedeemOnchainFunds(ctx, redeemOnchainFundsRequest.ToAddress, redeemOnchainFundsRequest.Amount, redeemOnchainFundsRequest.FeeRate, redeemOnchainFundsRequest.SendAll)
+	redeemOnchainFundsResponse, err := httpSvc.api.RedeemOnchainFunds(ctx, redeemOnchainFundsRequest.ToAddress, redeemOnchainFundsRequest.ResolvedAmountSat(), redeemOnchainFundsRequest.ResolvedFeeRateSatPerVbyte(), redeemOnchainFundsRequest.SendAll)
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{

--- a/lnclient/cashu/cashu.go
+++ b/lnclient/cashu/cashu.go
@@ -71,9 +71,9 @@ func (cs *CashuService) Shutdown() error {
 	return cs.wallet.Shutdown()
 }
 
-func (cs *CashuService) SendPaymentSync(invoice string, amount *uint64) (response *lnclient.PayInvoiceResponse, err error) {
+func (cs *CashuService) SendPaymentSync(invoice string, amountMsat *uint64) (response *lnclient.PayInvoiceResponse, err error) {
 	// TODO: support 0-amount invoices
-	if amount != nil {
+	if amountMsat != nil {
 		return nil, errors.New("0-amount invoices not supported")
 	}
 
@@ -93,23 +93,31 @@ func (cs *CashuService) SendPaymentSync(invoice string, amount *uint64) (respons
 		return nil, errors.New("no preimage in melt response")
 	}
 	fee := meltResponse.FeeReserve - meltResponse.Change.Amount()
+	feeMsat := fee * 1000
 
 	return &lnclient.PayInvoiceResponse{
 		Preimage: meltResponse.Preimage,
-		Fee:      fee * 1000,
+		Fee:      feeMsat,
+		FeeMsat:  feeMsat,
 	}, nil
 }
 
-func (cs *CashuService) SendKeysend(amount uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
+func (cs *CashuService) SendKeysend(amountMsat uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
 	return nil, errors.New("keysend not supported")
 }
 
-func (cs *CashuService) MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
+func (cs *CashuService) MakeInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
 	// TODO: support expiry
 	if expiry == 0 {
 		expiry = lnclient.DEFAULT_INVOICE_EXPIRY
 	}
-	mintResponse, err := cs.wallet.RequestMint(uint64(amount/1000), cs.wallet.CurrentMint())
+	if amountMsat <= 0 {
+		return nil, errors.New("amountMsat must be positive")
+	}
+	if amountMsat%1000 != 0 {
+		return nil, errors.New("cashu only supports sat-granular amounts")
+	}
+	mintResponse, err := cs.wallet.RequestMint(uint64(amountMsat/1000), cs.wallet.CurrentMint())
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to mint")
 		return nil, err
@@ -119,7 +127,7 @@ func (cs *CashuService) MakeInvoice(ctx context.Context, amount int64, descripti
 	return cs.cashuMintQuoteToTransaction(mintQuote), nil
 }
 
-func (cs *CashuService) MakeHoldInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *lnclient.Transaction, err error) {
+func (cs *CashuService) MakeHoldInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *lnclient.Transaction, err error) {
 	_ = minCltvExpiryDelta
 	return nil, errors.New("not implemented")
 }
@@ -190,7 +198,7 @@ func (cs *CashuService) GetOnchainBalance(ctx context.Context) (*lnclient.Onchai
 	return &lnclient.OnchainBalanceResponse{}, nil
 }
 
-func (cs *CashuService) RedeemOnchainFunds(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool) (string, error) {
+func (cs *CashuService) RedeemOnchainFunds(ctx context.Context, toAddress string, amountSat uint64, feeRateSatPerVbyte *uint64, sendAll bool) (string, error) {
 	return "", nil
 }
 
@@ -301,7 +309,7 @@ func (cs *CashuService) cashuMintQuoteToTransaction(mintQuote *storage.MintQuote
 		PaymentHash: paymentRequest.PaymentHash,
 		// note: setting dummy preimage so that it gets marked as settled
 		Preimage:        paymentRequest.PaymentHash,
-		Amount:          paymentRequest.MSatoshi,
+		AmountMsat:      paymentRequest.MSatoshi,
 		CreatedAt:       int64(paymentRequest.CreatedAt),
 		ExpiresAt:       expiresAt,
 		Description:     description,
@@ -330,14 +338,14 @@ func (cs *CashuService) cashuMeltQuoteToTransaction(meltQuote *storage.MeltQuote
 		Type:            constants.TRANSACTION_TYPE_OUTGOING,
 		Invoice:         meltQuote.PaymentRequest,
 		PaymentHash:     paymentRequest.PaymentHash,
-		Amount:          paymentRequest.MSatoshi,
+		AmountMsat:      paymentRequest.MSatoshi,
 		CreatedAt:       int64(paymentRequest.CreatedAt),
 		ExpiresAt:       expiresAt,
 		Description:     description,
 		DescriptionHash: descriptionHash,
 		Preimage:        meltQuote.Preimage,
 		SettledAt:       settledAt,
-		FeesPaid:        int64(meltQuote.FeeReserve * 1000),
+		FeesPaidMsat:    int64(meltQuote.FeeReserve * 1000),
 	}
 }
 

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -494,7 +494,7 @@ func (ls *LDKService) MakeOffer(ctx context.Context, description string) (string
 	return offer.String(), nil
 }
 
-func (ls *LDKService) SendPaymentSync(invoice string, amount *uint64) (*lnclient.PayInvoiceResponse, error) {
+func (ls *LDKService) SendPaymentSync(invoice string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
 	paymentRequest, err := decodepay.Decodepay(invoice)
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
@@ -505,8 +505,8 @@ func (ls *LDKService) SendPaymentSync(invoice string, amount *uint64) (*lnclient
 	}
 
 	paymentAmountMsat := uint64(paymentRequest.MSatoshi)
-	if amount != nil {
-		paymentAmountMsat = *amount
+	if amountMsat != nil {
+		paymentAmountMsat = *amountMsat
 	}
 
 	maxSpendable := ls.getMaxSpendable()
@@ -544,10 +544,10 @@ func (ls *LDKService) SendPaymentSync(invoice string, amount *uint64) (*lnclient
 	}
 
 	var paymentHash string
-	if amount == nil {
+	if amountMsat == nil {
 		paymentHash, err = ls.node.Bolt11Payment().Send(invoiceObj, routeParameters)
 	} else {
-		paymentHash, err = ls.node.Bolt11Payment().SendUsingAmount(invoiceObj, *amount, routeParameters)
+		paymentHash, err = ls.node.Bolt11Payment().SendUsingAmount(invoiceObj, *amountMsat, routeParameters)
 	}
 	if err != nil {
 		logger.Logger.WithError(err).Error("SendPayment failed")
@@ -591,6 +591,7 @@ func (ls *LDKService) SendPaymentSync(invoice string, amount *uint64) (*lnclient
 				return &lnclient.PayInvoiceResponse{
 					Preimage: preimage,
 					Fee:      feeMsat,
+					FeeMsat:  feeMsat,
 				}, nil
 			case ldk_node.EventPaymentFailed:
 				if event.PaymentHash != nil && *event.PaymentHash == paymentHash {
@@ -606,7 +607,7 @@ func (ls *LDKService) SendPaymentSync(invoice string, amount *uint64) (*lnclient
 	}
 }
 
-func (ls *LDKService) SendKeysend(amount uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
+func (ls *LDKService) SendKeysend(amountMsat uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
 	paymentStart := time.Now()
 	customTlvs := []ldk_node.CustomTlvRecord{}
 
@@ -626,7 +627,7 @@ func (ls *LDKService) SendKeysend(amount uint64, destination string, custom_reco
 
 	saturationPower := ls.cfg.GetEnv().LDKMaxChannelSaturationPowerOfHalf
 	maxPathCount := ls.cfg.GetEnv().LDKMaxPathCount
-	maxTotalRoutingFeeMsat := getMaxTotalRoutingFeeLimit(amount)
+	maxTotalRoutingFeeMsat := getMaxTotalRoutingFeeLimit(amountMsat)
 
 	routeParameters := &ldk_node.RouteParametersConfig{
 		MaxTotalRoutingFeeMsat:          &maxTotalRoutingFeeMsat,
@@ -635,7 +636,7 @@ func (ls *LDKService) SendKeysend(amount uint64, destination string, custom_reco
 		MaxTotalCltvExpiryDelta:         1008, // TODO: remove and use default
 	}
 
-	paymentHash, err := ls.node.SpontaneousPayment().SendWithPreimageAndCustomTlvs(amount, destination, customTlvs, preimage, routeParameters)
+	paymentHash, err := ls.node.SpontaneousPayment().SendWithPreimageAndCustomTlvs(amountMsat, destination, customTlvs, preimage, routeParameters)
 	if err != nil {
 		logger.Logger.WithError(err).Error("Keysend failed")
 		return nil, err
@@ -661,7 +662,8 @@ func (ls *LDKService) SendKeysend(amount uint64, destination string, custom_reco
 					"fee":      feeMsat,
 				}).Info("Successful keysend payment")
 				return &lnclient.PayKeysendResponse{
-					Fee: feeMsat,
+					Fee:     feeMsat,
+					FeeMsat: feeMsat,
 				}, nil
 			}
 			if isEventPaymentFailedEvent && eventPaymentFailed.PaymentHash != nil && *eventPaymentFailed.PaymentHash == paymentHash {
@@ -702,7 +704,7 @@ func (ls *LDKService) getMaxSpendable() uint64 {
 	return spendable
 }
 
-func (ls *LDKService) MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
+func (ls *LDKService) MakeInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
 
 	if time.Duration(expiry)*time.Second > maxInvoiceExpiry {
 		return nil, errors.New("expiry is too long")
@@ -710,7 +712,7 @@ func (ls *LDKService) MakeInvoice(ctx context.Context, amount int64, description
 
 	maxReceivable := ls.getMaxReceivable()
 
-	if amount > maxReceivable {
+	if amountMsat > maxReceivable {
 		ls.eventPublisher.Publish(&events.Event{
 			Event: "nwc_incoming_liquidity_required",
 			Properties: map[string]interface{}{
@@ -736,7 +738,7 @@ func (ls *LDKService) MakeInvoice(ctx context.Context, amount int64, description
 		}
 	}
 
-	invoiceObj, err := ls.node.Bolt11Payment().Receive(uint64(amount),
+	invoiceObj, err := ls.node.Bolt11Payment().Receive(uint64(amountMsat),
 		descriptionType,
 		uint32(expiry))
 
@@ -762,7 +764,7 @@ func (ls *LDKService) MakeInvoice(ctx context.Context, amount int64, description
 		Invoice:         invoice,
 		PaymentHash:     paymentRequest.PaymentHash,
 		Preimage:        *payment.Kind.(ldk_node.PaymentKindBolt11).Preimage,
-		Amount:          amount,
+		AmountMsat:      amountMsat,
 		CreatedAt:       int64(paymentRequest.CreatedAt),
 		ExpiresAt:       &expiresAtUnix,
 		Description:     paymentRequest.Description,
@@ -890,24 +892,24 @@ func (ls *LDKService) ListChannels(ctx context.Context) ([]lnclient.Channel, err
 		isActive := ldkChannel.IsUsable /* superset of ldkChannel.IsReady */ && channelError == nil
 
 		channels = append(channels, lnclient.Channel{
-			InternalChannel:                          internalChannel,
-			LocalBalance:                             int64(ldkChannel.ChannelValueSats*1000 - ldkChannel.InboundCapacityMsat - ldkChannel.CounterpartyUnspendablePunishmentReserve*1000),
-			LocalSpendableBalance:                    int64(ldkChannel.OutboundCapacityMsat),
-			RemoteBalance:                            int64(ldkChannel.InboundCapacityMsat),
-			RemotePubkey:                             ldkChannel.CounterpartyNodeId,
-			Id:                                       ldkChannel.UserChannelId, // CloseChannel takes the UserChannelId
-			Active:                                   isActive,
-			Public:                                   ldkChannel.IsAnnounced,
-			FundingTxId:                              fundingTxId,
-			FundingTxVout:                            fundingTxVout,
-			Confirmations:                            ldkChannel.Confirmations,
-			ConfirmationsRequired:                    ldkChannel.ConfirmationsRequired,
-			ForwardingFeeBaseMsat:                    ldkChannel.Config.ForwardingFeeBaseMsat,
-			ForwardingFeeProportionalMillionths:      ldkChannel.Config.ForwardingFeeProportionalMillionths,
-			UnspendablePunishmentReserve:             unspendablePunishmentReserve,
-			CounterpartyUnspendablePunishmentReserve: ldkChannel.CounterpartyUnspendablePunishmentReserve,
-			Error:                                    channelError,
-			IsOutbound:                               ldkChannel.IsOutbound,
+			InternalChannel:                       internalChannel,
+			LocalBalanceMsat:                    int64(ldkChannel.ChannelValueSats*1000 - ldkChannel.InboundCapacityMsat - ldkChannel.CounterpartyUnspendablePunishmentReserve*1000),
+			LocalSpendableBalanceMsat:           int64(ldkChannel.OutboundCapacityMsat),
+			RemoteBalanceMsat:                   int64(ldkChannel.InboundCapacityMsat),
+			RemotePubkey:                        ldkChannel.CounterpartyNodeId,
+			Id:                                  ldkChannel.UserChannelId, // CloseChannel takes the UserChannelId
+			Active:                              isActive,
+			Public:                              ldkChannel.IsAnnounced,
+			FundingTxId:                         fundingTxId,
+			FundingTxVout:                       fundingTxVout,
+			Confirmations:                       ldkChannel.Confirmations,
+			ConfirmationsRequired:               ldkChannel.ConfirmationsRequired,
+			ForwardingFeeBaseMsat:               ldkChannel.Config.ForwardingFeeBaseMsat,
+			ForwardingFeeProportionalMillionths:  ldkChannel.Config.ForwardingFeeProportionalMillionths,
+			UnspendablePunishmentReserveSat:     unspendablePunishmentReserve,
+			CounterpartyUnspendablePunishmentReserveSat: ldkChannel.CounterpartyUnspendablePunishmentReserve,
+			Error:                               channelError,
+			IsOutbound:                          ldkChannel.IsOutbound,
 		})
 	}
 
@@ -1229,14 +1231,14 @@ func (ls *LDKService) GetOnchainBalance(ctx context.Context) (*lnclient.OnchainB
 	}, nil
 }
 
-func (ls *LDKService) RedeemOnchainFunds(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool) (string, error) {
+func (ls *LDKService) RedeemOnchainFunds(ctx context.Context, toAddress string, amountSat uint64, feeRateSatPerVbyte *uint64, sendAll bool) (string, error) {
 	if ls.redeemedOnchainFundsWithinThisSync {
 		return "", errors.New("please wait a minute for the wallet to sync before doing another on-chain payment")
 	}
 
 	var feePtr **ldk_node.FeeRate
-	if feeRate != nil {
-		fee := ldk_node.FeeRateFromSatPerVbUnchecked(*feeRate)
+	if feeRateSatPerVbyte != nil {
+		fee := ldk_node.FeeRateFromSatPerVbUnchecked(*feeRateSatPerVbyte)
 		feePtr = &fee
 	}
 
@@ -1246,7 +1248,7 @@ func (ls *LDKService) RedeemOnchainFunds(ctx context.Context, toAddress string, 
 	if !sendAll {
 		// NOTE: this may fail if user does not reserve enough for the onchain transaction
 		// and can also drain the anchor reserves if the user provides a too high amount.
-		txId, err = ls.node.OnchainPayment().SendToAddress(toAddress, amount, feePtr)
+		txId, err = ls.node.OnchainPayment().SendToAddress(toAddress, amountSat, feePtr)
 	} else {
 		txId, err = ls.node.OnchainPayment().SendAllToAddress(toAddress, false, feePtr)
 	}
@@ -1441,9 +1443,9 @@ func (ls *LDKService) ldkPaymentToTransaction(payment *ldk_node.PaymentDetails) 
 		Preimage:        preimage,
 		PaymentHash:     paymentHash,
 		SettledAt:       settledAt,
-		Amount:          int64(amountMsat),
+		AmountMsat:      int64(amountMsat),
 		Invoice:         bolt11Invoice,
-		FeesPaid:        int64(feeMsat),
+		FeesPaidMsat:    int64(feeMsat),
 		CreatedAt:       createdAt,
 		Description:     description,
 		DescriptionHash: descriptionHash,
@@ -2188,6 +2190,7 @@ func (ls *LDKService) PayOfferSync(ctx context.Context, offer string, amount uin
 		PaymentHash: paymentHash,
 		Preimage:    preimage,
 		Fee:         fee,
+		FeeMsat:     fee,
 	}, nil
 }
 
@@ -2259,7 +2262,7 @@ func (ls *LDKService) ExecuteCustomNodeCommand(ctx context.Context, command *lnc
 			Response: map[string]interface{}{
 				"paymentHash": payOfferResponse.PaymentHash,
 				"preimage":    payOfferResponse.Preimage,
-				"fee":         payOfferResponse.Fee,
+				"fee":         payOfferResponse.FeeMsat,
 			},
 		}, nil
 	case nodeCommandExportPathfindingScores:
@@ -2302,14 +2305,14 @@ func (ls *LDKService) ExecuteCustomNodeCommand(ctx context.Context, command *lnc
 	return nil, lnclient.ErrUnknownCustomNodeCommand
 }
 
-func (ls *LDKService) MakeHoldInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (*lnclient.Transaction, error) {
+func (ls *LDKService) MakeHoldInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (*lnclient.Transaction, error) {
 	if time.Duration(expiry)*time.Second > maxInvoiceExpiry {
 		return nil, errors.New("expiry is too long")
 	}
 
 	maxReceivable := ls.getMaxReceivable()
 
-	if amount > maxReceivable {
+	if amountMsat > maxReceivable {
 		ls.eventPublisher.Publish(&events.Event{
 			Event: "nwc_incoming_liquidity_required",
 			Properties: map[string]interface{}{
@@ -2351,7 +2354,7 @@ func (ls *LDKService) MakeHoldInvoice(ctx context.Context, amount int64, descrip
 			return nil, errors.New("min_cltv_expiry_delta must be <= 65535")
 		}
 		invoiceObj, err = ls.node.Bolt11Payment().ReceiveForHashWithMinCltvExpiryDelta(
-			uint64(amount),
+			uint64(amountMsat),
 			descriptionType,
 			uint32(expiry),
 			ldkPaymentHash,
@@ -2359,7 +2362,7 @@ func (ls *LDKService) MakeHoldInvoice(ctx context.Context, amount int64, descrip
 		)
 	} else {
 		invoiceObj, err = ls.node.Bolt11Payment().ReceiveForHash(
-			uint64(amount),
+			uint64(amountMsat),
 			descriptionType,
 			uint32(expiry),
 			ldkPaymentHash,
@@ -2386,7 +2389,7 @@ func (ls *LDKService) MakeHoldInvoice(ctx context.Context, amount int64, descrip
 		Type:            "incoming",
 		Invoice:         *payment.Kind.(ldk_node.PaymentKindBolt11).Bolt11Invoice,
 		PaymentHash:     paymentRequest.PaymentHash,
-		Amount:          amount,
+		AmountMsat:      amountMsat,
 		CreatedAt:       int64(payment.CreatedAt),
 		ExpiresAt:       &expiresAtUnix,
 		Description:     paymentRequest.Description,

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -432,7 +432,7 @@ func (svc *LNDService) Shutdown() error {
 	return nil
 }
 
-func (svc *LNDService) SendPaymentSync(payReq string, amount *uint64) (*lnclient.PayInvoiceResponse, error) {
+func (svc *LNDService) SendPaymentSync(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
 	const MAX_PARTIAL_PAYMENTS = 16
 
 	paymentRequest, err := decodepay.Decodepay(payReq)
@@ -444,8 +444,8 @@ func (svc *LNDService) SendPaymentSync(payReq string, amount *uint64) (*lnclient
 	}
 
 	paymentAmountMsat := uint64(paymentRequest.MSatoshi)
-	if amount != nil {
-		paymentAmountMsat = *amount
+	if amountMsat != nil {
+		paymentAmountMsat = *amountMsat
 	}
 	sendRequest := &routerrpc.SendPaymentRequest{
 		PaymentRequest: payReq,
@@ -454,8 +454,8 @@ func (svc *LNDService) SendPaymentSync(payReq string, amount *uint64) (*lnclient
 		TimeoutSeconds: SEND_PAYMENT_TIMEOUT,
 	}
 
-	if amount != nil {
-		sendRequest.AmtMsat = int64(*amount)
+	if amountMsat != nil {
+		sendRequest.AmtMsat = int64(*amountMsat)
 	}
 
 	payStream, err := svc.client.SendPayment(svc.ctx, sendRequest)
@@ -488,13 +488,15 @@ func (svc *LNDService) SendPaymentSync(payReq string, amount *uint64) (*lnclient
 		return nil, errors.New("no preimage in response")
 	}
 
+	feeMsat := uint64(resp.FeeMsat)
 	return &lnclient.PayInvoiceResponse{
 		Preimage: resp.PaymentPreimage,
-		Fee:      uint64(resp.FeeMsat),
+		Fee:      feeMsat,
+		FeeMsat:  feeMsat,
 	}, nil
 }
 
-func (svc *LNDService) SendKeysend(amount uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
+func (svc *LNDService) SendKeysend(amountMsat uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
 	destBytes, err := hex.DecodeString(destination)
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
@@ -534,13 +536,13 @@ func (svc *LNDService) SendKeysend(amount uint64, destination string, custom_rec
 	destCustomRecords[KEYSEND_CUSTOM_RECORD] = preImageBytes
 	sendPaymentRequest := &routerrpc.SendPaymentRequest{
 		Dest:              destBytes,
-		AmtMsat:           int64(amount),
+		AmtMsat:           int64(amountMsat),
 		PaymentHash:       paymentHashBytes,
 		DestFeatures:      []lnrpc.FeatureBit{lnrpc.FeatureBit_TLV_ONION_REQ},
 		DestCustomRecords: destCustomRecords,
 		MaxParts:          MAX_PARTIAL_PAYMENTS,
 		TimeoutSeconds:    SEND_PAYMENT_TIMEOUT,
-		FeeLimitMsat:      int64(transactions.CalculateFeeReserveMsat(amount)),
+		FeeLimitMsat:      int64(transactions.CalculateFeeReserveMsat(amountMsat)),
 	}
 
 	payStream, err := svc.client.SendPayment(svc.ctx, sendPaymentRequest)
@@ -583,8 +585,10 @@ func (svc *LNDService) SendKeysend(amount uint64, destination string, custom_rec
 		"preimage":     preimage,
 	}).Info("Keysend payment successful")
 
+	feeMsat := uint64(resp.FeeMsat)
 	return &lnclient.PayKeysendResponse{
-		Fee: uint64(resp.FeeMsat),
+		Fee:     feeMsat,
+		FeeMsat: feeMsat,
 	}, nil
 }
 
@@ -601,7 +605,7 @@ func (svc *LNDService) getPaymentResult(stream routerrpc.Router_SendPaymentV2Cli
 	}
 }
 
-func (svc *LNDService) MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
+func (svc *LNDService) MakeInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
 	var descriptionHashBytes []byte
 
 	if descriptionHash != "" {
@@ -703,7 +707,7 @@ func (svc *LNDService) MakeInvoice(ctx context.Context, amount int64, descriptio
 	}
 
 	addInvoiceRequest := &lnrpc.Invoice{
-		ValueMsat:       amount,
+		ValueMsat:       amountMsat,
 		Memo:            description,
 		DescriptionHash: descriptionHashBytes,
 		Expiry:          expiry,
@@ -727,7 +731,7 @@ func (svc *LNDService) MakeInvoice(ctx context.Context, amount int64, descriptio
 	return transaction, nil
 }
 
-func (svc *LNDService) MakeHoldInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *lnclient.Transaction, err error) {
+func (svc *LNDService) MakeHoldInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *lnclient.Transaction, err error) {
 	var descriptionHashBytes []byte
 	var paymentHashBytes []byte
 
@@ -772,7 +776,7 @@ func (svc *LNDService) MakeHoldInvoice(ctx context.Context, amount int64, descri
 	}
 
 	addInvoiceRequest := &invoicesrpc.AddHoldInvoiceRequest{
-		ValueMsat:       amount,
+		ValueMsat:       amountMsat,
 		Memo:            description,
 		DescriptionHash: descriptionHashBytes,
 		Expiry:          expiry,
@@ -943,23 +947,23 @@ func (svc *LNDService) ListChannels(ctx context.Context) ([]lnclient.Channel, er
 		}
 
 		channels[i] = lnclient.Channel{
-			InternalChannel:                          lndChannel,
-			LocalBalance:                             lndChannel.LocalBalance * 1000,
-			LocalSpendableBalance:                    int64(math.Max(float64((lndChannel.LocalBalance-int64(lndChannel.LocalConstraints.ChanReserveSat))*1000), float64(0))),
-			RemoteBalance:                            lndChannel.RemoteBalance * 1000,
-			RemotePubkey:                             lndChannel.RemotePubkey,
-			Id:                                       strconv.FormatUint(lndChannel.ChanId, 10),
-			Active:                                   lndChannel.Active,
-			Public:                                   !lndChannel.Private,
-			FundingTxId:                              channelPoint.GetFundingTxidStr(),
-			FundingTxVout:                            channelPoint.GetOutputIndex(),
-			Confirmations:                            &confirmations,
-			ConfirmationsRequired:                    &confirmationsRequired,
-			UnspendablePunishmentReserve:             lndChannel.LocalConstraints.ChanReserveSat,
-			CounterpartyUnspendablePunishmentReserve: lndChannel.RemoteConstraints.ChanReserveSat,
-			IsOutbound:                               lndChannel.Initiator,
-			ForwardingFeeBaseMsat:                    forwardingFeeBaseMsat,
-			ForwardingFeeProportionalMillionths:      forwardingFeeProportionalMillionths,
+			InternalChannel:                       lndChannel,
+			LocalBalanceMsat:                      lndChannel.LocalBalance * 1000,
+			LocalSpendableBalanceMsat:             int64(math.Max(float64((lndChannel.LocalBalance-int64(lndChannel.LocalConstraints.ChanReserveSat))*1000), float64(0))),
+			RemoteBalanceMsat:                     lndChannel.RemoteBalance * 1000,
+			RemotePubkey:                          lndChannel.RemotePubkey,
+			Id:                                    strconv.FormatUint(lndChannel.ChanId, 10),
+			Active:                                lndChannel.Active,
+			Public:                                !lndChannel.Private,
+			FundingTxId:                           channelPoint.GetFundingTxidStr(),
+			FundingTxVout:                         channelPoint.GetOutputIndex(),
+			Confirmations:                         &confirmations,
+			ConfirmationsRequired:                 &confirmationsRequired,
+			UnspendablePunishmentReserveSat:       lndChannel.LocalConstraints.ChanReserveSat,
+			CounterpartyUnspendablePunishmentReserveSat: lndChannel.RemoteConstraints.ChanReserveSat,
+			IsOutbound:                            lndChannel.Initiator,
+			ForwardingFeeBaseMsat:                 forwardingFeeBaseMsat,
+			ForwardingFeeProportionalMillionths:   forwardingFeeProportionalMillionths,
 		}
 	}
 
@@ -980,8 +984,8 @@ func (svc *LNDService) ListChannels(ctx context.Context) ([]lnclient.Channel, er
 
 		channels[j+len(activeResp.Channels)] = lnclient.Channel{
 			InternalChannel:       lndChannel,
-			LocalBalance:          lndChannel.Channel.LocalBalance * 1000,
-			RemoteBalance:         lndChannel.Channel.RemoteBalance * 1000,
+			LocalBalanceMsat:      lndChannel.Channel.LocalBalance * 1000,
+			RemoteBalanceMsat:     lndChannel.Channel.RemoteBalance * 1000,
 			RemotePubkey:          lndChannel.Channel.RemoteNodePub,
 			Public:                !lndChannel.Channel.Private,
 			FundingTxId:           fundingTxId,
@@ -1291,15 +1295,15 @@ func (svc *LNDService) GetOnchainBalance(ctx context.Context) (*lnclient.Onchain
 	}, nil
 }
 
-func (svc *LNDService) RedeemOnchainFunds(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool) (txId string, err error) {
+func (svc *LNDService) RedeemOnchainFunds(ctx context.Context, toAddress string, amountSat uint64, feeRateSatPerVbyte *uint64, sendAll bool) (txId string, err error) {
 	sendCoinsRequest := &lnrpc.SendCoinsRequest{
 		Addr:    toAddress,
 		SendAll: sendAll,
-		Amount:  int64(amount),
+		Amount:  int64(amountSat),
 	}
 
-	if feeRate != nil {
-		sendCoinsRequest.SatPerVbyte = *feeRate
+	if feeRateSatPerVbyte != nil {
+		sendCoinsRequest.SatPerVbyte = *feeRateSatPerVbyte
 	} else {
 		sendCoinsRequest.TargetConf = 1
 	}
@@ -1596,8 +1600,8 @@ func lndPaymentToTransaction(payment *lnrpc.Payment) (*lnclient.Transaction, err
 		Invoice:         payment.PaymentRequest,
 		Preimage:        payment.PaymentPreimage,
 		PaymentHash:     payment.PaymentHash,
-		Amount:          payment.ValueMsat,
-		FeesPaid:        payment.FeeMsat,
+		AmountMsat:      payment.ValueMsat,
+		FeesPaidMsat:    payment.FeeMsat,
 		CreatedAt:       time.Unix(0, payment.CreationTimeNs).Unix(),
 		Description:     description,
 		DescriptionHash: descriptionHash,
@@ -1641,7 +1645,7 @@ func lndInvoiceToTransaction(invoice *lnrpc.Invoice) *lnclient.Transaction {
 		DescriptionHash: hex.EncodeToString(invoice.DescriptionHash),
 		Preimage:        preimage,
 		PaymentHash:     hex.EncodeToString(invoice.RHash),
-		Amount:          invoice.ValueMsat,
+		AmountMsat:      invoice.ValueMsat,
 		CreatedAt:       invoice.CreationDate,
 		SettledAt:       settledAt,
 		ExpiresAt:       expiresAt,

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -31,10 +31,10 @@ type Transaction struct {
 	Description     string
 	DescriptionHash string
 	Preimage        string
-	PaymentHash     string
-	Amount          int64
-	FeesPaid        int64
-	CreatedAt       int64
+	PaymentHash  string
+	AmountMsat   int64
+	FeesPaidMsat int64
+	CreatedAt    int64
 	ExpiresAt       *int64
 	SettledAt       *int64
 	Metadata        Metadata
@@ -57,12 +57,12 @@ type NodeConnectionInfo struct {
 }
 
 type LNClient interface {
-	SendPaymentSync(payReq string, amount *uint64) (*PayInvoiceResponse, error)
-	SendKeysend(amount uint64, destination string, customRecords []TLVRecord, preimage string) (*PayKeysendResponse, error)
+	SendPaymentSync(payReq string, amountMsat *uint64) (*PayInvoiceResponse, error)
+	SendKeysend(amountMsat uint64, destination string, customRecords []TLVRecord, preimage string) (*PayKeysendResponse, error)
 	GetPubkey() string
 	GetInfo(ctx context.Context) (info *NodeInfo, err error)
-	MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *Transaction, err error)
-	MakeHoldInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *Transaction, err error)
+	MakeInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *Transaction, err error)
+	MakeHoldInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *Transaction, err error)
 	SettleHoldInvoice(ctx context.Context, preimage string) (err error)
 	CancelHoldInvoice(ctx context.Context, paymentHash string) (err error)
 	LookupInvoice(ctx context.Context, paymentHash string) (transaction *Transaction, err error)
@@ -81,7 +81,7 @@ type LNClient interface {
 	ResetRouter(key string) error
 	GetOnchainBalance(ctx context.Context) (*OnchainBalanceResponse, error)
 	GetBalances(ctx context.Context, includeInactiveChannels bool) (*BalancesResponse, error)
-	RedeemOnchainFunds(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool) (txId string, err error)
+	RedeemOnchainFunds(ctx context.Context, toAddress string, amountSat uint64, feeRateSatPerVbyte *uint64, sendAll bool) (txId string, err error)
 	SendPaymentProbes(ctx context.Context, invoice string) error
 	SendSpontaneousPaymentProbes(ctx context.Context, amountMsat uint64, nodeId string) error
 	ListPeers(ctx context.Context) ([]PeerDetails, error)
@@ -97,24 +97,24 @@ type LNClient interface {
 }
 
 type Channel struct {
-	LocalBalance                             int64
-	LocalSpendableBalance                    int64
-	RemoteBalance                            int64
-	Id                                       string
-	RemotePubkey                             string
-	FundingTxId                              string
-	FundingTxVout                            uint32
-	Active                                   bool
-	Public                                   bool
-	InternalChannel                          interface{}
-	Confirmations                            *uint32
-	ConfirmationsRequired                    *uint32
-	ForwardingFeeBaseMsat                    uint32
-	ForwardingFeeProportionalMillionths      uint32
-	UnspendablePunishmentReserve             uint64
-	CounterpartyUnspendablePunishmentReserve uint64
-	Error                                    *string
-	IsOutbound                               bool
+	LocalBalanceMsat          int64
+	LocalSpendableBalanceMsat int64
+	RemoteBalanceMsat         int64
+	Id                        string
+	RemotePubkey              string
+	FundingTxId               string
+	FundingTxVout             uint32
+	Active                    bool
+	Public                    bool
+	InternalChannel           interface{}
+	Confirmations             *uint32
+	ConfirmationsRequired     *uint32
+	ForwardingFeeBaseMsat     uint32
+	ForwardingFeeProportionalMillionths uint32
+	UnspendablePunishmentReserveSat                uint64
+	CounterpartyUnspendablePunishmentReserveSat    uint64
+	Error                         *string
+	IsOutbound                    bool
 }
 
 type NodeStatus struct {
@@ -207,17 +207,20 @@ type LightningBalanceResponse struct {
 
 type PayInvoiceResponse struct {
 	Preimage string `json:"preimage"`
-	Fee      uint64 `json:"fee"`
+	Fee      uint64 `json:"fee"` // deprecated: use feeMsat
+	FeeMsat  uint64 `json:"feeMsat"`
 }
 
 type PayOfferResponse = struct {
 	Preimage    string `json:"preimage"`
-	Fee         uint64 `json:"fee"`
+	Fee         uint64 `json:"fee"` // deprecated: use feeMsat
+	FeeMsat     uint64 `json:"feeMsat"`
 	PaymentHash string `json:"payment_hash"`
 }
 
 type PayKeysendResponse struct {
-	Fee uint64 `json:"fee"`
+	Fee     uint64 `json:"fee"` // deprecated: use feeMsat
+	FeeMsat uint64 `json:"feeMsat"`
 }
 
 type BalancesResponse struct {

--- a/lnclient/phoenixd/phoenixd.go
+++ b/lnclient/phoenixd/phoenixd.go
@@ -192,13 +192,19 @@ func (svc *PhoenixService) ListChannels(ctx context.Context) ([]lnclient.Channel
 	return channels, nil
 }
 
-func (svc *PhoenixService) MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
+func (svc *PhoenixService) MakeInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
 	// TODO: support expiry
 	if expiry == 0 {
 		expiry = lnclient.DEFAULT_INVOICE_EXPIRY
 	}
+	if amountMsat <= 0 {
+		return nil, errors.New("amountMsat must be positive")
+	}
+	if amountMsat%1000 != 0 {
+		return nil, fmt.Errorf("amountMsat must be sat-granular")
+	}
 	form := url.Values{}
-	amountSat := strconv.FormatInt(amount/1000, 10)
+	amountSat := strconv.FormatInt(amountMsat/1000, 10)
 	form.Add("amountSat", amountSat)
 	if description != "" {
 		form.Add("description", description)
@@ -253,7 +259,7 @@ func (svc *PhoenixService) MakeInvoice(ctx context.Context, amount int64, descri
 	return tx, nil
 }
 
-func (svc *PhoenixService) MakeHoldInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *lnclient.Transaction, err error) {
+func (svc *PhoenixService) MakeHoldInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *lnclient.Transaction, err error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -303,9 +309,9 @@ func (svc *PhoenixService) LookupInvoice(ctx context.Context, paymentHash string
 	return transaction, nil
 }
 
-func (svc *PhoenixService) SendPaymentSync(payReq string, amount *uint64) (*lnclient.PayInvoiceResponse, error) {
+func (svc *PhoenixService) SendPaymentSync(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
 	// TODO: support 0-amount invoices
-	if amount != nil {
+	if amountMsat != nil {
 		return nil, errors.New("0-amount invoices not supported")
 	}
 	form := url.Values{}
@@ -336,17 +342,19 @@ func (svc *PhoenixService) SendPaymentSync(payReq string, amount *uint64) (*lncl
 		return nil, err
 	}
 
+	feeMsat := uint64(payRes.RoutingFeeSat) * 1000
 	return &lnclient.PayInvoiceResponse{
 		Preimage: payRes.PaymentPreimage,
-		Fee:      uint64(payRes.RoutingFeeSat) * 1000,
+		Fee:      feeMsat,
+		FeeMsat:  feeMsat,
 	}, nil
 }
 
-func (svc *PhoenixService) SendKeysend(amount uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
+func (svc *PhoenixService) SendKeysend(amountMsat uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (svc *PhoenixService) RedeemOnchainFunds(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool) (txId string, err error) {
+func (svc *PhoenixService) RedeemOnchainFunds(ctx context.Context, toAddress string, amountSat uint64, feeRateSatPerVbyte *uint64, sendAll bool) (txId string, err error) {
 	return "", errors.New("not implemented")
 }
 
@@ -492,8 +500,8 @@ func phoenixInvoiceToTransaction(invoiceRes *InvoiceResponse) (*lnclient.Transac
 		Invoice:         invoiceRes.Invoice,
 		Preimage:        invoiceRes.Preimage,
 		PaymentHash:     invoiceRes.PaymentHash,
-		Amount:          paymentRequest.MSatoshi,
-		FeesPaid:        invoiceRes.Fees * 1000,
+		AmountMsat:      paymentRequest.MSatoshi,
+		FeesPaidMsat:    invoiceRes.Fees * 1000,
 		CreatedAt:       time.UnixMilli(invoiceRes.CreatedAt).Unix(),
 		Description:     invoiceRes.Description,
 		SettledAt:       settledAt,

--- a/nip47/controllers/list_transactions_controller_test.go
+++ b/nip47/controllers/list_transactions_controller_test.go
@@ -57,8 +57,8 @@ func TestHandleListTransactionsEvent(t *testing.T) {
 			DescriptionHash: tests.MockLNClientTransactions[i].DescriptionHash,
 			Preimage:        &tests.MockLNClientTransactions[i].Preimage,
 			PaymentHash:     tests.MockLNClientTransactions[i].PaymentHash,
-			AmountMsat:      uint64(tests.MockLNClientTransactions[i].Amount),
-			FeeMsat:         uint64(tests.MockLNClientTransactions[i].FeesPaid),
+			AmountMsat:      uint64(tests.MockLNClientTransactions[i].AmountMsat),
+			FeeMsat:         uint64(tests.MockLNClientTransactions[i].FeesPaidMsat),
 			SettledAt:       &settledAt,
 			State:           constants.TRANSACTION_STATE_SETTLED,
 			AppId:           &app.ID,
@@ -86,8 +86,8 @@ func TestHandleListTransactionsEvent(t *testing.T) {
 	assert.Equal(t, tests.MockLNClientTransactions[0].DescriptionHash, transaction.DescriptionHash)
 	assert.Equal(t, tests.MockLNClientTransactions[0].Preimage, transaction.Preimage)
 	assert.Equal(t, tests.MockLNClientTransactions[0].PaymentHash, transaction.PaymentHash)
-	assert.Equal(t, tests.MockLNClientTransactions[0].Amount, transaction.Amount)
-	assert.Equal(t, tests.MockLNClientTransactions[0].FeesPaid, transaction.FeesPaid)
+	assert.Equal(t, tests.MockLNClientTransactions[0].AmountMsat, transaction.Amount)
+	assert.Equal(t, tests.MockLNClientTransactions[0].FeesPaidMsat, transaction.FeesPaid)
 	assert.Equal(t, tests.MockLNClientTransactions[0].SettledAt, transaction.SettledAt)
 	assert.Equal(t, "settled", transaction.State)
 }

--- a/nip47/controllers/lookup_invoice_controller_test.go
+++ b/nip47/controllers/lookup_invoice_controller_test.go
@@ -51,8 +51,8 @@ func TestHandleLookupInvoiceEvent(t *testing.T) {
 		DescriptionHash: tests.MockLNClientTransaction.DescriptionHash,
 		Preimage:        &tests.MockLNClientTransaction.Preimage,
 		PaymentHash:     tests.MockLNClientTransaction.PaymentHash,
-		AmountMsat:      uint64(tests.MockLNClientTransaction.Amount),
-		FeeMsat:         uint64(tests.MockLNClientTransaction.FeesPaid),
+		AmountMsat:      uint64(tests.MockLNClientTransaction.AmountMsat),
+		FeeMsat:         uint64(tests.MockLNClientTransaction.FeesPaidMsat),
 		SettledAt:       &settledAt,
 		AppId:           &app.ID,
 	}).Error
@@ -75,7 +75,7 @@ func TestHandleLookupInvoiceEvent(t *testing.T) {
 	assert.Equal(t, tests.MockLNClientTransaction.DescriptionHash, transaction.DescriptionHash)
 	assert.Equal(t, tests.MockLNClientTransaction.Preimage, transaction.Preimage)
 	assert.Equal(t, tests.MockLNClientTransaction.PaymentHash, transaction.PaymentHash)
-	assert.Equal(t, tests.MockLNClientTransaction.Amount, transaction.Amount)
-	assert.Equal(t, tests.MockLNClientTransaction.FeesPaid, transaction.FeesPaid)
+	assert.Equal(t, tests.MockLNClientTransaction.AmountMsat, transaction.Amount)
+	assert.Equal(t, tests.MockLNClientTransaction.FeesPaidMsat, transaction.FeesPaid)
 	assert.Equal(t, tests.MockLNClientTransaction.SettledAt, transaction.SettledAt)
 }

--- a/nip47/notifications/nip47_notifier_test.go
+++ b/nip47/notifications/nip47_notifier_test.go
@@ -54,8 +54,8 @@ func doTestSendNotificationPaymentReceived(t *testing.T, svc *tests.TestService,
 		DescriptionHash: tests.MockLNClientTransaction.DescriptionHash,
 		Preimage:        &tests.MockLNClientTransaction.Preimage,
 		PaymentHash:     tests.MockLNClientTransaction.PaymentHash,
-		AmountMsat:      uint64(tests.MockLNClientTransaction.Amount),
-		FeeMsat:         uint64(tests.MockLNClientTransaction.FeesPaid),
+		AmountMsat:      uint64(tests.MockLNClientTransaction.AmountMsat),
+		FeeMsat:         uint64(tests.MockLNClientTransaction.FeesPaidMsat),
 		SettledAt:       &settledAt,
 		AppId:           &app.ID,
 		State:           constants.TRANSACTION_STATE_SETTLED,
@@ -110,8 +110,8 @@ func doTestSendNotificationPaymentReceived(t *testing.T, svc *tests.TestService,
 	assert.Equal(t, tests.MockLNClientTransaction.DescriptionHash, transaction.DescriptionHash)
 	assert.Equal(t, tests.MockLNClientTransaction.Preimage, transaction.Preimage)
 	assert.Equal(t, tests.MockLNClientTransaction.PaymentHash, transaction.PaymentHash)
-	assert.Equal(t, tests.MockLNClientTransaction.Amount, transaction.Amount)
-	assert.Equal(t, tests.MockLNClientTransaction.FeesPaid, transaction.FeesPaid)
+	assert.Equal(t, tests.MockLNClientTransaction.AmountMsat, transaction.Amount)
+	assert.Equal(t, tests.MockLNClientTransaction.FeesPaidMsat, transaction.FeesPaid)
 	assert.Equal(t, tests.MockLNClientTransaction.SettledAt, transaction.SettledAt)
 }
 
@@ -169,8 +169,8 @@ func doTestSendNotificationPaymentSent(t *testing.T, svc *tests.TestService, cre
 		DescriptionHash: tests.MockLNClientTransaction.DescriptionHash,
 		Preimage:        &tests.MockLNClientTransaction.Preimage,
 		PaymentHash:     tests.MockLNClientTransaction.PaymentHash,
-		AmountMsat:      uint64(tests.MockLNClientTransaction.Amount),
-		FeeMsat:         uint64(tests.MockLNClientTransaction.FeesPaid),
+		AmountMsat:      uint64(tests.MockLNClientTransaction.AmountMsat),
+		FeeMsat:         uint64(tests.MockLNClientTransaction.FeesPaidMsat),
 		SettledAt:       &settledAt,
 		AppId:           &app.ID,
 	}
@@ -224,8 +224,8 @@ func doTestSendNotificationPaymentSent(t *testing.T, svc *tests.TestService, cre
 	assert.Equal(t, tests.MockLNClientTransaction.DescriptionHash, transaction.DescriptionHash)
 	assert.Equal(t, tests.MockLNClientTransaction.Preimage, transaction.Preimage)
 	assert.Equal(t, tests.MockLNClientTransaction.PaymentHash, transaction.PaymentHash)
-	assert.Equal(t, tests.MockLNClientTransaction.Amount, transaction.Amount)
-	assert.Equal(t, tests.MockLNClientTransaction.FeesPaid, transaction.FeesPaid)
+	assert.Equal(t, tests.MockLNClientTransaction.AmountMsat, transaction.Amount)
+	assert.Equal(t, tests.MockLNClientTransaction.FeesPaidMsat, transaction.FeesPaid)
 	assert.Equal(t, tests.MockLNClientTransaction.SettledAt, transaction.SettledAt)
 }
 

--- a/swaps/swaps_service.go
+++ b/swaps/swaps_service.go
@@ -308,7 +308,7 @@ func (svc *swapsService) SwapOut(amount uint64, destination string, autoSwap, us
 		Preimage:           hex.EncodeToString(preimage),
 		AutoSwap:           autoSwap,
 		UsedXpub:           usedXpubDerivation,
-		ReceiveAmount:      amount,
+		ReceiveAmountSat:   amount,
 	}
 
 	var ourKeys *btcec.PrivateKey
@@ -362,7 +362,7 @@ func (svc *swapsService) SwapOut(amount uint64, destination string, autoSwap, us
 
 		err = tx.Model(&dbSwap).Updates(&db.Swap{
 			SwapId:             swap.Id,
-			SendAmount:         uint64(paymentRequest.MSatoshi / 1000),
+			SendAmountSat:      uint64(paymentRequest.MSatoshi / 1000),
 			Invoice:            swap.Invoice,
 			LockupAddress:      swap.LockupAddress,
 			TimeoutBlockHeight: swap.TimeoutBlockHeight,
@@ -483,7 +483,7 @@ func (svc *swapsService) SwapIn(amount uint64, autoSwap bool) (*SwapResponse, er
 
 		err = tx.Model(&dbSwap).Updates(&db.Swap{
 			SwapId:             swap.Id,
-			SendAmount:         swap.ExpectedAmount,
+			SendAmountSat:      swap.ExpectedAmount,
 			LockupAddress:      swap.Address,
 			TimeoutBlockHeight: swap.TimeoutBlockHeight,
 			BoltzPubkey:        hex.EncodeToString(swap.ClaimPublicKey),
@@ -797,9 +797,9 @@ func (svc *swapsService) RefundSwap(swapId, address string, enableRetries bool) 
 	}).Info("Claim transaction broadcasted for refund")
 
 	err = svc.db.Model(&swap).Updates(&db.Swap{
-		ClaimTxId:     claimTxId,
-		ReceiveAmount: refundAmount,
-		State:         constants.SWAP_STATE_REFUNDED,
+		ClaimTxId:        claimTxId,
+		ReceiveAmountSat: refundAmount,
+		State:            constants.SWAP_STATE_REFUNDED,
 	}).Error
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
@@ -998,7 +998,7 @@ func (svc *swapsService) startSwapInListener(swap *db.Swap) {
 			case boltz.InvoicePaid:
 				svc.markSwapState(swap, constants.SWAP_STATE_SUCCESS)
 				err = svc.db.Model(swap).Updates(&db.Swap{
-					ReceiveAmount: amount,
+					ReceiveAmountSat: amount,
 				}).Error
 				if err != nil {
 					logger.Logger.WithFields(logrus.Fields{
@@ -1253,7 +1253,7 @@ func (svc *swapsService) startSwapOutListener(swap *db.Swap) {
 				}
 
 				var boltzFee boltz.Fee
-				if swap.ReceiveAmount != 0 {
+				if swap.ReceiveAmountSat != 0 {
 					lockupAmount, err := lockupTransaction.VoutValue(vout)
 					if err != nil {
 						logger.Logger.WithError(err).WithFields(logrus.Fields{
@@ -1261,7 +1261,15 @@ func (svc *swapsService) startSwapOutListener(swap *db.Swap) {
 						}).Error("Failed to find lockup output value")
 						return
 					}
-					fee := lockupAmount - swap.ReceiveAmount
+					if lockupAmount < swap.ReceiveAmountSat {
+						logger.Logger.WithFields(logrus.Fields{
+							"swapId":           swap.SwapId,
+							"lockupAmountSat":  lockupAmount,
+							"receiveAmountSat": swap.ReceiveAmountSat,
+						}).Error("Lockup amount is lower than expected receive amount; refusing invalid fee calculation")
+						return
+					}
+					fee := lockupAmount - swap.ReceiveAmountSat
 					boltzFee.Sats = &fee
 				} else {
 					var feeRates *FeeRates
@@ -1325,8 +1333,8 @@ func (svc *swapsService) startSwapOutListener(swap *db.Swap) {
 				}).Info("Claim transaction broadcasted")
 
 				err = svc.db.Model(swap).Updates(&db.Swap{
-					ClaimTxId:     claimTxId,
-					ReceiveAmount: claimAmount,
+					ClaimTxId:        claimTxId,
+					ReceiveAmountSat: claimAmount,
 				}).Error
 				if err != nil {
 					logger.Logger.WithFields(logrus.Fields{
@@ -1336,6 +1344,8 @@ func (svc *swapsService) startSwapOutListener(swap *db.Swap) {
 					}).WithError(err).Error("Failed to save claim info to swap")
 					return
 				}
+				swap.ClaimTxId = claimTxId
+				swap.ReceiveAmountSat = claimAmount
 			case boltz.TransactionFailed, boltz.SwapExpired:
 				logger.Logger.WithFields(logrus.Fields{
 					"swapId": swap.SwapId,

--- a/tests/mock_ln_client.go
+++ b/tests/mock_ln_client.go
@@ -46,8 +46,8 @@ var MockLNClientTransactions = []lnclient.Transaction{
 		DescriptionHash: "hash1",
 		Preimage:        "preimage1",
 		PaymentHash:     MockPaymentHash,
-		Amount:          1000,
-		FeesPaid:        50,
+		AmountMsat:      1000,
+		FeesPaidMsat:    50,
 		SettledAt:       &MockTimeUnix,
 		Metadata: map[string]interface{}{
 			"key1": "value1",
@@ -61,8 +61,8 @@ var MockLNClientTransactions = []lnclient.Transaction{
 		DescriptionHash: "hash2",
 		Preimage:        "preimage2",
 		PaymentHash:     MockPaymentHash,
-		Amount:          2000,
-		FeesPaid:        75,
+		AmountMsat:      2000,
+		FeesPaidMsat:    75,
 		SettledAt:       &MockTimeUnix,
 	},
 }
@@ -75,7 +75,7 @@ var MockLNClientHoldTransaction = &lnclient.Transaction{
 	DescriptionHash: "",
 	Preimage:        "4aa083cad11038359b4f614f3a3d6a8298ae17d5275412bc3eca4f5f4d27f2d4",
 	PaymentHash:     "2779f32f463c795e3cca0e2d40911e4b4d7941baa60bfdf15d28df405df847f5",
-	Amount:          2000,
+	AmountMsat:      2000,
 }
 
 type MockLn struct {
@@ -94,7 +94,7 @@ func NewMockLn() (*MockLn, error) {
 	return &MockLn{}, nil
 }
 
-func (mln *MockLn) SendPaymentSync(payReq string, amount *uint64) (*lnclient.PayInvoiceResponse, error) {
+func (mln *MockLn) SendPaymentSync(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
 	if len(mln.PayInvoiceResponses) > 0 {
 		response := mln.PayInvoiceResponses[0]
 		err := mln.PayInvoiceErrors[0]
@@ -108,12 +108,14 @@ func (mln *MockLn) SendPaymentSync(payReq string, amount *uint64) (*lnclient.Pay
 
 	return &lnclient.PayInvoiceResponse{
 		Preimage: "123preimage",
+		FeeMsat:  0,
 	}, nil
 }
 
-func (mln *MockLn) SendKeysend(amount uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
+func (mln *MockLn) SendKeysend(amountMsat uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
 	return &lnclient.PayKeysendResponse{
-		Fee: 1,
+		Fee:     1,
+		FeeMsat: 1,
 	}, nil
 }
 
@@ -121,7 +123,7 @@ func (mln *MockLn) GetInfo(ctx context.Context) (info *lnclient.NodeInfo, err er
 	return &MockNodeInfo, nil
 }
 
-func (mln *MockLn) MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
+func (mln *MockLn) MakeInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
 	if len(mln.MakeInvoiceResponses) > 0 {
 		response := mln.MakeInvoiceResponses[0]
 		err := mln.MakeInvoiceErrors[0]
@@ -132,7 +134,7 @@ func (mln *MockLn) MakeInvoice(ctx context.Context, amount int64, description st
 	return MockLNClientTransaction, nil
 }
 
-func (mln *MockLn) MakeHoldInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *lnclient.Transaction, err error) {
+func (mln *MockLn) MakeHoldInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *lnclient.Transaction, err error) {
 	if minCltvExpiryDelta == nil {
 		mln.LastMinCltvExpiryDelta = nil
 	} else {
@@ -193,7 +195,7 @@ func (mln *MockLn) GetBalances(ctx context.Context, includeInactiveChannels bool
 func (mln *MockLn) GetOnchainBalance(ctx context.Context) (*lnclient.OnchainBalanceResponse, error) {
 	return nil, nil
 }
-func (mln *MockLn) RedeemOnchainFunds(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool) (txId string, err error) {
+func (mln *MockLn) RedeemOnchainFunds(ctx context.Context, toAddress string, amountSat uint64, feeRateSatPerVbyte *uint64, sendAll bool) (txId string, err error) {
 	return "", nil
 }
 func (mln *MockLn) ResetRouter(key string) error {

--- a/tests/mocks/LNClient.go
+++ b/tests/mocks/LNClient.go
@@ -1347,8 +1347,8 @@ func (_c *MockLNClient_LookupInvoice_Call) RunAndReturn(run func(ctx context.Con
 }
 
 // MakeHoldInvoice provides a mock function for the type MockLNClient
-func (_mock *MockLNClient) MakeHoldInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (*lnclient.Transaction, error) {
-	ret := _mock.Called(ctx, amount, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)
+func (_mock *MockLNClient) MakeHoldInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (*lnclient.Transaction, error) {
+	ret := _mock.Called(ctx, amountMsat, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)
 
 	if len(ret) == 0 {
 		panic("no return value specified for MakeHoldInvoice")
@@ -1357,17 +1357,17 @@ func (_mock *MockLNClient) MakeHoldInvoice(ctx context.Context, amount int64, de
 	var r0 *lnclient.Transaction
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func(context.Context, int64, string, string, int64, string, *uint64) (*lnclient.Transaction, error)); ok {
-		return returnFunc(ctx, amount, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)
+		return returnFunc(ctx, amountMsat, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, int64, string, string, int64, string, *uint64) *lnclient.Transaction); ok {
-		r0 = returnFunc(ctx, amount, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)
+		r0 = returnFunc(ctx, amountMsat, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*lnclient.Transaction)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, int64, string, string, int64, string, *uint64) error); ok {
-		r1 = returnFunc(ctx, amount, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)
+		r1 = returnFunc(ctx, amountMsat, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1381,17 +1381,17 @@ type MockLNClient_MakeHoldInvoice_Call struct {
 
 // MakeHoldInvoice is a helper method to define mock.On call
 //   - ctx context.Context
-//   - amount int64
+//   - amountMsat int64
 //   - description string
 //   - descriptionHash string
 //   - expiry int64
 //   - paymentHash string
 //   - minCltvExpiryDelta *uint64
-func (_e *MockLNClient_Expecter) MakeHoldInvoice(ctx interface{}, amount interface{}, description interface{}, descriptionHash interface{}, expiry interface{}, paymentHash interface{}, minCltvExpiryDelta interface{}) *MockLNClient_MakeHoldInvoice_Call {
-	return &MockLNClient_MakeHoldInvoice_Call{Call: _e.mock.On("MakeHoldInvoice", ctx, amount, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)}
+func (_e *MockLNClient_Expecter) MakeHoldInvoice(ctx interface{}, amountMsat interface{}, description interface{}, descriptionHash interface{}, expiry interface{}, paymentHash interface{}, minCltvExpiryDelta interface{}) *MockLNClient_MakeHoldInvoice_Call {
+	return &MockLNClient_MakeHoldInvoice_Call{Call: _e.mock.On("MakeHoldInvoice", ctx, amountMsat, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)}
 }
 
-func (_c *MockLNClient_MakeHoldInvoice_Call) Run(run func(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64)) *MockLNClient_MakeHoldInvoice_Call {
+func (_c *MockLNClient_MakeHoldInvoice_Call) Run(run func(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64)) *MockLNClient_MakeHoldInvoice_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1439,14 +1439,14 @@ func (_c *MockLNClient_MakeHoldInvoice_Call) Return(transaction *lnclient.Transa
 	return _c
 }
 
-func (_c *MockLNClient_MakeHoldInvoice_Call) RunAndReturn(run func(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (*lnclient.Transaction, error)) *MockLNClient_MakeHoldInvoice_Call {
+func (_c *MockLNClient_MakeHoldInvoice_Call) RunAndReturn(run func(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (*lnclient.Transaction, error)) *MockLNClient_MakeHoldInvoice_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // MakeInvoice provides a mock function for the type MockLNClient
-func (_mock *MockLNClient) MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (*lnclient.Transaction, error) {
-	ret := _mock.Called(ctx, amount, description, descriptionHash, expiry, throughNodePubkey)
+func (_mock *MockLNClient) MakeInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (*lnclient.Transaction, error) {
+	ret := _mock.Called(ctx, amountMsat, description, descriptionHash, expiry, throughNodePubkey)
 
 	if len(ret) == 0 {
 		panic("no return value specified for MakeInvoice")
@@ -1455,17 +1455,17 @@ func (_mock *MockLNClient) MakeInvoice(ctx context.Context, amount int64, descri
 	var r0 *lnclient.Transaction
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func(context.Context, int64, string, string, int64, *string) (*lnclient.Transaction, error)); ok {
-		return returnFunc(ctx, amount, description, descriptionHash, expiry, throughNodePubkey)
+		return returnFunc(ctx, amountMsat, description, descriptionHash, expiry, throughNodePubkey)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, int64, string, string, int64, *string) *lnclient.Transaction); ok {
-		r0 = returnFunc(ctx, amount, description, descriptionHash, expiry, throughNodePubkey)
+		r0 = returnFunc(ctx, amountMsat, description, descriptionHash, expiry, throughNodePubkey)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*lnclient.Transaction)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, int64, string, string, int64, *string) error); ok {
-		r1 = returnFunc(ctx, amount, description, descriptionHash, expiry, throughNodePubkey)
+		r1 = returnFunc(ctx, amountMsat, description, descriptionHash, expiry, throughNodePubkey)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1479,16 +1479,16 @@ type MockLNClient_MakeInvoice_Call struct {
 
 // MakeInvoice is a helper method to define mock.On call
 //   - ctx context.Context
-//   - amount int64
+//   - amountMsat int64
 //   - description string
 //   - descriptionHash string
 //   - expiry int64
 //   - throughNodePubkey *string
-func (_e *MockLNClient_Expecter) MakeInvoice(ctx interface{}, amount interface{}, description interface{}, descriptionHash interface{}, expiry interface{}, throughNodePubkey interface{}) *MockLNClient_MakeInvoice_Call {
-	return &MockLNClient_MakeInvoice_Call{Call: _e.mock.On("MakeInvoice", ctx, amount, description, descriptionHash, expiry, throughNodePubkey)}
+func (_e *MockLNClient_Expecter) MakeInvoice(ctx interface{}, amountMsat interface{}, description interface{}, descriptionHash interface{}, expiry interface{}, throughNodePubkey interface{}) *MockLNClient_MakeInvoice_Call {
+	return &MockLNClient_MakeInvoice_Call{Call: _e.mock.On("MakeInvoice", ctx, amountMsat, description, descriptionHash, expiry, throughNodePubkey)}
 }
 
-func (_c *MockLNClient_MakeInvoice_Call) Run(run func(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string)) *MockLNClient_MakeInvoice_Call {
+func (_c *MockLNClient_MakeInvoice_Call) Run(run func(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string)) *MockLNClient_MakeInvoice_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1531,7 +1531,7 @@ func (_c *MockLNClient_MakeInvoice_Call) Return(transaction *lnclient.Transactio
 	return _c
 }
 
-func (_c *MockLNClient_MakeInvoice_Call) RunAndReturn(run func(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (*lnclient.Transaction, error)) *MockLNClient_MakeInvoice_Call {
+func (_c *MockLNClient_MakeInvoice_Call) RunAndReturn(run func(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (*lnclient.Transaction, error)) *MockLNClient_MakeInvoice_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1671,8 +1671,8 @@ func (_c *MockLNClient_OpenChannel_Call) RunAndReturn(run func(ctx context.Conte
 }
 
 // RedeemOnchainFunds provides a mock function for the type MockLNClient
-func (_mock *MockLNClient) RedeemOnchainFunds(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool) (string, error) {
-	ret := _mock.Called(ctx, toAddress, amount, feeRate, sendAll)
+func (_mock *MockLNClient) RedeemOnchainFunds(ctx context.Context, toAddress string, amountSat uint64, feeRateSatPerVbyte *uint64, sendAll bool) (string, error) {
+	ret := _mock.Called(ctx, toAddress, amountSat, feeRateSatPerVbyte, sendAll)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RedeemOnchainFunds")
@@ -1681,15 +1681,15 @@ func (_mock *MockLNClient) RedeemOnchainFunds(ctx context.Context, toAddress str
 	var r0 string
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, uint64, *uint64, bool) (string, error)); ok {
-		return returnFunc(ctx, toAddress, amount, feeRate, sendAll)
+		return returnFunc(ctx, toAddress, amountSat, feeRateSatPerVbyte, sendAll)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, uint64, *uint64, bool) string); ok {
-		r0 = returnFunc(ctx, toAddress, amount, feeRate, sendAll)
+		r0 = returnFunc(ctx, toAddress, amountSat, feeRateSatPerVbyte, sendAll)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string, uint64, *uint64, bool) error); ok {
-		r1 = returnFunc(ctx, toAddress, amount, feeRate, sendAll)
+		r1 = returnFunc(ctx, toAddress, amountSat, feeRateSatPerVbyte, sendAll)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1704,14 +1704,14 @@ type MockLNClient_RedeemOnchainFunds_Call struct {
 // RedeemOnchainFunds is a helper method to define mock.On call
 //   - ctx context.Context
 //   - toAddress string
-//   - amount uint64
-//   - feeRate *uint64
+//   - amountSat uint64
+//   - feeRateSatPerVbyte *uint64
 //   - sendAll bool
-func (_e *MockLNClient_Expecter) RedeemOnchainFunds(ctx interface{}, toAddress interface{}, amount interface{}, feeRate interface{}, sendAll interface{}) *MockLNClient_RedeemOnchainFunds_Call {
-	return &MockLNClient_RedeemOnchainFunds_Call{Call: _e.mock.On("RedeemOnchainFunds", ctx, toAddress, amount, feeRate, sendAll)}
+func (_e *MockLNClient_Expecter) RedeemOnchainFunds(ctx interface{}, toAddress interface{}, amountSat interface{}, feeRateSatPerVbyte interface{}, sendAll interface{}) *MockLNClient_RedeemOnchainFunds_Call {
+	return &MockLNClient_RedeemOnchainFunds_Call{Call: _e.mock.On("RedeemOnchainFunds", ctx, toAddress, amountSat, feeRateSatPerVbyte, sendAll)}
 }
 
-func (_c *MockLNClient_RedeemOnchainFunds_Call) Run(run func(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool)) *MockLNClient_RedeemOnchainFunds_Call {
+func (_c *MockLNClient_RedeemOnchainFunds_Call) Run(run func(ctx context.Context, toAddress string, amountSat uint64, feeRateSatPerVbyte *uint64, sendAll bool)) *MockLNClient_RedeemOnchainFunds_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1749,7 +1749,7 @@ func (_c *MockLNClient_RedeemOnchainFunds_Call) Return(txId string, err error) *
 	return _c
 }
 
-func (_c *MockLNClient_RedeemOnchainFunds_Call) RunAndReturn(run func(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool) (string, error)) *MockLNClient_RedeemOnchainFunds_Call {
+func (_c *MockLNClient_RedeemOnchainFunds_Call) RunAndReturn(run func(ctx context.Context, toAddress string, amountSat uint64, feeRateSatPerVbyte *uint64, sendAll bool) (string, error)) *MockLNClient_RedeemOnchainFunds_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1806,8 +1806,8 @@ func (_c *MockLNClient_ResetRouter_Call) RunAndReturn(run func(key string) error
 }
 
 // SendKeysend provides a mock function for the type MockLNClient
-func (_mock *MockLNClient) SendKeysend(amount uint64, destination string, customRecords []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
-	ret := _mock.Called(amount, destination, customRecords, preimage)
+func (_mock *MockLNClient) SendKeysend(amountMsat uint64, destination string, customRecords []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
+	ret := _mock.Called(amountMsat, destination, customRecords, preimage)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendKeysend")
@@ -1816,17 +1816,17 @@ func (_mock *MockLNClient) SendKeysend(amount uint64, destination string, custom
 	var r0 *lnclient.PayKeysendResponse
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func(uint64, string, []lnclient.TLVRecord, string) (*lnclient.PayKeysendResponse, error)); ok {
-		return returnFunc(amount, destination, customRecords, preimage)
+		return returnFunc(amountMsat, destination, customRecords, preimage)
 	}
 	if returnFunc, ok := ret.Get(0).(func(uint64, string, []lnclient.TLVRecord, string) *lnclient.PayKeysendResponse); ok {
-		r0 = returnFunc(amount, destination, customRecords, preimage)
+		r0 = returnFunc(amountMsat, destination, customRecords, preimage)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*lnclient.PayKeysendResponse)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(uint64, string, []lnclient.TLVRecord, string) error); ok {
-		r1 = returnFunc(amount, destination, customRecords, preimage)
+		r1 = returnFunc(amountMsat, destination, customRecords, preimage)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1839,15 +1839,15 @@ type MockLNClient_SendKeysend_Call struct {
 }
 
 // SendKeysend is a helper method to define mock.On call
-//   - amount uint64
+//   - amountMsat uint64
 //   - destination string
 //   - customRecords []lnclient.TLVRecord
 //   - preimage string
-func (_e *MockLNClient_Expecter) SendKeysend(amount interface{}, destination interface{}, customRecords interface{}, preimage interface{}) *MockLNClient_SendKeysend_Call {
-	return &MockLNClient_SendKeysend_Call{Call: _e.mock.On("SendKeysend", amount, destination, customRecords, preimage)}
+func (_e *MockLNClient_Expecter) SendKeysend(amountMsat interface{}, destination interface{}, customRecords interface{}, preimage interface{}) *MockLNClient_SendKeysend_Call {
+	return &MockLNClient_SendKeysend_Call{Call: _e.mock.On("SendKeysend", amountMsat, destination, customRecords, preimage)}
 }
 
-func (_c *MockLNClient_SendKeysend_Call) Run(run func(amount uint64, destination string, customRecords []lnclient.TLVRecord, preimage string)) *MockLNClient_SendKeysend_Call {
+func (_c *MockLNClient_SendKeysend_Call) Run(run func(amountMsat uint64, destination string, customRecords []lnclient.TLVRecord, preimage string)) *MockLNClient_SendKeysend_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 uint64
 		if args[0] != nil {
@@ -1880,7 +1880,7 @@ func (_c *MockLNClient_SendKeysend_Call) Return(payKeysendResponse *lnclient.Pay
 	return _c
 }
 
-func (_c *MockLNClient_SendKeysend_Call) RunAndReturn(run func(amount uint64, destination string, customRecords []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error)) *MockLNClient_SendKeysend_Call {
+func (_c *MockLNClient_SendKeysend_Call) RunAndReturn(run func(amountMsat uint64, destination string, customRecords []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error)) *MockLNClient_SendKeysend_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1943,8 +1943,8 @@ func (_c *MockLNClient_SendPaymentProbes_Call) RunAndReturn(run func(ctx context
 }
 
 // SendPaymentSync provides a mock function for the type MockLNClient
-func (_mock *MockLNClient) SendPaymentSync(payReq string, amount *uint64) (*lnclient.PayInvoiceResponse, error) {
-	ret := _mock.Called(payReq, amount)
+func (_mock *MockLNClient) SendPaymentSync(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
+	ret := _mock.Called(payReq, amountMsat)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendPaymentSync")
@@ -1953,17 +1953,17 @@ func (_mock *MockLNClient) SendPaymentSync(payReq string, amount *uint64) (*lncl
 	var r0 *lnclient.PayInvoiceResponse
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func(string, *uint64) (*lnclient.PayInvoiceResponse, error)); ok {
-		return returnFunc(payReq, amount)
+		return returnFunc(payReq, amountMsat)
 	}
 	if returnFunc, ok := ret.Get(0).(func(string, *uint64) *lnclient.PayInvoiceResponse); ok {
-		r0 = returnFunc(payReq, amount)
+		r0 = returnFunc(payReq, amountMsat)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*lnclient.PayInvoiceResponse)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(string, *uint64) error); ok {
-		r1 = returnFunc(payReq, amount)
+		r1 = returnFunc(payReq, amountMsat)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1977,12 +1977,12 @@ type MockLNClient_SendPaymentSync_Call struct {
 
 // SendPaymentSync is a helper method to define mock.On call
 //   - payReq string
-//   - amount *uint64
-func (_e *MockLNClient_Expecter) SendPaymentSync(payReq interface{}, amount interface{}) *MockLNClient_SendPaymentSync_Call {
-	return &MockLNClient_SendPaymentSync_Call{Call: _e.mock.On("SendPaymentSync", payReq, amount)}
+//   - amountMsat *uint64
+func (_e *MockLNClient_Expecter) SendPaymentSync(payReq interface{}, amountMsat interface{}) *MockLNClient_SendPaymentSync_Call {
+	return &MockLNClient_SendPaymentSync_Call{Call: _e.mock.On("SendPaymentSync", payReq, amountMsat)}
 }
 
-func (_c *MockLNClient_SendPaymentSync_Call) Run(run func(payReq string, amount *uint64)) *MockLNClient_SendPaymentSync_Call {
+func (_c *MockLNClient_SendPaymentSync_Call) Run(run func(payReq string, amountMsat *uint64)) *MockLNClient_SendPaymentSync_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -2005,7 +2005,7 @@ func (_c *MockLNClient_SendPaymentSync_Call) Return(payInvoiceResponse *lnclient
 	return _c
 }
 
-func (_c *MockLNClient_SendPaymentSync_Call) RunAndReturn(run func(payReq string, amount *uint64) (*lnclient.PayInvoiceResponse, error)) *MockLNClient_SendPaymentSync_Call {
+func (_c *MockLNClient_SendPaymentSync_Call) RunAndReturn(run func(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error)) *MockLNClient_SendPaymentSync_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/transactions/make_invoice_test.go
+++ b/transactions/make_invoice_test.go
@@ -33,7 +33,7 @@ func TestMakeInvoice_NoApp(t *testing.T) {
 	err = json.Unmarshal(transaction.Metadata, &metadata)
 	assert.NoError(t, err)
 
-	assert.Equal(t, uint64(tests.MockLNClientTransaction.Amount), transaction.AmountMsat)
+	assert.Equal(t, uint64(tests.MockLNClientTransaction.AmountMsat), transaction.AmountMsat)
 	assert.Equal(t, constants.TRANSACTION_STATE_PENDING, transaction.State)
 	assert.Equal(t, tests.MockLNClientTransaction.Preimage, *transaction.Preimage)
 	assert.Equal(t, txMetadata["randomkey"], metadata["randomkey"])
@@ -75,7 +75,7 @@ func TestMakeInvoice_App(t *testing.T) {
 	transaction, err := transactionsService.MakeInvoice(ctx, 1234, "Hello world", "", 0, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
 
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(tests.MockLNClientTransaction.Amount), transaction.AmountMsat)
+	assert.Equal(t, uint64(tests.MockLNClientTransaction.AmountMsat), transaction.AmountMsat)
 	assert.Equal(t, constants.TRANSACTION_STATE_PENDING, transaction.State)
 	assert.Equal(t, tests.MockLNClientTransaction.Preimage, *transaction.Preimage)
 	assert.Equal(t, app.ID, *transaction.AppId)

--- a/transactions/notifications_test.go
+++ b/transactions/notifications_test.go
@@ -69,7 +69,7 @@ func TestNotifications_ReceivedUnknownPayment(t *testing.T) {
 	transactionType := constants.TRANSACTION_TYPE_INCOMING
 	incomingTransaction, err := transactionsService.LookupTransaction(ctx, tests.MockLNClientTransaction.PaymentHash, &transactionType, svc.LNClient, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(tests.MockLNClientTransaction.Amount), incomingTransaction.AmountMsat)
+	assert.Equal(t, uint64(tests.MockLNClientTransaction.AmountMsat), incomingTransaction.AmountMsat)
 	assert.Equal(t, constants.TRANSACTION_STATE_SETTLED, incomingTransaction.State)
 	assert.Equal(t, tests.MockLNClientTransaction.Preimage, *incomingTransaction.Preimage)
 	assert.Zero(t, incomingTransaction.FeeReserveMsat)
@@ -104,8 +104,8 @@ func TestNotifications_ReceivedKeysend(t *testing.T) {
 		DescriptionHash: "",
 		Preimage:        tests.MockLNClientTransaction.Preimage,
 		PaymentHash:     tests.MockLNClientTransaction.PaymentHash,
-		Amount:          2000,
-		FeesPaid:        75,
+		AmountMsat:      2000,
+		FeesPaidMsat:    75,
 		SettledAt:       &tests.MockTimeUnix,
 		Metadata:        metadata,
 	}
@@ -202,7 +202,7 @@ func TestNotifications_SentUnknownPayment(t *testing.T) {
 	transactionType := constants.TRANSACTION_TYPE_OUTGOING
 	outgoingTransaction, err := transactionsService.LookupTransaction(ctx, tests.MockLNClientTransaction.PaymentHash, &transactionType, svc.LNClient, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(tests.MockLNClientTransaction.Amount), outgoingTransaction.AmountMsat)
+	assert.Equal(t, uint64(tests.MockLNClientTransaction.AmountMsat), outgoingTransaction.AmountMsat)
 	assert.Equal(t, constants.TRANSACTION_STATE_SETTLED, outgoingTransaction.State)
 	assert.Equal(t, tests.MockLNClientTransaction.Preimage, *outgoingTransaction.Preimage)
 	assert.Zero(t, outgoingTransaction.FeeReserveMsat)

--- a/transactions/payments_test.go
+++ b/transactions/payments_test.go
@@ -444,8 +444,8 @@ func TestConsumeEvent_FailedMarkedAsSuccessful(t *testing.T) {
 			DescriptionHash: tests.MockLNClientTransaction.DescriptionHash,
 			Preimage:        tests.MockLNClientTransaction.Preimage,
 			PaymentHash:     tests.MockLNClientTransaction.PaymentHash,
-			Amount:          tests.MockLNClientTransaction.Amount,
-			FeesPaid:        tests.MockLNClientTransaction.FeesPaid,
+			AmountMsat:      tests.MockLNClientTransaction.AmountMsat,
+			FeesPaidMsat:    tests.MockLNClientTransaction.FeesPaidMsat,
 		},
 	}, nil)
 

--- a/transactions/receive_keysend_test.go
+++ b/transactions/receive_keysend_test.go
@@ -35,8 +35,8 @@ func TestReceiveKeysend_ValidBoostagram(t *testing.T) {
 		Description: "mock invoice 1",
 		Preimage:    "9f59b18f80a77c2930deb8be5ff1143eacdd1891c63c23d61bc9f99c64e57325",
 		PaymentHash: "ae4277b7be3ca1420cafd24c143866190f52b996856b0e4164763f936e61ea1b",
-		Amount:      1000,
-		FeesPaid:    50,
+		AmountMsat:   1000,
+		FeesPaidMsat: 50,
 		SettledAt:   &tests.MockTimeUnix,
 		Metadata: map[string]interface{}{
 			"tlv_records": tlv,
@@ -76,8 +76,8 @@ func TestReceiveKeysend_InvalidBoostagram(t *testing.T) {
 		Description: "mock invoice 1",
 		Preimage:    "9f59b18f80a77c2930deb8be5ff1143eacdd1891c63c23d61bc9f99c64e57325",
 		PaymentHash: "ae4277b7be3ca1420cafd24c143866190f52b996856b0e4164763f936e61ea1b",
-		Amount:      1000,
-		FeesPaid:    50,
+		AmountMsat:   1000,
+		FeesPaidMsat: 50,
 		SettledAt:   &tests.MockTimeUnix,
 		Metadata: map[string]interface{}{
 			"tlv_records": tlv,
@@ -122,8 +122,8 @@ func TestReceiveKeysendWithCustomKey(t *testing.T) {
 		Description: "mock invoice 1",
 		Preimage:    "9f59b18f80a77c2930deb8be5ff1143eacdd1891c63c23d61bc9f99c64e57325",
 		PaymentHash: "ae4277b7be3ca1420cafd24c143866190f52b996856b0e4164763f936e61ea1b",
-		Amount:      1000,
-		FeesPaid:    50,
+		AmountMsat:   1000,
+		FeesPaidMsat: 50,
 		SettledAt:   &tests.MockTimeUnix,
 		Metadata: map[string]interface{}{
 			"tlv_records": tlv,

--- a/transactions/self_hold_payments_test.go
+++ b/transactions/self_hold_payments_test.go
@@ -169,7 +169,7 @@ func TestWrappedInvoice(t *testing.T) {
 		DescriptionHash: "",
 		Preimage:        "fcf200c74d9900dc77af17eb1f57c02eec0f94b5b169d3eee23df9a216a3411b",
 		PaymentHash:     "8f3cfa1cdcf19de4b6fdb9ec339b7470e724d0c755b7c7568164d5df1b70ea6e",
-		Amount:          1000_000,
+		AmountMsat:      1000_000,
 	}
 
 	// Bob's 1100 sat invoice
@@ -182,7 +182,7 @@ func TestWrappedInvoice(t *testing.T) {
 		DescriptionHash: "",
 		Preimage:        "",
 		PaymentHash:     "8f3cfa1cdcf19de4b6fdb9ec339b7470e724d0c755b7c7568164d5df1b70ea6e",
-		Amount:          1100_000,
+		AmountMsat:      1100_000,
 	}
 
 	svc.LNClient.(*tests.MockLn).MakeInvoiceResponses = []*lnclient.Transaction{
@@ -194,8 +194,10 @@ func TestWrappedInvoice(t *testing.T) {
 	var preimages = []string{tests.MockLNClientHoldTransaction.Preimage, tests.MockLNClientHoldTransaction.Preimage}
 	svc.LNClient.(*tests.MockLn).PayInvoiceResponses = []*lnclient.PayInvoiceResponse{{
 		Preimage: preimages[0],
+		FeeMsat:  0,
 	}, {
 		Preimage: preimages[1],
+		FeeMsat:  0,
 	}}
 	svc.LNClient.(*tests.MockLn).PayInvoiceErrors = []error{nil, nil}
 

--- a/transactions/transactions_service.go
+++ b/transactions/transactions_service.go
@@ -196,7 +196,7 @@ func (svc *transactionsService) MakeInvoice(ctx context.Context, amount uint64, 
 		RequestEventId:  requestEventId,
 		Type:            lnClientTransaction.Type,
 		State:           constants.TRANSACTION_STATE_PENDING,
-		AmountMsat:      uint64(lnClientTransaction.Amount),
+		AmountMsat:      uint64(lnClientTransaction.AmountMsat),
 		Description:     description,
 		DescriptionHash: descriptionHash,
 		PaymentRequest:  lnClientTransaction.Invoice,
@@ -249,7 +249,7 @@ func (svc *transactionsService) MakeHoldInvoice(ctx context.Context, amount uint
 		RequestEventId:  requestEventId,
 		Type:            constants.TRANSACTION_TYPE_INCOMING,
 		State:           constants.TRANSACTION_STATE_PENDING,
-		AmountMsat:      uint64(lnClientTransaction.Amount),
+		AmountMsat:      uint64(lnClientTransaction.AmountMsat),
 		Description:     description,
 		DescriptionHash: descriptionHash,
 		PaymentRequest:  lnClientTransaction.Invoice,
@@ -411,7 +411,7 @@ func (svc *transactionsService) SendPaymentSync(payReq string, amountMsat *uint6
 	// the payment definitely succeeded
 	var settledTransaction *db.Transaction
 	err = svc.db.Transaction(func(tx *gorm.DB) error {
-		settledTransaction, err = svc.markTransactionSettled(tx, &dbTransaction, response.Preimage, response.Fee, selfPayment)
+		settledTransaction, err = svc.markTransactionSettled(tx, &dbTransaction, response.Preimage, response.FeeMsat, selfPayment)
 		return err
 	})
 	if err != nil {
@@ -523,7 +523,8 @@ func (svc *transactionsService) SendKeysend(amount uint64, destination string, c
 		_, err = svc.interceptSelfPayment("", paymentHash, lnClient)
 		if err == nil {
 			payKeysendResponse = &lnclient.PayKeysendResponse{
-				Fee: 0,
+				Fee:     0,
+				FeeMsat: 0,
 			}
 		}
 	} else {
@@ -553,7 +554,7 @@ func (svc *transactionsService) SendKeysend(amount uint64, destination string, c
 	// the payment definitely succeeded
 	var settledTransaction *db.Transaction
 	err = svc.db.Transaction(func(tx *gorm.DB) error {
-		settledTransaction, err = svc.markTransactionSettled(tx, &dbTransaction, preimage, payKeysendResponse.Fee, selfPayment)
+		settledTransaction, err = svc.markTransactionSettled(tx, &dbTransaction, preimage, payKeysendResponse.FeeMsat, selfPayment)
 		return err
 	})
 
@@ -721,7 +722,7 @@ func (svc *transactionsService) checkUnsettledTransaction(ctx context.Context, t
 	// update transaction state
 	if lnClientTransaction.SettledAt != nil {
 		err = svc.db.Transaction(func(tx *gorm.DB) error {
-			_, err = svc.markTransactionSettled(tx, transaction, lnClientTransaction.Preimage, uint64(lnClientTransaction.FeesPaid), false)
+			_, err = svc.markTransactionSettled(tx, transaction, lnClientTransaction.Preimage, uint64(lnClientTransaction.FeesPaidMsat), false)
 			return err
 		})
 
@@ -778,7 +779,7 @@ func (svc *transactionsService) ConsumeEvent(ctx context.Context, event *events.
 				}
 				dbTransaction = db.Transaction{
 					Type:            constants.TRANSACTION_TYPE_INCOMING,
-					AmountMsat:      uint64(lnClientTransaction.Amount),
+					AmountMsat:      uint64(lnClientTransaction.AmountMsat),
 					PaymentRequest:  lnClientTransaction.Invoice,
 					PaymentHash:     lnClientTransaction.PaymentHash,
 					Description:     description,
@@ -797,7 +798,7 @@ func (svc *transactionsService) ConsumeEvent(ctx context.Context, event *events.
 				}
 			}
 
-			_, err := svc.markTransactionSettled(tx, &dbTransaction, lnClientTransaction.Preimage, uint64(lnClientTransaction.FeesPaid), false)
+			_, err := svc.markTransactionSettled(tx, &dbTransaction, lnClientTransaction.Preimage, uint64(lnClientTransaction.FeesPaidMsat), false)
 			return err
 		})
 
@@ -867,7 +868,7 @@ func (svc *transactionsService) ConsumeEvent(ctx context.Context, event *events.
 						dbTransaction = db.Transaction{
 							Type:            constants.TRANSACTION_TYPE_OUTGOING,
 							State:           constants.TRANSACTION_STATE_PENDING,
-							AmountMsat:      uint64(lnClientTransaction.Amount),
+							AmountMsat:      uint64(lnClientTransaction.AmountMsat),
 							FeeReserveMsat:  0,
 							PaymentRequest:  lnClientTransaction.Invoice,
 							PaymentHash:     lnClientTransaction.PaymentHash,
@@ -891,7 +892,7 @@ func (svc *transactionsService) ConsumeEvent(ctx context.Context, event *events.
 				}
 			}
 
-			_, err := svc.markTransactionSettled(tx, &dbTransaction, lnClientTransaction.Preimage, uint64(lnClientTransaction.FeesPaid), false)
+			_, err := svc.markTransactionSettled(tx, &dbTransaction, lnClientTransaction.Preimage, uint64(lnClientTransaction.FeesPaidMsat), false)
 			return err
 		})
 
@@ -1023,6 +1024,7 @@ func (svc *transactionsService) interceptSelfPayment(paymentRequest string, paym
 	return &lnclient.PayInvoiceResponse{
 		Preimage: *incomingTransaction.Preimage,
 		Fee:      0,
+		FeeMsat:  0,
 	}, nil
 }
 
@@ -1057,6 +1059,7 @@ func (svc *transactionsService) interceptSelfHoldPayment(paymentRequest string, 
 		return &lnclient.PayInvoiceResponse{
 			Preimage: *settledTransaction.Preimage,
 			Fee:      0,
+			FeeMsat:  0,
 		}, nil
 	case canceledTransaction := <-canceledChannel:
 		logger.Logger.WithField("canceled_transaction", canceledTransaction).Info("self hold payment was canceled")

--- a/wails/wails_handlers.go
+++ b/wails/wails_handlers.go
@@ -344,7 +344,7 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 				return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 			}
 		}
-		paymentResponse, err := app.api.SendPayment(ctx, invoice, payRequest.Amount, payRequest.Metadata)
+		paymentResponse, err := app.api.SendPayment(ctx, invoice, payRequest.ResolvedAmountMsat(), payRequest.Metadata)
 		if err != nil {
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
@@ -547,7 +547,7 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			}).WithError(err).Error("Failed to decode request to wails router")
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
-		invoice, err := app.api.CreateInvoice(ctx, makeInvoiceRequest.Amount, makeInvoiceRequest.Description)
+		invoice, err := app.api.CreateInvoice(ctx, makeInvoiceRequest.ResolvedAmountMsat(), makeInvoiceRequest.Description)
 		if err != nil {
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
@@ -580,7 +580,7 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
 
-		redeemOnchainFundsResponse, err := app.api.RedeemOnchainFunds(ctx, redeemOnchainFundsRequest.ToAddress, redeemOnchainFundsRequest.Amount, redeemOnchainFundsRequest.FeeRate, redeemOnchainFundsRequest.SendAll)
+		redeemOnchainFundsResponse, err := app.api.RedeemOnchainFunds(ctx, redeemOnchainFundsRequest.ToAddress, redeemOnchainFundsRequest.ResolvedAmountSat(), redeemOnchainFundsRequest.ResolvedFeeRateSatPerVbyte(), redeemOnchainFundsRequest.SendAll)
 		if err != nil {
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}


### PR DESCRIPTION
Should close #2223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - API now exposes explicit sat/msat/fee-rate fields for invoices, payments, swaps and channel balances for clearer units and safer amounts.
- **Refactor**
  - Internal request/resolution logic now prefers explicit sat/msat fields while keeping legacy aliases for compatibility; protocol clients and transaction records moved to msat/sat naming.
- **Tests**
  - Unit tests updated/added to verify resolution behavior and msat/sat mappings across APIs and services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->