### PR TITLE
fix: remove bzip install command (agent can figure it out)

### DIFF
--- a/scripts/linux-aarch64/install.sh
+++ b/scripts/linux-aarch64/install.sh
@@ -91,7 +91,7 @@ cd "$INSTALL_DIR" || exit 1
 
 # check bzip2 is available before downloading
 if ! command -v bzip2 > /dev/null 2>&1; then
-  echo "❌ bzip2 is required but not installed. Run: sudo apt-get install -y bzip2" >&2
+  echo "❌ bzip2 is required but not installed." >&2
   exit 1
 fi
 

--- a/scripts/linux-x86_64/install.sh
+++ b/scripts/linux-x86_64/install.sh
@@ -91,7 +91,7 @@ cd "$INSTALL_DIR" || exit 1
 
 # check bzip2 is available before downloading
 if ! command -v bzip2 > /dev/null 2>&1; then
-  echo "❌ bzip2 is required but not installed. Run: sudo apt-get install -y bzip2" >&2
+  echo "❌ bzip2 is required but not installed." >&2
   exit 1
 fi
 


### PR DESCRIPTION
See https://github.com/getAlby/hub/pull/2245#discussion_r3116201180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Simplified error messaging in Linux installation scripts when the `bzip2` dependency is missing, providing cleaner output during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->