### PR TITLE
chore: update request structs to use sat/msat suffixes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -72,7 +72,11 @@ func (api *api) CreateApp(createAppRequest *CreateAppRequest) (*CreateAppRespons
 		}
 	}
 
-	maxAmountSat, _ := ResolveToSat(createAppRequest.MaxAmountSat, createAppRequest.MaxAmountMsat, createAppRequest.MaxAmount, nil)
+	maxAmountSat := uint64(0)
+	resolvedMaxAmountSat, _ := ResolveToSat(createAppRequest.MaxAmountSat, createAppRequest.MaxAmountMsat, createAppRequest.MaxAmount, nil)
+	if resolvedMaxAmountSat != nil {
+		maxAmountSat = *resolvedMaxAmountSat
+	}
 
 	if createAppRequest.Name == alby.ALBY_ACCOUNT_APP_NAME {
 		return nil, fmt.Errorf("Reserved app name: %s", alby.ALBY_ACCOUNT_APP_NAME)
@@ -92,7 +96,7 @@ func (api *api) CreateApp(createAppRequest *CreateAppRequest) (*CreateAppRespons
 	app, pairingSecretKey, err := api.appsSvc.CreateApp(
 		createAppRequest.Name,
 		createAppRequest.Pubkey,
-		*maxAmountSat,
+		maxAmountSat,
 		createAppRequest.BudgetRenewal,
 		expiresAt,
 		createAppRequest.Scopes,

--- a/api/api.go
+++ b/api/api.go
@@ -692,15 +692,15 @@ func (api *api) ListChannels(ctx context.Context) ([]Channel, error) {
 		}
 
 		apiChannels = append(apiChannels, Channel{
-			LocalBalance:                             channel.LocalBalance,
-			LocalBalanceSat:                          channel.LocalBalance / 1000,
-			LocalBalanceMsat:                         channel.LocalBalance,
-			LocalSpendableBalance:                    channel.LocalSpendableBalance,
-			LocalSpendableBalanceSat:                 channel.LocalSpendableBalance / 1000,
-			LocalSpendableBalanceMsat:                channel.LocalSpendableBalance,
-			RemoteBalance:                            channel.RemoteBalance,
-			RemoteBalanceSat:                         channel.RemoteBalance / 1000,
-			RemoteBalanceMsat:                        channel.RemoteBalance,
+			LocalBalance:                             channel.LocalBalanceMsat,
+			LocalBalanceSat:                          channel.LocalBalanceMsat / 1000,
+			LocalBalanceMsat:                         channel.LocalBalanceMsat,
+			LocalSpendableBalance:                    channel.LocalSpendableBalanceMsat,
+			LocalSpendableBalanceSat:                 channel.LocalSpendableBalanceMsat / 1000,
+			LocalSpendableBalanceMsat:                channel.LocalSpendableBalanceMsat,
+			RemoteBalance:                            channel.RemoteBalanceMsat,
+			RemoteBalanceSat:                         channel.RemoteBalanceMsat / 1000,
+			RemoteBalanceMsat:                        channel.RemoteBalanceMsat,
 			Id:                                       channel.Id,
 			RemotePubkey:                             channel.RemotePubkey,
 			FundingTxId:                              channel.FundingTxId,
@@ -712,10 +712,10 @@ func (api *api) ListChannels(ctx context.Context) ([]Channel, error) {
 			ConfirmationsRequired:                    channel.ConfirmationsRequired,
 			ForwardingFeeBaseMsat:                    channel.ForwardingFeeBaseMsat,
 			ForwardingFeeProportionalMillionths:      channel.ForwardingFeeProportionalMillionths,
-			UnspendablePunishmentReserve:             channel.UnspendablePunishmentReserve,
-			UnspendablePunishmentReserveSat:          channel.UnspendablePunishmentReserve,
-			CounterpartyUnspendablePunishmentReserve: channel.CounterpartyUnspendablePunishmentReserve,
-			CounterpartyUnspendablePunishmentReserveSat: channel.CounterpartyUnspendablePunishmentReserve,
+			UnspendablePunishmentReserve:             channel.UnspendablePunishmentReserveSat,
+			UnspendablePunishmentReserveSat:          channel.UnspendablePunishmentReserveSat,
+			CounterpartyUnspendablePunishmentReserve: channel.CounterpartyUnspendablePunishmentReserveSat,
+			CounterpartyUnspendablePunishmentReserveSat: channel.CounterpartyUnspendablePunishmentReserveSat,
 			Error:      channel.Error,
 			IsOutbound: channel.IsOutbound,
 			Status:     status,
@@ -913,10 +913,10 @@ func toApiSwap(swap *swaps.Swap) *Swap {
 		Type:               swap.Type,
 		State:              swap.State,
 		Invoice:            swap.Invoice,
-		SendAmount:         swap.SendAmount,
-		SendAmountSat:      swap.SendAmount,
-		ReceiveAmount:      swap.ReceiveAmount,
-		ReceiveAmountSat:   swap.ReceiveAmount,
+		SendAmount:         swap.SendAmountSat,
+		SendAmountSat:      swap.SendAmountSat,
+		ReceiveAmount:      swap.ReceiveAmountSat,
+		ReceiveAmountSat:   swap.ReceiveAmountSat,
 		PaymentHash:        swap.PaymentHash,
 		DestinationAddress: swap.DestinationAddress,
 		RefundAddress:      swap.RefundAddress,
@@ -944,12 +944,12 @@ func (api *api) GetSwapInInfo() (*SwapInfoResponse, error) {
 	return &SwapInfoResponse{
 		AlbyServiceFee:     swapInInfo.AlbyServiceFee,
 		BoltzServiceFee:    swapInInfo.BoltzServiceFee,
-		BoltzNetworkFee:    swapInInfo.BoltzNetworkFee,
-		BoltzNetworkFeeSat: swapInInfo.BoltzNetworkFee,
-		MinAmount:          swapInInfo.MinAmount,
-		MinAmountSat:       swapInInfo.MinAmount,
-		MaxAmount:          swapInInfo.MaxAmount,
-		MaxAmountSat:       swapInInfo.MaxAmount,
+		BoltzNetworkFee:    swapInInfo.BoltzNetworkFeeSat,
+		BoltzNetworkFeeSat: swapInInfo.BoltzNetworkFeeSat,
+		MinAmount:          swapInInfo.MinAmountSat,
+		MinAmountSat:       swapInInfo.MinAmountSat,
+		MaxAmount:          swapInInfo.MaxAmountSat,
+		MaxAmountSat:       swapInInfo.MaxAmountSat,
 	}, nil
 }
 
@@ -966,12 +966,12 @@ func (api *api) GetSwapOutInfo() (*SwapInfoResponse, error) {
 	return &SwapInfoResponse{
 		AlbyServiceFee:     swapOutInfo.AlbyServiceFee,
 		BoltzServiceFee:    swapOutInfo.BoltzServiceFee,
-		BoltzNetworkFee:    swapOutInfo.BoltzNetworkFee,
-		BoltzNetworkFeeSat: swapOutInfo.BoltzNetworkFee,
-		MinAmount:          swapOutInfo.MinAmount,
-		MinAmountSat:       swapOutInfo.MinAmount,
-		MaxAmount:          swapOutInfo.MaxAmount,
-		MaxAmountSat:       swapOutInfo.MaxAmount,
+		BoltzNetworkFee:    swapOutInfo.BoltzNetworkFeeSat,
+		BoltzNetworkFeeSat: swapOutInfo.BoltzNetworkFeeSat,
+		MinAmount:          swapOutInfo.MinAmountSat,
+		MinAmountSat:       swapOutInfo.MinAmountSat,
+		MaxAmount:          swapOutInfo.MaxAmountSat,
+		MaxAmountSat:       swapOutInfo.MaxAmountSat,
 	}, nil
 }
 
@@ -985,17 +985,17 @@ func (api *api) InitiateSwapOut(ctx context.Context, initiateSwapOutRequest *Ini
 		return nil, errors.New("SwapsService not started")
 	}
 
-	amount := initiateSwapOutRequest.SwapAmount
+	amountSat := initiateSwapOutRequest.SwapAmount
 	destination := initiateSwapOutRequest.Destination
 
-	if amount == 0 {
+	if amountSat == 0 {
 		return nil, errors.New("invalid swap amount")
 	}
 
-	swapOutResponse, err := api.svc.GetSwapsService().SwapOut(amount, destination, false, false)
+	swapOutResponse, err := api.svc.GetSwapsService().SwapOut(amountSat, destination, false, false)
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
-			"amount":      amount,
+			"amount_sat":  amountSat,
 			"destination": destination,
 		}).WithError(err).Error("Failed to initiate swap out")
 		return nil, err
@@ -1014,16 +1014,16 @@ func (api *api) InitiateSwapIn(ctx context.Context, initiateSwapInRequest *Initi
 		return nil, errors.New("SwapsService not started")
 	}
 
-	amount := initiateSwapInRequest.SwapAmount
+	amountSat := initiateSwapInRequest.SwapAmount
 
-	if amount == 0 {
+	if amountSat == 0 {
 		return nil, errors.New("invalid swap amount")
 	}
 
-	swapInResponse, err := api.svc.GetSwapsService().SwapIn(amount, false)
+	swapInResponse, err := api.svc.GetSwapsService().SwapIn(amountSat, false)
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
-			"amount": amount,
+			"amount_sat": amountSat,
 		}).WithError(err).Error("Failed to initiate swap in")
 		return nil, err
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -73,7 +73,7 @@ func (api *api) CreateApp(createAppRequest *CreateAppRequest) (*CreateAppRespons
 	}
 
 	maxAmountSat := uint64(0)
-	resolvedMaxAmountSat, _ := ResolveToSat(createAppRequest.MaxAmountSat, createAppRequest.MaxAmountMsat, createAppRequest.MaxAmount, nil)
+	resolvedMaxAmountSat := ResolveToSat(createAppRequest.MaxAmountSat, createAppRequest.MaxAmountMsat, createAppRequest.MaxAmount, nil)
 	if resolvedMaxAmountSat != nil {
 		maxAmountSat = *resolvedMaxAmountSat
 	}
@@ -150,7 +150,7 @@ func (api *api) CreateApp(createAppRequest *CreateAppRequest) (*CreateAppRespons
 }
 
 func (api *api) UpdateApp(userApp *db.App, updateAppRequest *UpdateAppRequest) error {
-	resolvedMaxAmountSat, _ := ResolveToSat(updateAppRequest.MaxAmountSat, updateAppRequest.MaxAmountMsat, updateAppRequest.MaxAmount, nil)
+	resolvedMaxAmountSat := ResolveToSat(updateAppRequest.MaxAmountSat, updateAppRequest.MaxAmountMsat, updateAppRequest.MaxAmount, nil)
 
 	err := api.db.Transaction(func(tx *gorm.DB) error {
 		// Initialize name with current app name, update if provided
@@ -993,8 +993,11 @@ func (api *api) InitiateSwapOut(ctx context.Context, initiateSwapOutRequest *Ini
 		return nil, errors.New("SwapsService not started")
 	}
 
-	resolvedAmountSat, _ := ResolveToSat(initiateSwapOutRequest.SwapAmountSat, nil, initiateSwapOutRequest.SwapAmount, nil)
-	amountSat := *resolvedAmountSat
+	amountSat := uint64(0)
+	resolvedAmountSat := ResolveToSat(initiateSwapOutRequest.SwapAmountSat, nil, initiateSwapOutRequest.SwapAmount, nil)
+	if resolvedAmountSat != nil {
+		amountSat = *resolvedAmountSat
+	}
 	destination := initiateSwapOutRequest.Destination
 
 	if amountSat == 0 {
@@ -1023,8 +1026,11 @@ func (api *api) InitiateSwapIn(ctx context.Context, initiateSwapInRequest *Initi
 		return nil, errors.New("SwapsService not started")
 	}
 
-	resolvedAmountSat, _ := ResolveToSat(initiateSwapInRequest.SwapAmountSat, nil, initiateSwapInRequest.SwapAmount, nil)
-	amountSat := *resolvedAmountSat
+	amountSat := uint64(0)
+	resolvedAmountSat := ResolveToSat(initiateSwapInRequest.SwapAmountSat, nil, initiateSwapInRequest.SwapAmount, nil)
+	if resolvedAmountSat != nil {
+		amountSat = *resolvedAmountSat
+	}
 
 	if amountSat == 0 {
 		return nil, errors.New("invalid swap amount")
@@ -1066,16 +1072,24 @@ func (api *api) EnableAutoSwapOut(ctx context.Context, enableAutoSwapsRequest *E
 		}
 	}
 
-	resolvedBalanceThresholdSat, _ := ResolveToSat(enableAutoSwapsRequest.BalanceThresholdSat, nil, enableAutoSwapsRequest.BalanceThreshold, nil)
-	balanceThresholdSat := *resolvedBalanceThresholdSat
+	balanceThresholdSat := uint64(0)
+	resolvedBalanceThresholdSat := ResolveToSat(enableAutoSwapsRequest.BalanceThresholdSat, nil, enableAutoSwapsRequest.BalanceThreshold, nil)
+	if resolvedBalanceThresholdSat != nil {
+		balanceThresholdSat = *resolvedBalanceThresholdSat
+	}
+
 	err := api.cfg.SetUpdate(config.AutoSwapBalanceThresholdKey, strconv.FormatUint(balanceThresholdSat, 10), "")
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to save autoswap balance threshold to config")
 		return err
 	}
 
-	resolvedSwapAmountSat, _ := ResolveToSat(enableAutoSwapsRequest.SwapAmountSat, nil, enableAutoSwapsRequest.SwapAmount, nil)
-	swapAmountSat := *resolvedSwapAmountSat
+	swapAmountSat := uint64(0)
+	resolvedSwapAmountSat := ResolveToSat(enableAutoSwapsRequest.SwapAmountSat, nil, enableAutoSwapsRequest.SwapAmount, nil)
+	if resolvedSwapAmountSat != nil {
+		swapAmountSat = *resolvedSwapAmountSat
+	}
+
 	err = api.cfg.SetUpdate(config.AutoSwapAmountKey, strconv.FormatUint(swapAmountSat, 10), "")
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to save autoswap amount to config")
@@ -1685,8 +1699,11 @@ func (api *api) MigrateNodeStorage(ctx context.Context, to string) error {
 }
 
 func (api *api) SendSpontaneousPaymentProbes(ctx context.Context, sendSpontaneousPaymentProbesRequest *SendSpontaneousPaymentProbesRequest) (*SendSpontaneousPaymentProbesResponse, error) {
-	resolvedAmountMsat, _ := ResolveToMsat(sendSpontaneousPaymentProbesRequest.AmountSat, sendSpontaneousPaymentProbesRequest.AmountMsat, nil, sendSpontaneousPaymentProbesRequest.Amount)
-	amountMsat := *resolvedAmountMsat
+	amountMsat := uint64(0)
+	resolvedAmountMsat := ResolveToMsat(sendSpontaneousPaymentProbesRequest.AmountSat, sendSpontaneousPaymentProbesRequest.AmountMsat, nil, sendSpontaneousPaymentProbesRequest.Amount)
+	if resolvedAmountMsat != nil {
+		amountMsat = *resolvedAmountMsat
+	}
 
 	lnClient := api.svc.GetLNClient()
 	if lnClient == nil {

--- a/api/api.go
+++ b/api/api.go
@@ -72,6 +72,8 @@ func (api *api) CreateApp(createAppRequest *CreateAppRequest) (*CreateAppRespons
 		}
 	}
 
+	maxAmountSat, _ := ResolveToSat(createAppRequest.MaxAmountSat, createAppRequest.MaxAmountMsat, createAppRequest.MaxAmount, nil)
+
 	if createAppRequest.Name == alby.ALBY_ACCOUNT_APP_NAME {
 		return nil, fmt.Errorf("Reserved app name: %s", alby.ALBY_ACCOUNT_APP_NAME)
 	}
@@ -90,7 +92,7 @@ func (api *api) CreateApp(createAppRequest *CreateAppRequest) (*CreateAppRespons
 	app, pairingSecretKey, err := api.appsSvc.CreateApp(
 		createAppRequest.Name,
 		createAppRequest.Pubkey,
-		createAppRequest.MaxAmountSat,
+		*maxAmountSat,
 		createAppRequest.BudgetRenewal,
 		expiresAt,
 		createAppRequest.Scopes,
@@ -144,6 +146,8 @@ func (api *api) CreateApp(createAppRequest *CreateAppRequest) (*CreateAppRespons
 }
 
 func (api *api) UpdateApp(userApp *db.App, updateAppRequest *UpdateAppRequest) error {
+	resolvedMaxAmountSat, _ := ResolveToSat(updateAppRequest.MaxAmountSat, updateAppRequest.MaxAmountMsat, updateAppRequest.MaxAmount, nil)
+
 	err := api.db.Transaction(func(tx *gorm.DB) error {
 		// Initialize name with current app name, update if provided
 		name := userApp.Name
@@ -206,7 +210,7 @@ func (api *api) UpdateApp(userApp *db.App, updateAppRequest *UpdateAppRequest) e
 		}
 
 		// Handle permissions updates only if any permission-related field is provided
-		if updateAppRequest.Scopes != nil || updateAppRequest.MaxAmountSat != nil ||
+		if updateAppRequest.Scopes != nil || resolvedMaxAmountSat != nil ||
 			updateAppRequest.BudgetRenewal != nil || updateAppRequest.ExpiresAt != nil || updateAppRequest.UpdateExpiresAt {
 
 			// Get current values or use provided ones
@@ -234,8 +238,8 @@ func (api *api) UpdateApp(userApp *db.App, updateAppRequest *UpdateAppRequest) e
 			}
 
 			// Override with provided values
-			if updateAppRequest.MaxAmountSat != nil {
-				maxAmountSat = *updateAppRequest.MaxAmountSat
+			if resolvedMaxAmountSat != nil {
+				maxAmountSat = *resolvedMaxAmountSat
 			}
 			if updateAppRequest.BudgetRenewal != nil {
 				budgetRenewal = *updateAppRequest.BudgetRenewal
@@ -985,7 +989,8 @@ func (api *api) InitiateSwapOut(ctx context.Context, initiateSwapOutRequest *Ini
 		return nil, errors.New("SwapsService not started")
 	}
 
-	amountSat := initiateSwapOutRequest.SwapAmount
+	resolvedAmountSat, _ := ResolveToSat(initiateSwapOutRequest.SwapAmountSat, nil, initiateSwapOutRequest.SwapAmount, nil)
+	amountSat := *resolvedAmountSat
 	destination := initiateSwapOutRequest.Destination
 
 	if amountSat == 0 {
@@ -1014,7 +1019,8 @@ func (api *api) InitiateSwapIn(ctx context.Context, initiateSwapInRequest *Initi
 		return nil, errors.New("SwapsService not started")
 	}
 
-	amountSat := initiateSwapInRequest.SwapAmount
+	resolvedAmountSat, _ := ResolveToSat(initiateSwapInRequest.SwapAmountSat, nil, initiateSwapInRequest.SwapAmount, nil)
+	amountSat := *resolvedAmountSat
 
 	if amountSat == 0 {
 		return nil, errors.New("invalid swap amount")
@@ -1056,13 +1062,17 @@ func (api *api) EnableAutoSwapOut(ctx context.Context, enableAutoSwapsRequest *E
 		}
 	}
 
-	err := api.cfg.SetUpdate(config.AutoSwapBalanceThresholdKey, strconv.FormatUint(enableAutoSwapsRequest.BalanceThreshold, 10), "")
+	resolvedBalanceThresholdSat, _ := ResolveToSat(enableAutoSwapsRequest.BalanceThresholdSat, nil, enableAutoSwapsRequest.BalanceThreshold, nil)
+	balanceThresholdSat := *resolvedBalanceThresholdSat
+	err := api.cfg.SetUpdate(config.AutoSwapBalanceThresholdKey, strconv.FormatUint(balanceThresholdSat, 10), "")
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to save autoswap balance threshold to config")
 		return err
 	}
 
-	err = api.cfg.SetUpdate(config.AutoSwapAmountKey, strconv.FormatUint(enableAutoSwapsRequest.SwapAmount, 10), "")
+	resolvedSwapAmountSat, _ := ResolveToSat(enableAutoSwapsRequest.SwapAmountSat, nil, enableAutoSwapsRequest.SwapAmount, nil)
+	swapAmountSat := *resolvedSwapAmountSat
+	err = api.cfg.SetUpdate(config.AutoSwapAmountKey, strconv.FormatUint(swapAmountSat, 10), "")
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to save autoswap amount to config")
 		return err
@@ -1671,13 +1681,16 @@ func (api *api) MigrateNodeStorage(ctx context.Context, to string) error {
 }
 
 func (api *api) SendSpontaneousPaymentProbes(ctx context.Context, sendSpontaneousPaymentProbesRequest *SendSpontaneousPaymentProbesRequest) (*SendSpontaneousPaymentProbesResponse, error) {
+	resolvedAmountMsat, _ := ResolveToMsat(sendSpontaneousPaymentProbesRequest.AmountSat, sendSpontaneousPaymentProbesRequest.AmountMsat, nil, sendSpontaneousPaymentProbesRequest.Amount)
+	amountMsat := *resolvedAmountMsat
+
 	lnClient := api.svc.GetLNClient()
 	if lnClient == nil {
 		return nil, ErrLNClientNotStarted
 	}
 
 	var errMessage string
-	err := lnClient.SendSpontaneousPaymentProbes(ctx, sendSpontaneousPaymentProbesRequest.Amount, sendSpontaneousPaymentProbesRequest.NodeId)
+	err := lnClient.SendSpontaneousPaymentProbes(ctx, amountMsat, sendSpontaneousPaymentProbesRequest.NodeId)
 	if err != nil {
 		errMessage = err.Error()
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -1657,21 +1657,6 @@ func (api *api) GetWalletCapabilities(ctx context.Context) (*WalletCapabilitiesR
 	}, nil
 }
 
-func (api *api) SendPaymentProbes(ctx context.Context, sendPaymentProbesRequest *SendPaymentProbesRequest) (*SendPaymentProbesResponse, error) {
-	lnClient := api.svc.GetLNClient()
-	if lnClient == nil {
-		return nil, ErrLNClientNotStarted
-	}
-
-	var errMessage string
-	err := lnClient.SendPaymentProbes(ctx, sendPaymentProbesRequest.Invoice)
-	if err != nil {
-		errMessage = err.Error()
-	}
-
-	return &SendPaymentProbesResponse{Error: errMessage}, nil
-}
-
 func (api *api) MigrateNodeStorage(ctx context.Context, to string) error {
 	if api.svc.GetLNClient() == nil {
 		return ErrLNClientNotStarted
@@ -1696,27 +1681,6 @@ func (api *api) MigrateNodeStorage(ctx context.Context, to string) error {
 	api.cfg.SetUpdate("LdkVssEnabled", "true", "")
 	api.cfg.SetUpdate("LdkMigrateStorage", "VSS", "")
 	return api.Stop()
-}
-
-func (api *api) SendSpontaneousPaymentProbes(ctx context.Context, sendSpontaneousPaymentProbesRequest *SendSpontaneousPaymentProbesRequest) (*SendSpontaneousPaymentProbesResponse, error) {
-	amountMsat := uint64(0)
-	resolvedAmountMsat := ResolveToMsat(sendSpontaneousPaymentProbesRequest.AmountSat, sendSpontaneousPaymentProbesRequest.AmountMsat, nil, sendSpontaneousPaymentProbesRequest.Amount)
-	if resolvedAmountMsat != nil {
-		amountMsat = *resolvedAmountMsat
-	}
-
-	lnClient := api.svc.GetLNClient()
-	if lnClient == nil {
-		return nil, ErrLNClientNotStarted
-	}
-
-	var errMessage string
-	err := lnClient.SendSpontaneousPaymentProbes(ctx, amountMsat, sendSpontaneousPaymentProbesRequest.NodeId)
-	if err != nil {
-		errMessage = err.Error()
-	}
-
-	return &SendSpontaneousPaymentProbesResponse{Error: errMessage}, nil
 }
 
 func (api *api) GetNetworkGraph(ctx context.Context, nodeIds []string) (NetworkGraphResponse, error) {

--- a/api/lsp.go
+++ b/api/lsp.go
@@ -59,8 +59,11 @@ func (api *api) RequestLSPOrder(ctx context.Context, request *LSPOrderRequest) (
 
 	invoice, feeSat, err := api.requestLSPS1Invoice(ctx, lnClient, request, nodeInfo.Network, nodeInfo.Pubkey, lspInfo.MaxChannelExpiryBlocks, lspInfo.MinRequiredChannelConfirmations, lspInfo.MinFundingConfirmsWithinBlocks)
 	invoiceAmountSat := uint64(0)
-	amountSat, _ := ResolveToSat(request.AmountSat, nil, request.Amount, nil)
-	incomingLiquiditySat := *amountSat
+	incomingLiquiditySat := uint64(0)
+	resolvedAmountSat := ResolveToSat(request.AmountSat, nil, request.Amount, nil)
+	if resolvedAmountSat != nil {
+		incomingLiquiditySat = *resolvedAmountSat
+	}
 
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to request invoice")
@@ -141,8 +144,12 @@ func (api *api) requestLSPS1Invoice(ctx context.Context, lnClient lnclient.LNCli
 		token = "AlbyHub/" + version.Tag
 	}
 
-	amountSat, _ := ResolveToSat(request.AmountSat, nil, request.Amount, nil)
-	lspBalanceSat := strconv.FormatUint(*amountSat, 10)
+	amountSat := uint64(0)
+	resolvedAmountSat := ResolveToSat(request.AmountSat, nil, request.Amount, nil)
+	if resolvedAmountSat != nil {
+		amountSat = *resolvedAmountSat
+	}
+	lspBalanceSat := strconv.FormatUint(amountSat, 10)
 
 	lsps1ChannelRequest := &alby.LSPChannelRequest{
 		PublicKey:                    pubkey,

--- a/api/lsp.go
+++ b/api/lsp.go
@@ -59,7 +59,8 @@ func (api *api) RequestLSPOrder(ctx context.Context, request *LSPOrderRequest) (
 
 	invoice, feeSat, err := api.requestLSPS1Invoice(ctx, lnClient, request, nodeInfo.Network, nodeInfo.Pubkey, lspInfo.MaxChannelExpiryBlocks, lspInfo.MinRequiredChannelConfirmations, lspInfo.MinFundingConfirmsWithinBlocks)
 	invoiceAmountSat := uint64(0)
-	incomingLiquiditySat := request.Amount
+	amountSat, _ := ResolveToSat(request.AmountSat, nil, request.Amount, nil)
+	incomingLiquiditySat := *amountSat
 
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to request invoice")
@@ -140,9 +141,12 @@ func (api *api) requestLSPS1Invoice(ctx context.Context, lnClient lnclient.LNCli
 		token = "AlbyHub/" + version.Tag
 	}
 
+	amountSat, _ := ResolveToSat(request.AmountSat, nil, request.Amount, nil)
+	lspBalanceSat := strconv.FormatUint(*amountSat, 10)
+
 	lsps1ChannelRequest := &alby.LSPChannelRequest{
 		PublicKey:                    pubkey,
-		LSPBalanceSat:                strconv.FormatUint(request.Amount, 10),
+		LSPBalanceSat:                lspBalanceSat,
 		ClientBalanceSat:             "0",
 		RequiredChannelConfirmations: requiredChannelConfirmations,
 		FundingConfirmsWithinBlocks:  minFundingConfirmsWithinBlocks,

--- a/api/models.go
+++ b/api/models.go
@@ -54,8 +54,6 @@ type API interface {
 	SetNextBackupReminder(backupReminderRequest *BackupReminderRequest) error
 	Start(startRequest *StartRequest)
 	Setup(ctx context.Context, setupRequest *SetupRequest) error
-	SendPaymentProbes(ctx context.Context, sendPaymentProbesRequest *SendPaymentProbesRequest) (*SendPaymentProbesResponse, error)
-	SendSpontaneousPaymentProbes(ctx context.Context, sendSpontaneousPaymentProbesRequest *SendSpontaneousPaymentProbesRequest) (*SendSpontaneousPaymentProbesResponse, error)
 	GetNetworkGraph(ctx context.Context, nodeIds []string) (NetworkGraphResponse, error)
 	SyncWallet() error
 	GetLogOutput(ctx context.Context, logType string, getLogRequest *GetLogOutputRequest) (*GetLogOutputResponse, error)
@@ -440,26 +438,6 @@ type Boostagram struct {
 	Action         string `json:"action"`
 	ValueSatTotal  int64  `json:"valueSatTotal"`
 	ValueMsatTotal int64  `json:"valueMsatTotal"`
-}
-
-// debug api
-type SendPaymentProbesRequest struct {
-	Invoice string `json:"invoice"`
-}
-
-type SendPaymentProbesResponse struct {
-	Error string `json:"error"`
-}
-
-type SendSpontaneousPaymentProbesRequest struct {
-	Amount     *uint64 `json:"amount"` // deprecated
-	AmountSat  *uint64 `json:"amountSat"`
-	AmountMsat *uint64 `json:"amountMsat"`
-	NodeId     string  `json:"nodeId"`
-}
-
-type SendSpontaneousPaymentProbesResponse struct {
-	Error string `json:"error"`
 }
 
 const (

--- a/api/models.go
+++ b/api/models.go
@@ -629,7 +629,7 @@ type GetForwardsResponse struct {
 	NumForwards                 uint64 `json:"numForwards"`
 }
 
-func ResolveToSat(satValue *uint64, msatValue *uint64, legacyValueSat *uint64, legacyValueMsat *uint64) (resolvedSatValue *uint64, err error) {
+func ResolveToSat(satValue *uint64, msatValue *uint64, legacyValueSat *uint64, legacyValueMsat *uint64) (resolvedSatValue *uint64) {
 	if legacyValueSat != nil {
 		resolvedSatValue = legacyValueSat
 	}
@@ -648,14 +648,10 @@ func ResolveToSat(satValue *uint64, msatValue *uint64, legacyValueSat *uint64, l
 		resolvedSatValue = &satValue
 	}
 
-	if resolvedSatValue == nil {
-		return nil, errors.New("all fields are empty")
-	}
-
-	return resolvedSatValue, nil
+	return resolvedSatValue
 }
 
-func ResolveToMsat(satValue *uint64, msatValue *uint64, legacyValueSat *uint64, legacyValueMsat *uint64) (resolvedMsatValue *uint64, err error) {
+func ResolveToMsat(satValue *uint64, msatValue *uint64, legacyValueSat *uint64, legacyValueMsat *uint64) (resolvedMsatValue *uint64) {
 	if legacyValueSat != nil {
 		msatValue := *legacyValueSat * 1000
 		resolvedMsatValue = &msatValue
@@ -674,9 +670,5 @@ func ResolveToMsat(satValue *uint64, msatValue *uint64, legacyValueSat *uint64, 
 		resolvedMsatValue = msatValue
 	}
 
-	if resolvedMsatValue == nil {
-		return nil, errors.New("all fields are empty")
-	}
-
-	return resolvedMsatValue, nil
+	return resolvedMsatValue
 }

--- a/api/models.go
+++ b/api/models.go
@@ -367,7 +367,7 @@ type RebalanceChannelResponse struct {
 
 type RedeemOnchainFundsRequest struct {
 	ToAddress string  `json:"toAddress"`
-	Amount    uint64  `json:"amount"`
+	AmountSat uint64  `json:"amount"`
 	FeeRate   *uint64 `json:"feeRate"`
 	SendAll   bool    `json:"sendAll"`
 }

--- a/api/models.go
+++ b/api/models.go
@@ -132,7 +132,9 @@ type ListAppsResponse struct {
 
 type UpdateAppRequest struct {
 	Name            *string   `json:"name"`
-	MaxAmountSat    *uint64   `json:"maxAmount"`
+	MaxAmount       *uint64   `json:"maxAmount"` // deprecated
+	MaxAmountSat    *uint64   `json:"maxAmountSat"`
+	MaxAmountMsat   *uint64   `json:"maxAmountMsat"`
 	BudgetRenewal   *string   `json:"budgetRenewal"`
 	ExpiresAt       *string   `json:"expiresAt"`
 	UpdateExpiresAt bool      `json:"updateExpiresAt"`
@@ -142,16 +144,19 @@ type UpdateAppRequest struct {
 }
 
 type TransferRequest struct {
-	AmountSat   uint64 `json:"amountSat"`
-	FromAppId   *uint  `json:"fromAppId"`
-	ToAppId     *uint  `json:"toAppId"`
-	Description string `json:"description"`
+	AmountSat   *uint64 `json:"amountSat"`
+	AmountMsat  *uint64 `json:"amountMsat"`
+	FromAppId   *uint   `json:"fromAppId"`
+	ToAppId     *uint   `json:"toAppId"`
+	Description string  `json:"description"`
 }
 
 type CreateAppRequest struct {
 	Name           string   `json:"name"`
 	Pubkey         string   `json:"pubkey"`
-	MaxAmountSat   uint64   `json:"maxAmount"`
+	MaxAmount      *uint64  `json:"maxAmount"` // deprecated
+	MaxAmountSat   *uint64  `json:"maxAmountSat"`
+	MaxAmountMsat  *uint64  `json:"maxAmountMsat"`
 	BudgetRenewal  string   `json:"budgetRenewal"`
 	ExpiresAt      string   `json:"expiresAt"`
 	Scopes         []string `json:"scopes"`
@@ -167,8 +172,9 @@ type CreateLightningAddressRequest struct {
 }
 
 type InitiateSwapRequest struct {
-	SwapAmount  uint64 `json:"swapAmount"`
-	Destination string `json:"destination"`
+	SwapAmount    *uint64 `json:"swapAmount"` // deprecated
+	SwapAmountSat *uint64 `json:"swapAmountSat"`
+	Destination   string  `json:"destination"`
 }
 
 type RefundSwapRequest struct {
@@ -177,11 +183,13 @@ type RefundSwapRequest struct {
 }
 
 type EnableAutoSwapRequest struct {
-	BalanceThreshold uint64 `json:"balanceThreshold"`
-	SwapAmount       uint64 `json:"swapAmount"`
-	Destination      string `json:"destination"`
-	DestinationType  string `json:"destinationType"`
-	UnlockPassword   string `json:"unlockPassword"`
+	BalanceThreshold    *uint64 `json:"balanceThreshold"` // deprecated
+	BalanceThresholdSat *uint64 `json:"balanceThresholdSat"`
+	SwapAmount          *uint64 `json:"swapAmount"` // deprecated
+	SwapAmountSat       *uint64 `json:"swapAmountSat"`
+	Destination         string  `json:"destination"`
+	DestinationType     string  `json:"destinationType"`
+	UnlockPassword      string  `json:"unlockPassword"`
 }
 
 type GetAutoSwapConfigResponse struct {
@@ -357,8 +365,9 @@ type CloseChannelResponse = lnclient.CloseChannelResponse
 type UpdateChannelRequest = lnclient.UpdateChannelRequest
 
 type RebalanceChannelRequest struct {
-	ReceiveThroughNodePubkey string `json:"receiveThroughNodePubkey"`
-	AmountSat                uint64 `json:"amountSat"`
+	ReceiveThroughNodePubkey string  `json:"receiveThroughNodePubkey"`
+	AmountSat                *uint64 `json:"amountSat"`
+	AmountMsat               *uint64 `json:"amountMsat"`
 }
 type RebalanceChannelResponse struct {
 	TotalFeeSat  uint64 `json:"totalFeeSat"`
@@ -367,7 +376,8 @@ type RebalanceChannelResponse struct {
 
 type RedeemOnchainFundsRequest struct {
 	ToAddress string  `json:"toAddress"`
-	AmountSat uint64  `json:"amount"`
+	Amount    *uint64 `json:"amount"` // deprecated
+	AmountSat *uint64 `json:"amountSat"`
 	FeeRate   *uint64 `json:"feeRate"`
 	SendAll   bool    `json:"sendAll"`
 }
@@ -442,8 +452,10 @@ type SendPaymentProbesResponse struct {
 }
 
 type SendSpontaneousPaymentProbesRequest struct {
-	Amount uint64 `json:"amount"`
-	NodeId string `json:"nodeId"`
+	Amount     *uint64 `json:"amount"` // deprecated
+	AmountSat  *uint64 `json:"amountSat"`
+	AmountMsat *uint64 `json:"amountMsat"`
+	NodeId     string  `json:"nodeId"`
 }
 
 type SendSpontaneousPaymentProbesResponse struct {
@@ -473,8 +485,10 @@ type SignMessageResponse struct {
 }
 
 type PayInvoiceRequest struct {
-	Amount   *uint64  `json:"amount"`
-	Metadata Metadata `json:"metadata"`
+	Amount     *uint64  `json:"amount"` // deprecated
+	AmountSat  *uint64  `json:"amountSat"`
+	AmountMsat *uint64  `json:"amountMsat"`
+	Metadata   Metadata `json:"metadata"`
 }
 
 type MakeOfferRequest struct {
@@ -482,8 +496,10 @@ type MakeOfferRequest struct {
 }
 
 type MakeInvoiceRequest struct {
-	Amount      uint64 `json:"amount"`
-	Description string `json:"description"`
+	Amount      *uint64 `json:"amount"` // deprecated
+	AmountSat   *uint64 `json:"amountSat"`
+	AmountMsat  *uint64 `json:"amountMsat"`
+	Description string  `json:"description"`
 }
 
 type ResetRouterRequest struct {
@@ -501,10 +517,11 @@ type BasicRestoreWailsRequest struct {
 type NetworkGraphResponse = lnclient.NetworkGraphResponse
 
 type LSPOrderRequest struct {
-	Amount        uint64 `json:"amount"`
-	LSPType       string `json:"lspType"`
-	LSPIdentifier string `json:"lspIdentifier"`
-	Public        bool   `json:"public"`
+	Amount        *uint64 `json:"amount"` // deprecated
+	AmountSat     *uint64 `json:"amountSat"`
+	LSPType       string  `json:"lspType"`
+	LSPIdentifier string  `json:"lspIdentifier"`
+	Public        bool    `json:"public"`
 }
 
 type LSPOrderResponse struct {
@@ -610,4 +627,56 @@ type GetForwardsResponse struct {
 	TotalFeeEarnedSat           uint64 `json:"totalFeeEarnedSat"`
 	TotalFeeEarnedMsat          uint64 `json:"totalFeeEarnedMsat"`
 	NumForwards                 uint64 `json:"numForwards"`
+}
+
+func ResolveToSat(satValue *uint64, msatValue *uint64, legacyValueSat *uint64, legacyValueMsat *uint64) (resolvedSatValue *uint64, err error) {
+	if legacyValueSat != nil {
+		resolvedSatValue = legacyValueSat
+	}
+
+	if legacyValueMsat != nil {
+		satValue := *legacyValueMsat / 1000
+		resolvedSatValue = &satValue
+	}
+
+	if satValue != nil {
+		resolvedSatValue = satValue
+	}
+
+	if msatValue != nil {
+		satValue := *msatValue / 1000
+		resolvedSatValue = &satValue
+	}
+
+	if resolvedSatValue == nil {
+		return nil, errors.New("all fields are empty")
+	}
+
+	return resolvedSatValue, nil
+}
+
+func ResolveToMsat(satValue *uint64, msatValue *uint64, legacyValueSat *uint64, legacyValueMsat *uint64) (resolvedMsatValue *uint64, err error) {
+	if legacyValueSat != nil {
+		msatValue := *legacyValueSat * 1000
+		resolvedMsatValue = &msatValue
+	}
+
+	if legacyValueMsat != nil {
+		resolvedMsatValue = legacyValueMsat
+	}
+
+	if satValue != nil {
+		msatValue := *satValue * 1000
+		resolvedMsatValue = &msatValue
+	}
+
+	if msatValue != nil {
+		resolvedMsatValue = msatValue
+	}
+
+	if resolvedMsatValue == nil {
+		return nil, errors.New("all fields are empty")
+	}
+
+	return resolvedMsatValue, nil
 }

--- a/api/rebalance.go
+++ b/api/rebalance.go
@@ -23,8 +23,11 @@ func (api *api) RebalanceChannel(ctx context.Context, rebalanceChannelRequest *R
 		return nil, ErrLNClientNotStarted
 	}
 
-	resolvedAmountSat, _ := ResolveToSat(rebalanceChannelRequest.AmountSat, rebalanceChannelRequest.AmountMsat, nil, nil)
-	amountSat := *resolvedAmountSat
+	amountSat := uint64(0)
+	resolvedAmountSat := ResolveToSat(rebalanceChannelRequest.AmountSat, rebalanceChannelRequest.AmountMsat, nil, nil)
+	if resolvedAmountSat != nil {
+		amountSat = *resolvedAmountSat
+	}
 
 	receiveMetadata := map[string]interface{}{
 		"receive_through": rebalanceChannelRequest.ReceiveThroughNodePubkey,

--- a/api/rebalance.go
+++ b/api/rebalance.go
@@ -23,11 +23,14 @@ func (api *api) RebalanceChannel(ctx context.Context, rebalanceChannelRequest *R
 		return nil, ErrLNClientNotStarted
 	}
 
+	resolvedAmountSat, _ := ResolveToSat(rebalanceChannelRequest.AmountSat, rebalanceChannelRequest.AmountMsat, nil, nil)
+	amountSat := *resolvedAmountSat
+
 	receiveMetadata := map[string]interface{}{
 		"receive_through": rebalanceChannelRequest.ReceiveThroughNodePubkey,
 	}
 
-	receiveInvoice, err := api.svc.GetTransactionsService().MakeInvoice(ctx, rebalanceChannelRequest.AmountSat*1000, "Alby Hub Rebalance through "+rebalanceChannelRequest.ReceiveThroughNodePubkey, "", 0, receiveMetadata, lnClient, nil, nil, &rebalanceChannelRequest.ReceiveThroughNodePubkey)
+	receiveInvoice, err := api.svc.GetTransactionsService().MakeInvoice(ctx, amountSat*1000, "Alby Hub Rebalance through "+rebalanceChannelRequest.ReceiveThroughNodePubkey, "", 0, receiveMetadata, lnClient, nil, nil, &rebalanceChannelRequest.ReceiveThroughNodePubkey)
 	if err != nil {
 		logger.Logger.WithError(err).Error("failed to generate rebalance receive invoice")
 		return nil, err
@@ -116,13 +119,13 @@ func (api *api) RebalanceChannel(ctx context.Context, rebalanceChannelRequest *R
 		return nil, err
 	}
 
-	if paymentRequest.MSatoshi > int64(float64(rebalanceChannelRequest.AmountSat)*float64(1000)*float64(1.003)+1 /*0.3% fees*/) {
+	if paymentRequest.MSatoshi > int64(float64(amountSat)*float64(1000)*float64(1.003)+1 /*0.3% fees*/) {
 		return nil, errors.New("rebalance payment is more expensive than expected")
 	}
 
 	payMetadata := map[string]interface{}{
 		"receive_through": rebalanceChannelRequest.ReceiveThroughNodePubkey,
-		"amount_sat":      rebalanceChannelRequest.AmountSat,
+		"amount_sat":      amountSat,
 		"order_id":        rebalanceCreateOrderResponse.OrderId,
 	}
 
@@ -138,7 +141,7 @@ func (api *api) RebalanceChannel(ctx context.Context, rebalanceChannelRequest *R
 		Properties: map[string]interface{}{},
 	})
 
-	totalFeeMsat := uint64(paymentRequest.MSatoshi) + payRebalanceInvoiceResponse.FeeMsat - rebalanceChannelRequest.AmountSat*1000
+	totalFeeMsat := uint64(paymentRequest.MSatoshi) + payRebalanceInvoiceResponse.FeeMsat - amountSat*1000
 
 	return &RebalanceChannelResponse{
 		TotalFeeSat:  totalFeeMsat / 1000,

--- a/db/models.go
+++ b/db/models.go
@@ -97,8 +97,8 @@ type Swap struct {
 	Type               string
 	State              string
 	Invoice            string
-	SendAmount         uint64
-	ReceiveAmount      uint64
+	SendAmountSat      uint64 `gorm:"column:send_amount"`
+	ReceiveAmountSat   uint64 `gorm:"column:receive_amount"`
 	Preimage           string
 	PaymentHash        string
 	DestinationAddress string

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -121,15 +121,15 @@ export interface App {
   lastSettledTransactionAt?: string;
   expiresAt?: string;
   isolated: boolean;
-  balance: number; // @depreated
+  balance: number; // @deprecated
   balanceSat: number;
   balanceMsat: number;
 
   scopes: Scope[];
-  maxAmount: number; // @depreated
+  maxAmount: number; // @deprecated
   maxAmountSat: number;
   maxAmountMsat: number;
-  budgetUsage: number; // @depreated
+  budgetUsage: number; // @deprecated
   budgetUsageSat: number;
   budgetUsageMsat: number;
   budgetRenewal: BudgetRenewalType;
@@ -209,9 +209,9 @@ export type AppMetadata = {
 export type AutoSwapConfig = {
   type: "out";
   enabled: boolean;
-  balanceThreshold: number; // @depreated
+  balanceThreshold: number; // @deprecated
   balanceThresholdSat: number;
-  swapAmount: number; // @depreated
+  swapAmount: number; // @deprecated
   swapAmountSat: number;
   destination: string;
 };
@@ -219,17 +219,17 @@ export type AutoSwapConfig = {
 export type SwapInfo = {
   albyServiceFee: number;
   boltzServiceFee: number;
-  boltzNetworkFee: number; // @depreated
+  boltzNetworkFee: number; // @deprecated
   boltzNetworkFeeSat: number;
-  minAmount: number; // @depreated
+  minAmount: number; // @deprecated
   minAmountSat: number;
-  maxAmount: number; // @depreated
+  maxAmount: number; // @deprecated
   maxAmountSat: number;
 };
 
 export type BaseSwap = {
   id: string;
-  sendAmount: number; // @depreated
+  sendAmount: number; // @deprecated
   sendAmountSat: number;
   lockupAddress: string;
   paymentHash: string;
@@ -241,7 +241,7 @@ export type BaseSwap = {
   updatedAt: string;
   lockupTxId?: string;
   claimTxId?: string;
-  receiveAmount?: number; // @depreated
+  receiveAmount?: number; // @deprecated
   receiveAmountSat?: number;
 };
 
@@ -271,7 +271,9 @@ export interface MnemonicResponse {
 export interface CreateAppRequest {
   name: string;
   pubkey?: string;
-  maxAmount?: number;
+  maxAmount?: number; // @deprecated
+  maxAmountSat?: number;
+  maxAmountMsat?: number;
   budgetRenewal?: BudgetRenewalType;
   expiresAt?: string;
   scopes: Scope[];
@@ -295,7 +297,9 @@ export interface CreateAppResponse {
 
 export type UpdateAppRequest = {
   name?: string;
-  maxAmount?: number;
+  maxAmount?: number; // @deprecated
+  maxAmountSat?: number;
+  maxAmountMsat?: number;
   budgetRenewal?: string;
   expiresAt?: string | undefined;
   updateExpiresAt?: boolean;
@@ -305,13 +309,13 @@ export type UpdateAppRequest = {
 };
 
 export type Channel = {
-  localBalance: number; // @depreated
+  localBalance: number; // @deprecated
   localBalanceSat: number;
   localBalanceMsat: number;
-  localSpendableBalance: number; // @depreated
+  localSpendableBalance: number; // @deprecated
   localSpendableBalanceSat: number;
   localSpendableBalanceMsat: number;
-  remoteBalance: number; // @depreated
+  remoteBalance: number; // @deprecated
   remoteBalanceSat: number;
   remoteBalanceMsat: number;
   remotePubkey: string;
@@ -324,9 +328,9 @@ export type Channel = {
   confirmationsRequired?: number;
   forwardingFeeBaseMsat: number;
   forwardingFeeProportionalMillionths: number;
-  unspendablePunishmentReserve: number; // @depreated
+  unspendablePunishmentReserve: number; // @deprecated
   unspendablePunishmentReserveSat: number;
-  counterpartyUnspendablePunishmentReserve: number; // @depreated
+  counterpartyUnspendablePunishmentReserve: number; // @deprecated
   counterpartyUnspendablePunishmentReserveSat: number;
   error?: string;
   status: "online" | "opening" | "offline";
@@ -375,8 +379,17 @@ export type CreateOfferRequest = {
 };
 
 export type CreateInvoiceRequest = {
-  amount: number;
+  amount?: number; // @deprecated
+  amountSat?: number;
+  amountMsat?: number;
   description: string;
+};
+
+export type PayInvoiceRequest = {
+  amount?: number; // @deprecated
+  amountSat?: number;
+  amountMsat?: number;
+  metadata?: Record<string, unknown>;
 };
 
 export type OpenChannelRequest = {
@@ -395,20 +408,20 @@ export type CloseChannelResponse = {};
 export type PendingBalancesDetails = {
   channelId: string;
   nodeId: string;
-  amount: number; // @depreated
+  amount: number; // @deprecated
   amountSat: number;
   fundingTxId: string;
   fundingTxVout: number;
 };
 
 export type OnchainBalanceResponse = {
-  spendable: number; // @depreated
+  spendable: number; // @deprecated
   spendableSat: number;
-  total: number; // @depreated
+  total: number; // @deprecated
   totalSat: number;
-  reserved: number; // @depreated
+  reserved: number; // @deprecated
   reservedSat: number;
-  pendingBalancesFromChannelClosures: number; // @depreated
+  pendingBalancesFromChannelClosures: number; // @deprecated
   pendingBalancesFromChannelClosuresSat: number;
   pendingBalancesDetails: PendingBalancesDetails[];
   pendingSweepBalancesDetails: PendingBalancesDetails[];
@@ -495,9 +508,9 @@ export type RecommendedChannelPeer = {
   network: Network;
   image: string;
   name: string;
-  minimumChannelSize: number; // @depreated
+  minimumChannelSize: number; // @deprecated
   minimumChannelSizeSat: number;
-  maximumChannelSize: number; // @depreated
+  maximumChannelSize: number; // @deprecated
   maximumChannelSizeSat: number;
   note: string;
   publicChannelsAllowed: boolean;
@@ -566,21 +579,46 @@ export type AlbyMe = {
 };
 
 export type LSPOrderRequest = {
-  amount: number;
+  amount?: number; // @deprecated
+  amountSat?: number;
   lspType: LSPType;
   lspIdentifier: string;
   public: boolean;
 };
 
+export type RedeemOnchainFundsRequest = {
+  toAddress: string;
+  amount?: number; // @deprecated
+  amountSat?: number;
+  feeRate?: number;
+  sendAll?: boolean;
+};
+
+export type AutoSwapRequest = {
+  balanceThreshold?: number; // @deprecated
+  balanceThresholdSat?: number;
+  swapAmount?: number; // @deprecated
+  swapAmountSat?: number;
+  destination: string;
+  destinationType?: string;
+  unlockPassword?: string;
+};
+
+export type InitiateSwapRequest = {
+  swapAmount?: number; // @deprecated
+  swapAmountSat?: number;
+  destination?: string;
+};
+
 export type LSPOrderResponse = {
   invoice?: string;
-  fee: number; // @depreated
+  fee: number; // @deprecated
   feeSat: number;
-  invoiceAmount: number; // @depreated
+  invoiceAmount: number; // @deprecated
   invoiceAmountSat: number;
-  incomingLiquidity: number; // @depreated
+  incomingLiquidity: number; // @deprecated
   incomingLiquiditySat: number;
-  outgoingLiquidity: number; // @depreated
+  outgoingLiquidity: number; // @deprecated
   outgoingLiquiditySat: number;
 };
 
@@ -589,9 +627,9 @@ export type AutoChannelRequest = {
 };
 export type AutoChannelResponse = {
   invoice?: string;
-  fee?: number; // @depreated
+  fee?: number; // @deprecated
   feeSat?: number;
-  channelSize: number; // @depreated
+  channelSize: number; // @deprecated
   channelSizeSat: number;
 };
 
@@ -600,22 +638,22 @@ export type RedeemOnchainFundsResponse = {
 };
 
 export type LightningBalanceResponse = {
-  totalSpendable: number; // @depreated
+  totalSpendable: number; // @deprecated
   totalSpendableSat: number;
   totalSpendableMsat: number;
-  totalReceivable: number; // @depreated
+  totalReceivable: number; // @deprecated
   totalReceivableSat: number;
   totalReceivableMsat: number;
-  nextMaxSpendable: number; // @depreated
+  nextMaxSpendable: number; // @deprecated
   nextMaxSpendableSat: number;
   nextMaxSpendableMsat: number;
-  nextMaxReceivable: number; // @depreated
+  nextMaxReceivable: number; // @deprecated
   nextMaxReceivableSat: number;
   nextMaxReceivableMsat: number;
-  nextMaxSpendableMPP: number; // @depreated
+  nextMaxSpendableMPP: number; // @deprecated
   nextMaxSpendableMPPSat: number;
   nextMaxSpendableMPPMsat: number;
-  nextMaxReceivableMPP: number; // @depreated
+  nextMaxReceivableMPP: number; // @deprecated
   nextMaxReceivableMPPSat: number;
   nextMaxReceivableMPPMsat: number;
 };
@@ -634,10 +672,10 @@ export type Transaction = {
   descriptionHash: string;
   preimage: string | undefined;
   paymentHash: string;
-  amount: number; // @depreated
+  amount: number; // @deprecated
   amountSat: number;
   amountMsat: number;
-  feesPaid: number; // @depreated
+  feesPaid: number; // @deprecated
   feesPaidSat: number;
   feesPaidMsat: number;
   updatedAt: string;
@@ -700,7 +738,7 @@ export type OnchainTransaction = {
 export type ListAppsResponse = {
   apps: App[];
   totalCount: number;
-  totalBalance?: number; // @depreated
+  totalBalance?: number; // @deprecated
   totalBalanceSat?: number;
   totalBalanceMsat?: number;
 };

--- a/http/http_service.go
+++ b/http/http_service.go
@@ -640,7 +640,7 @@ func (httpSvc *HttpService) sendPaymentHandler(c echo.Context) error {
 			Message: fmt.Sprintf("Bad request: %s", err.Error()),
 		})
 	}
-	amountMsat, _ := api.ResolveToMsat(payInvoiceRequest.AmountSat, payInvoiceRequest.AmountMsat, nil, payInvoiceRequest.Amount)
+	amountMsat := api.ResolveToMsat(payInvoiceRequest.AmountSat, payInvoiceRequest.AmountMsat, nil, payInvoiceRequest.Amount)
 
 	paymentResponse, err := httpSvc.api.SendPayment(ctx, c.Param("invoice"), amountMsat, payInvoiceRequest.Metadata)
 
@@ -682,8 +682,11 @@ func (httpSvc *HttpService) makeInvoiceHandler(c echo.Context) error {
 		})
 	}
 
-	resolvedAmountMsat, _ := api.ResolveToMsat(makeInvoiceRequest.AmountSat, makeInvoiceRequest.AmountMsat, nil, makeInvoiceRequest.Amount)
-	amountMsat := *resolvedAmountMsat
+	amountMsat := uint64(0)
+	resolvedAmountMsat := api.ResolveToMsat(makeInvoiceRequest.AmountSat, makeInvoiceRequest.AmountMsat, nil, makeInvoiceRequest.Amount)
+	if resolvedAmountMsat != nil {
+		amountMsat = *resolvedAmountMsat
+	}
 
 	invoice, err := httpSvc.api.CreateInvoice(c.Request().Context(), amountMsat, makeInvoiceRequest.Description)
 
@@ -983,8 +986,11 @@ func (httpSvc *HttpService) redeemOnchainFundsHandler(c echo.Context) error {
 		})
 	}
 
-	resolvedAmountSat, _ := api.ResolveToSat(redeemOnchainFundsRequest.AmountSat, nil, redeemOnchainFundsRequest.Amount, nil)
-	amountSat := *resolvedAmountSat
+	amountSat := uint64(0)
+	resolvedAmountSat := api.ResolveToSat(redeemOnchainFundsRequest.AmountSat, nil, redeemOnchainFundsRequest.Amount, nil)
+	if resolvedAmountSat != nil {
+		amountSat = *resolvedAmountSat
+	}
 
 	redeemOnchainFundsResponse, err := httpSvc.api.RedeemOnchainFunds(ctx, redeemOnchainFundsRequest.ToAddress, amountSat, redeemOnchainFundsRequest.FeeRate, redeemOnchainFundsRequest.SendAll)
 
@@ -1146,8 +1152,11 @@ func (httpSvc *HttpService) transfersHandler(c echo.Context) error {
 		})
 	}
 
-	resolvedAmountMsat, _ := api.ResolveToMsat(requestData.AmountSat, requestData.AmountMsat, nil, nil)
-	amountMsat := *resolvedAmountMsat
+	amountMsat := uint64(0)
+	resolvedAmountMsat := api.ResolveToMsat(requestData.AmountSat, requestData.AmountMsat, nil, nil)
+	if resolvedAmountMsat != nil {
+		amountMsat = *resolvedAmountMsat
+	}
 
 	err := httpSvc.api.Transfer(c.Request().Context(), requestData.FromAppId, requestData.ToAppId, amountMsat, requestData.Description)
 

--- a/http/http_service.go
+++ b/http/http_service.go
@@ -186,8 +186,6 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	fullAccessApiGroup.POST("/offers", httpSvc.makeOfferHandler)
 	fullAccessApiGroup.POST("/reset-router", httpSvc.resetRouterHandler)
 	fullAccessApiGroup.POST("/stop", httpSvc.stopHandler)
-	fullAccessApiGroup.POST("/send-payment-probes", httpSvc.sendPaymentProbesHandler)
-	fullAccessApiGroup.POST("/send-spontaneous-payment-probes", httpSvc.sendSpontaneousPaymentProbesHandler)
 	fullAccessApiGroup.POST("/command", httpSvc.execCustomNodeCommandHandler)
 	fullAccessApiGroup.POST("/swaps/out", httpSvc.initiateSwapOutHandler)
 	fullAccessApiGroup.POST("/swaps/in", httpSvc.initiateSwapInHandler)
@@ -1268,42 +1266,6 @@ func (httpSvc *HttpService) setupHandler(c echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusNoContent)
-}
-
-func (httpSvc *HttpService) sendPaymentProbesHandler(c echo.Context) error {
-	var sendPaymentProbesRequest api.SendPaymentProbesRequest
-	if err := c.Bind(&sendPaymentProbesRequest); err != nil {
-		return c.JSON(http.StatusBadRequest, ErrorResponse{
-			Message: fmt.Sprintf("Bad request: %s", err.Error()),
-		})
-	}
-
-	sendPaymentProbesResponse, err := httpSvc.api.SendPaymentProbes(c.Request().Context(), &sendPaymentProbesRequest)
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, ErrorResponse{
-			Message: fmt.Sprintf("Failed to send payment probes: %v", err),
-		})
-	}
-
-	return c.JSON(http.StatusOK, sendPaymentProbesResponse)
-}
-
-func (httpSvc *HttpService) sendSpontaneousPaymentProbesHandler(c echo.Context) error {
-	var sendSpontaneousPaymentProbesRequest api.SendSpontaneousPaymentProbesRequest
-	if err := c.Bind(&sendSpontaneousPaymentProbesRequest); err != nil {
-		return c.JSON(http.StatusBadRequest, ErrorResponse{
-			Message: fmt.Sprintf("Bad request: %s", err.Error()),
-		})
-	}
-
-	sendSpontaneousPaymentProbesResponse, err := httpSvc.api.SendSpontaneousPaymentProbes(c.Request().Context(), &sendSpontaneousPaymentProbesRequest)
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, ErrorResponse{
-			Message: fmt.Sprintf("Failed to send spontaneous payment probes: %v", err),
-		})
-	}
-
-	return c.JSON(http.StatusOK, sendSpontaneousPaymentProbesResponse)
 }
 
 func (httpSvc *HttpService) getLogOutputHandler(c echo.Context) error {

--- a/http/http_service.go
+++ b/http/http_service.go
@@ -640,8 +640,9 @@ func (httpSvc *HttpService) sendPaymentHandler(c echo.Context) error {
 			Message: fmt.Sprintf("Bad request: %s", err.Error()),
 		})
 	}
+	amountMsat, _ := api.ResolveToMsat(payInvoiceRequest.AmountSat, payInvoiceRequest.AmountMsat, nil, payInvoiceRequest.Amount)
 
-	paymentResponse, err := httpSvc.api.SendPayment(ctx, c.Param("invoice"), payInvoiceRequest.Amount, payInvoiceRequest.Metadata)
+	paymentResponse, err := httpSvc.api.SendPayment(ctx, c.Param("invoice"), amountMsat, payInvoiceRequest.Metadata)
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{
@@ -681,7 +682,10 @@ func (httpSvc *HttpService) makeInvoiceHandler(c echo.Context) error {
 		})
 	}
 
-	invoice, err := httpSvc.api.CreateInvoice(c.Request().Context(), makeInvoiceRequest.Amount, makeInvoiceRequest.Description)
+	resolvedAmountMsat, _ := api.ResolveToMsat(makeInvoiceRequest.AmountSat, makeInvoiceRequest.AmountMsat, nil, makeInvoiceRequest.Amount)
+	amountMsat := *resolvedAmountMsat
+
+	invoice, err := httpSvc.api.CreateInvoice(c.Request().Context(), amountMsat, makeInvoiceRequest.Description)
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{
@@ -979,7 +983,10 @@ func (httpSvc *HttpService) redeemOnchainFundsHandler(c echo.Context) error {
 		})
 	}
 
-	redeemOnchainFundsResponse, err := httpSvc.api.RedeemOnchainFunds(ctx, redeemOnchainFundsRequest.ToAddress, redeemOnchainFundsRequest.AmountSat, redeemOnchainFundsRequest.FeeRate, redeemOnchainFundsRequest.SendAll)
+	resolvedAmountSat, _ := api.ResolveToSat(redeemOnchainFundsRequest.AmountSat, nil, redeemOnchainFundsRequest.Amount, nil)
+	amountSat := *resolvedAmountSat
+
+	redeemOnchainFundsResponse, err := httpSvc.api.RedeemOnchainFunds(ctx, redeemOnchainFundsRequest.ToAddress, amountSat, redeemOnchainFundsRequest.FeeRate, redeemOnchainFundsRequest.SendAll)
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{
@@ -1139,7 +1146,10 @@ func (httpSvc *HttpService) transfersHandler(c echo.Context) error {
 		})
 	}
 
-	err := httpSvc.api.Transfer(c.Request().Context(), requestData.FromAppId, requestData.ToAppId, requestData.AmountSat*1000, requestData.Description)
+	resolvedAmountMsat, _ := api.ResolveToMsat(requestData.AmountSat, requestData.AmountMsat, nil, nil)
+	amountMsat := *resolvedAmountMsat
+
+	err := httpSvc.api.Transfer(c.Request().Context(), requestData.FromAppId, requestData.ToAppId, amountMsat, requestData.Description)
 
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to transfer funds")

--- a/http/http_service.go
+++ b/http/http_service.go
@@ -979,7 +979,7 @@ func (httpSvc *HttpService) redeemOnchainFundsHandler(c echo.Context) error {
 		})
 	}
 
-	redeemOnchainFundsResponse, err := httpSvc.api.RedeemOnchainFunds(ctx, redeemOnchainFundsRequest.ToAddress, redeemOnchainFundsRequest.Amount, redeemOnchainFundsRequest.FeeRate, redeemOnchainFundsRequest.SendAll)
+	redeemOnchainFundsResponse, err := httpSvc.api.RedeemOnchainFunds(ctx, redeemOnchainFundsRequest.ToAddress, redeemOnchainFundsRequest.AmountSat, redeemOnchainFundsRequest.FeeRate, redeemOnchainFundsRequest.SendAll)
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{

--- a/lnclient/cashu/cashu.go
+++ b/lnclient/cashu/cashu.go
@@ -246,14 +246,6 @@ func (cs *CashuService) GetNodeStatus(ctx context.Context) (nodeStatus *lnclient
 	}, nil
 }
 
-func (cs *CashuService) SendPaymentProbes(ctx context.Context, invoice string) error {
-	return nil
-}
-
-func (cs *CashuService) SendSpontaneousPaymentProbes(ctx context.Context, amountMsat uint64, nodeId string) error {
-	return nil
-}
-
 func (cs *CashuService) UpdateChannel(ctx context.Context, updateChannelRequest *lnclient.UpdateChannelRequest) error {
 	return nil
 }

--- a/lnclient/cashu/cashu.go
+++ b/lnclient/cashu/cashu.go
@@ -71,9 +71,9 @@ func (cs *CashuService) Shutdown() error {
 	return cs.wallet.Shutdown()
 }
 
-func (cs *CashuService) SendPaymentSync(invoice string, amount *uint64) (response *lnclient.PayInvoiceResponse, err error) {
+func (cs *CashuService) SendPaymentSync(invoice string, amountMsat *uint64) (response *lnclient.PayInvoiceResponse, err error) {
 	// TODO: support 0-amount invoices
-	if amount != nil {
+	if amountMsat != nil {
 		return nil, errors.New("0-amount invoices not supported")
 	}
 
@@ -96,20 +96,20 @@ func (cs *CashuService) SendPaymentSync(invoice string, amount *uint64) (respons
 
 	return &lnclient.PayInvoiceResponse{
 		Preimage: meltResponse.Preimage,
-		Fee:      fee * 1000,
+		FeeMsat:  fee * 1000,
 	}, nil
 }
 
-func (cs *CashuService) SendKeysend(amount uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
+func (cs *CashuService) SendKeysend(amountMsat uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
 	return nil, errors.New("keysend not supported")
 }
 
-func (cs *CashuService) MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
+func (cs *CashuService) MakeInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
 	// TODO: support expiry
 	if expiry == 0 {
 		expiry = lnclient.DEFAULT_INVOICE_EXPIRY
 	}
-	mintResponse, err := cs.wallet.RequestMint(uint64(amount/1000), cs.wallet.CurrentMint())
+	mintResponse, err := cs.wallet.RequestMint(uint64(amountMsat/1000), cs.wallet.CurrentMint())
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to mint")
 		return nil, err
@@ -119,7 +119,7 @@ func (cs *CashuService) MakeInvoice(ctx context.Context, amount int64, descripti
 	return cs.cashuMintQuoteToTransaction(mintQuote), nil
 }
 
-func (cs *CashuService) MakeHoldInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *lnclient.Transaction, err error) {
+func (cs *CashuService) MakeHoldInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *lnclient.Transaction, err error) {
 	_ = minCltvExpiryDelta
 	return nil, errors.New("not implemented")
 }
@@ -190,7 +190,7 @@ func (cs *CashuService) GetOnchainBalance(ctx context.Context) (*lnclient.Onchai
 	return &lnclient.OnchainBalanceResponse{}, nil
 }
 
-func (cs *CashuService) RedeemOnchainFunds(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool) (string, error) {
+func (cs *CashuService) RedeemOnchainFunds(ctx context.Context, toAddress string, amountSat uint64, feeRate *uint64, sendAll bool) (string, error) {
 	return "", nil
 }
 
@@ -301,7 +301,7 @@ func (cs *CashuService) cashuMintQuoteToTransaction(mintQuote *storage.MintQuote
 		PaymentHash: paymentRequest.PaymentHash,
 		// note: setting dummy preimage so that it gets marked as settled
 		Preimage:        paymentRequest.PaymentHash,
-		Amount:          paymentRequest.MSatoshi,
+		AmountMsat:      paymentRequest.MSatoshi,
 		CreatedAt:       int64(paymentRequest.CreatedAt),
 		ExpiresAt:       expiresAt,
 		Description:     description,
@@ -330,14 +330,14 @@ func (cs *CashuService) cashuMeltQuoteToTransaction(meltQuote *storage.MeltQuote
 		Type:            constants.TRANSACTION_TYPE_OUTGOING,
 		Invoice:         meltQuote.PaymentRequest,
 		PaymentHash:     paymentRequest.PaymentHash,
-		Amount:          paymentRequest.MSatoshi,
+		AmountMsat:      paymentRequest.MSatoshi,
 		CreatedAt:       int64(paymentRequest.CreatedAt),
 		ExpiresAt:       expiresAt,
 		Description:     description,
 		DescriptionHash: descriptionHash,
 		Preimage:        meltQuote.Preimage,
 		SettledAt:       settledAt,
-		FeesPaid:        int64(meltQuote.FeeReserve * 1000),
+		FeesPaidMsat:    int64(meltQuote.FeeReserve * 1000),
 	}
 }
 

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -1452,14 +1452,6 @@ func (ls *LDKService) ldkPaymentToTransaction(payment *ldk_node.PaymentDetails) 
 	}, nil
 }
 
-func (ls *LDKService) SendPaymentProbes(ctx context.Context, invoice string) error {
-	return errors.ErrUnsupported
-}
-
-func (ls *LDKService) SendSpontaneousPaymentProbes(ctx context.Context, amountMsat uint64, nodeId string) error {
-	return errors.ErrUnsupported
-}
-
 func (ls *LDKService) ListPeers(ctx context.Context) ([]lnclient.PeerDetails, error) {
 	peers := ls.node.ListPeers()
 	ret := make([]lnclient.PeerDetails, 0, len(peers))

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -494,7 +494,7 @@ func (ls *LDKService) MakeOffer(ctx context.Context, description string) (string
 	return offer.String(), nil
 }
 
-func (ls *LDKService) SendPaymentSync(invoice string, amount *uint64) (*lnclient.PayInvoiceResponse, error) {
+func (ls *LDKService) SendPaymentSync(invoice string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
 	paymentRequest, err := decodepay.Decodepay(invoice)
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
@@ -505,8 +505,8 @@ func (ls *LDKService) SendPaymentSync(invoice string, amount *uint64) (*lnclient
 	}
 
 	paymentAmountMsat := uint64(paymentRequest.MSatoshi)
-	if amount != nil {
-		paymentAmountMsat = *amount
+	if amountMsat != nil {
+		paymentAmountMsat = *amountMsat
 	}
 
 	maxSpendable := ls.getMaxSpendable()
@@ -544,10 +544,10 @@ func (ls *LDKService) SendPaymentSync(invoice string, amount *uint64) (*lnclient
 	}
 
 	var paymentHash string
-	if amount == nil {
+	if amountMsat == nil {
 		paymentHash, err = ls.node.Bolt11Payment().Send(invoiceObj, routeParameters)
 	} else {
-		paymentHash, err = ls.node.Bolt11Payment().SendUsingAmount(invoiceObj, *amount, routeParameters)
+		paymentHash, err = ls.node.Bolt11Payment().SendUsingAmount(invoiceObj, *amountMsat, routeParameters)
 	}
 	if err != nil {
 		logger.Logger.WithError(err).Error("SendPayment failed")
@@ -590,7 +590,7 @@ func (ls *LDKService) SendPaymentSync(invoice string, amount *uint64) (*lnclient
 
 				return &lnclient.PayInvoiceResponse{
 					Preimage: preimage,
-					Fee:      feeMsat,
+					FeeMsat:  feeMsat,
 				}, nil
 			case ldk_node.EventPaymentFailed:
 				if event.PaymentHash != nil && *event.PaymentHash == paymentHash {
@@ -606,7 +606,7 @@ func (ls *LDKService) SendPaymentSync(invoice string, amount *uint64) (*lnclient
 	}
 }
 
-func (ls *LDKService) SendKeysend(amount uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
+func (ls *LDKService) SendKeysend(amountMsat uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
 	paymentStart := time.Now()
 	customTlvs := []ldk_node.CustomTlvRecord{}
 
@@ -626,7 +626,7 @@ func (ls *LDKService) SendKeysend(amount uint64, destination string, custom_reco
 
 	saturationPower := ls.cfg.GetEnv().LDKMaxChannelSaturationPowerOfHalf
 	maxPathCount := ls.cfg.GetEnv().LDKMaxPathCount
-	maxTotalRoutingFeeMsat := getMaxTotalRoutingFeeLimit(amount)
+	maxTotalRoutingFeeMsat := getMaxTotalRoutingFeeLimit(amountMsat)
 
 	routeParameters := &ldk_node.RouteParametersConfig{
 		MaxTotalRoutingFeeMsat:          &maxTotalRoutingFeeMsat,
@@ -635,7 +635,7 @@ func (ls *LDKService) SendKeysend(amount uint64, destination string, custom_reco
 		MaxTotalCltvExpiryDelta:         1008, // TODO: remove and use default
 	}
 
-	paymentHash, err := ls.node.SpontaneousPayment().SendWithPreimageAndCustomTlvs(amount, destination, customTlvs, preimage, routeParameters)
+	paymentHash, err := ls.node.SpontaneousPayment().SendWithPreimageAndCustomTlvs(amountMsat, destination, customTlvs, preimage, routeParameters)
 	if err != nil {
 		logger.Logger.WithError(err).Error("Keysend failed")
 		return nil, err
@@ -661,7 +661,7 @@ func (ls *LDKService) SendKeysend(amount uint64, destination string, custom_reco
 					"fee":      feeMsat,
 				}).Info("Successful keysend payment")
 				return &lnclient.PayKeysendResponse{
-					Fee: feeMsat,
+					FeeMsat: feeMsat,
 				}, nil
 			}
 			if isEventPaymentFailedEvent && eventPaymentFailed.PaymentHash != nil && *eventPaymentFailed.PaymentHash == paymentHash {
@@ -702,7 +702,7 @@ func (ls *LDKService) getMaxSpendable() uint64 {
 	return spendable
 }
 
-func (ls *LDKService) MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
+func (ls *LDKService) MakeInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
 
 	if time.Duration(expiry)*time.Second > maxInvoiceExpiry {
 		return nil, errors.New("expiry is too long")
@@ -710,7 +710,7 @@ func (ls *LDKService) MakeInvoice(ctx context.Context, amount int64, description
 
 	maxReceivable := ls.getMaxReceivable()
 
-	if amount > maxReceivable {
+	if amountMsat > maxReceivable {
 		ls.eventPublisher.Publish(&events.Event{
 			Event: "nwc_incoming_liquidity_required",
 			Properties: map[string]interface{}{
@@ -736,7 +736,7 @@ func (ls *LDKService) MakeInvoice(ctx context.Context, amount int64, description
 		}
 	}
 
-	invoiceObj, err := ls.node.Bolt11Payment().Receive(uint64(amount),
+	invoiceObj, err := ls.node.Bolt11Payment().Receive(uint64(amountMsat),
 		descriptionType,
 		uint32(expiry))
 
@@ -762,7 +762,7 @@ func (ls *LDKService) MakeInvoice(ctx context.Context, amount int64, description
 		Invoice:         invoice,
 		PaymentHash:     paymentRequest.PaymentHash,
 		Preimage:        *payment.Kind.(ldk_node.PaymentKindBolt11).Preimage,
-		Amount:          amount,
+		AmountMsat:      amountMsat,
 		CreatedAt:       int64(paymentRequest.CreatedAt),
 		ExpiresAt:       &expiresAtUnix,
 		Description:     paymentRequest.Description,
@@ -871,9 +871,9 @@ func (ls *LDKService) ListChannels(ctx context.Context) ([]lnclient.Channel, err
 			"MaxDustHtlcExposure":                 ldkChannel.Config.MaxDustHtlcExposure,
 		}
 
-		unspendablePunishmentReserve := uint64(0)
+		unspendablePunishmentReserveSat := uint64(0)
 		if ldkChannel.UnspendablePunishmentReserve != nil {
-			unspendablePunishmentReserve = *ldkChannel.UnspendablePunishmentReserve
+			unspendablePunishmentReserveSat = *ldkChannel.UnspendablePunishmentReserve
 		}
 
 		var channelError *string
@@ -890,24 +890,24 @@ func (ls *LDKService) ListChannels(ctx context.Context) ([]lnclient.Channel, err
 		isActive := ldkChannel.IsUsable /* superset of ldkChannel.IsReady */ && channelError == nil
 
 		channels = append(channels, lnclient.Channel{
-			InternalChannel:                          internalChannel,
-			LocalBalance:                             int64(ldkChannel.ChannelValueSats*1000 - ldkChannel.InboundCapacityMsat - ldkChannel.CounterpartyUnspendablePunishmentReserve*1000),
-			LocalSpendableBalance:                    int64(ldkChannel.OutboundCapacityMsat),
-			RemoteBalance:                            int64(ldkChannel.InboundCapacityMsat),
-			RemotePubkey:                             ldkChannel.CounterpartyNodeId,
-			Id:                                       ldkChannel.UserChannelId, // CloseChannel takes the UserChannelId
-			Active:                                   isActive,
-			Public:                                   ldkChannel.IsAnnounced,
-			FundingTxId:                              fundingTxId,
-			FundingTxVout:                            fundingTxVout,
-			Confirmations:                            ldkChannel.Confirmations,
-			ConfirmationsRequired:                    ldkChannel.ConfirmationsRequired,
-			ForwardingFeeBaseMsat:                    ldkChannel.Config.ForwardingFeeBaseMsat,
-			ForwardingFeeProportionalMillionths:      ldkChannel.Config.ForwardingFeeProportionalMillionths,
-			UnspendablePunishmentReserve:             unspendablePunishmentReserve,
-			CounterpartyUnspendablePunishmentReserve: ldkChannel.CounterpartyUnspendablePunishmentReserve,
-			Error:                                    channelError,
-			IsOutbound:                               ldkChannel.IsOutbound,
+			InternalChannel:                     internalChannel,
+			LocalBalanceMsat:                    int64(ldkChannel.ChannelValueSats*1000 - ldkChannel.InboundCapacityMsat - ldkChannel.CounterpartyUnspendablePunishmentReserve*1000),
+			LocalSpendableBalanceMsat:           int64(ldkChannel.OutboundCapacityMsat),
+			RemoteBalanceMsat:                   int64(ldkChannel.InboundCapacityMsat),
+			RemotePubkey:                        ldkChannel.CounterpartyNodeId,
+			Id:                                  ldkChannel.UserChannelId, // CloseChannel takes the UserChannelId
+			Active:                              isActive,
+			Public:                              ldkChannel.IsAnnounced,
+			FundingTxId:                         fundingTxId,
+			FundingTxVout:                       fundingTxVout,
+			Confirmations:                       ldkChannel.Confirmations,
+			ConfirmationsRequired:               ldkChannel.ConfirmationsRequired,
+			ForwardingFeeBaseMsat:               ldkChannel.Config.ForwardingFeeBaseMsat,
+			ForwardingFeeProportionalMillionths: ldkChannel.Config.ForwardingFeeProportionalMillionths,
+			UnspendablePunishmentReserveSat:     unspendablePunishmentReserveSat,
+			CounterpartyUnspendablePunishmentReserveSat: ldkChannel.CounterpartyUnspendablePunishmentReserve,
+			Error:      channelError,
+			IsOutbound: ldkChannel.IsOutbound,
 		})
 	}
 
@@ -1229,7 +1229,7 @@ func (ls *LDKService) GetOnchainBalance(ctx context.Context) (*lnclient.OnchainB
 	}, nil
 }
 
-func (ls *LDKService) RedeemOnchainFunds(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool) (string, error) {
+func (ls *LDKService) RedeemOnchainFunds(ctx context.Context, toAddress string, amountSat uint64, feeRate *uint64, sendAll bool) (string, error) {
 	if ls.redeemedOnchainFundsWithinThisSync {
 		return "", errors.New("please wait a minute for the wallet to sync before doing another on-chain payment")
 	}
@@ -1246,7 +1246,7 @@ func (ls *LDKService) RedeemOnchainFunds(ctx context.Context, toAddress string, 
 	if !sendAll {
 		// NOTE: this may fail if user does not reserve enough for the onchain transaction
 		// and can also drain the anchor reserves if the user provides a too high amount.
-		txId, err = ls.node.OnchainPayment().SendToAddress(toAddress, amount, feePtr)
+		txId, err = ls.node.OnchainPayment().SendToAddress(toAddress, amountSat, feePtr)
 	} else {
 		txId, err = ls.node.OnchainPayment().SendAllToAddress(toAddress, false, feePtr)
 	}
@@ -1441,9 +1441,9 @@ func (ls *LDKService) ldkPaymentToTransaction(payment *ldk_node.PaymentDetails) 
 		Preimage:        preimage,
 		PaymentHash:     paymentHash,
 		SettledAt:       settledAt,
-		Amount:          int64(amountMsat),
+		AmountMsat:      int64(amountMsat),
 		Invoice:         bolt11Invoice,
-		FeesPaid:        int64(feeMsat),
+		FeesPaidMsat:    int64(feeMsat),
 		CreatedAt:       createdAt,
 		Description:     description,
 		DescriptionHash: descriptionHash,
@@ -2117,7 +2117,7 @@ func (ls *LDKService) PayOfferSync(ctx context.Context, offer string, amount uin
 		"payment_id": paymentId,
 	}).Info("Initiated BOLT-12 variable amount payment")
 
-	fee := uint64(0)
+	feeMsat := uint64(0)
 	preimage := ""
 
 	payment := ls.node.Payment(paymentId)
@@ -2163,7 +2163,7 @@ func (ls *LDKService) PayOfferSync(ctx context.Context, offer string, amount uin
 			paymentHash = *bolt12PaymentKind.Hash
 
 			if eventPaymentSuccessful.FeePaidMsat != nil {
-				fee = *eventPaymentSuccessful.FeePaidMsat
+				feeMsat = *eventPaymentSuccessful.FeePaidMsat
 			}
 			break
 		}
@@ -2181,13 +2181,13 @@ func (ls *LDKService) PayOfferSync(ctx context.Context, offer string, amount uin
 
 	logger.Logger.WithFields(logrus.Fields{
 		"duration": time.Since(paymentStart).Milliseconds(),
-		"fee":      fee,
+		"feeMsat":  feeMsat,
 	}).Info("Successful BOLT-12 payment")
 
 	return &lnclient.PayOfferResponse{
 		PaymentHash: paymentHash,
 		Preimage:    preimage,
-		Fee:         fee,
+		FeeMsat:     feeMsat,
 	}, nil
 }
 
@@ -2259,7 +2259,7 @@ func (ls *LDKService) ExecuteCustomNodeCommand(ctx context.Context, command *lnc
 			Response: map[string]interface{}{
 				"paymentHash": payOfferResponse.PaymentHash,
 				"preimage":    payOfferResponse.Preimage,
-				"fee":         payOfferResponse.Fee,
+				"feeMsat":     payOfferResponse.FeeMsat,
 			},
 		}, nil
 	case nodeCommandExportPathfindingScores:
@@ -2302,14 +2302,14 @@ func (ls *LDKService) ExecuteCustomNodeCommand(ctx context.Context, command *lnc
 	return nil, lnclient.ErrUnknownCustomNodeCommand
 }
 
-func (ls *LDKService) MakeHoldInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (*lnclient.Transaction, error) {
+func (ls *LDKService) MakeHoldInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (*lnclient.Transaction, error) {
 	if time.Duration(expiry)*time.Second > maxInvoiceExpiry {
 		return nil, errors.New("expiry is too long")
 	}
 
 	maxReceivable := ls.getMaxReceivable()
 
-	if amount > maxReceivable {
+	if amountMsat > maxReceivable {
 		ls.eventPublisher.Publish(&events.Event{
 			Event: "nwc_incoming_liquidity_required",
 			Properties: map[string]interface{}{
@@ -2351,7 +2351,7 @@ func (ls *LDKService) MakeHoldInvoice(ctx context.Context, amount int64, descrip
 			return nil, errors.New("min_cltv_expiry_delta must be <= 65535")
 		}
 		invoiceObj, err = ls.node.Bolt11Payment().ReceiveForHashWithMinCltvExpiryDelta(
-			uint64(amount),
+			uint64(amountMsat),
 			descriptionType,
 			uint32(expiry),
 			ldkPaymentHash,
@@ -2359,7 +2359,7 @@ func (ls *LDKService) MakeHoldInvoice(ctx context.Context, amount int64, descrip
 		)
 	} else {
 		invoiceObj, err = ls.node.Bolt11Payment().ReceiveForHash(
-			uint64(amount),
+			uint64(amountMsat),
 			descriptionType,
 			uint32(expiry),
 			ldkPaymentHash,
@@ -2386,7 +2386,7 @@ func (ls *LDKService) MakeHoldInvoice(ctx context.Context, amount int64, descrip
 		Type:            "incoming",
 		Invoice:         *payment.Kind.(ldk_node.PaymentKindBolt11).Bolt11Invoice,
 		PaymentHash:     paymentRequest.PaymentHash,
-		Amount:          amount,
+		AmountMsat:      amountMsat,
 		CreatedAt:       int64(payment.CreatedAt),
 		ExpiresAt:       &expiresAtUnix,
 		Description:     paymentRequest.Description,

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -1326,14 +1326,6 @@ func (svc *LNDService) SignMessage(ctx context.Context, message string) (string,
 	return resp.Signature, nil
 }
 
-func (svc *LNDService) SendPaymentProbes(ctx context.Context, invoice string) error {
-	return nil
-}
-
-func (svc *LNDService) SendSpontaneousPaymentProbes(ctx context.Context, amountMsat uint64, nodeId string) error {
-	return nil
-}
-
 func (svc *LNDService) ListPeers(ctx context.Context) ([]lnclient.PeerDetails, error) {
 	resp, err := svc.client.ListPeers(ctx, &lnrpc.ListPeersRequest{})
 	if err != nil {

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -432,7 +432,7 @@ func (svc *LNDService) Shutdown() error {
 	return nil
 }
 
-func (svc *LNDService) SendPaymentSync(payReq string, amount *uint64) (*lnclient.PayInvoiceResponse, error) {
+func (svc *LNDService) SendPaymentSync(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
 	const MAX_PARTIAL_PAYMENTS = 16
 
 	paymentRequest, err := decodepay.Decodepay(payReq)
@@ -444,8 +444,8 @@ func (svc *LNDService) SendPaymentSync(payReq string, amount *uint64) (*lnclient
 	}
 
 	paymentAmountMsat := uint64(paymentRequest.MSatoshi)
-	if amount != nil {
-		paymentAmountMsat = *amount
+	if amountMsat != nil {
+		paymentAmountMsat = *amountMsat
 	}
 	sendRequest := &routerrpc.SendPaymentRequest{
 		PaymentRequest: payReq,
@@ -454,8 +454,8 @@ func (svc *LNDService) SendPaymentSync(payReq string, amount *uint64) (*lnclient
 		TimeoutSeconds: SEND_PAYMENT_TIMEOUT,
 	}
 
-	if amount != nil {
-		sendRequest.AmtMsat = int64(*amount)
+	if amountMsat != nil {
+		sendRequest.AmtMsat = int64(*amountMsat)
 	}
 
 	payStream, err := svc.client.SendPayment(svc.ctx, sendRequest)
@@ -490,11 +490,11 @@ func (svc *LNDService) SendPaymentSync(payReq string, amount *uint64) (*lnclient
 
 	return &lnclient.PayInvoiceResponse{
 		Preimage: resp.PaymentPreimage,
-		Fee:      uint64(resp.FeeMsat),
+		FeeMsat:  uint64(resp.FeeMsat),
 	}, nil
 }
 
-func (svc *LNDService) SendKeysend(amount uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
+func (svc *LNDService) SendKeysend(amountMsat uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
 	destBytes, err := hex.DecodeString(destination)
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
@@ -534,13 +534,13 @@ func (svc *LNDService) SendKeysend(amount uint64, destination string, custom_rec
 	destCustomRecords[KEYSEND_CUSTOM_RECORD] = preImageBytes
 	sendPaymentRequest := &routerrpc.SendPaymentRequest{
 		Dest:              destBytes,
-		AmtMsat:           int64(amount),
+		AmtMsat:           int64(amountMsat),
 		PaymentHash:       paymentHashBytes,
 		DestFeatures:      []lnrpc.FeatureBit{lnrpc.FeatureBit_TLV_ONION_REQ},
 		DestCustomRecords: destCustomRecords,
 		MaxParts:          MAX_PARTIAL_PAYMENTS,
 		TimeoutSeconds:    SEND_PAYMENT_TIMEOUT,
-		FeeLimitMsat:      int64(transactions.CalculateFeeReserveMsat(amount)),
+		FeeLimitMsat:      int64(transactions.CalculateFeeReserveMsat(amountMsat)),
 	}
 
 	payStream, err := svc.client.SendPayment(svc.ctx, sendPaymentRequest)
@@ -584,7 +584,7 @@ func (svc *LNDService) SendKeysend(amount uint64, destination string, custom_rec
 	}).Info("Keysend payment successful")
 
 	return &lnclient.PayKeysendResponse{
-		Fee: uint64(resp.FeeMsat),
+		FeeMsat: uint64(resp.FeeMsat),
 	}, nil
 }
 
@@ -601,7 +601,7 @@ func (svc *LNDService) getPaymentResult(stream routerrpc.Router_SendPaymentV2Cli
 	}
 }
 
-func (svc *LNDService) MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
+func (svc *LNDService) MakeInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
 	var descriptionHashBytes []byte
 
 	if descriptionHash != "" {
@@ -703,7 +703,7 @@ func (svc *LNDService) MakeInvoice(ctx context.Context, amount int64, descriptio
 	}
 
 	addInvoiceRequest := &lnrpc.Invoice{
-		ValueMsat:       amount,
+		ValueMsat:       amountMsat,
 		Memo:            description,
 		DescriptionHash: descriptionHashBytes,
 		Expiry:          expiry,
@@ -727,7 +727,7 @@ func (svc *LNDService) MakeInvoice(ctx context.Context, amount int64, descriptio
 	return transaction, nil
 }
 
-func (svc *LNDService) MakeHoldInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *lnclient.Transaction, err error) {
+func (svc *LNDService) MakeHoldInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *lnclient.Transaction, err error) {
 	var descriptionHashBytes []byte
 	var paymentHashBytes []byte
 
@@ -772,7 +772,7 @@ func (svc *LNDService) MakeHoldInvoice(ctx context.Context, amount int64, descri
 	}
 
 	addInvoiceRequest := &invoicesrpc.AddHoldInvoiceRequest{
-		ValueMsat:       amount,
+		ValueMsat:       amountMsat,
 		Memo:            description,
 		DescriptionHash: descriptionHashBytes,
 		Expiry:          expiry,
@@ -943,23 +943,23 @@ func (svc *LNDService) ListChannels(ctx context.Context) ([]lnclient.Channel, er
 		}
 
 		channels[i] = lnclient.Channel{
-			InternalChannel:                          lndChannel,
-			LocalBalance:                             lndChannel.LocalBalance * 1000,
-			LocalSpendableBalance:                    int64(math.Max(float64((lndChannel.LocalBalance-int64(lndChannel.LocalConstraints.ChanReserveSat))*1000), float64(0))),
-			RemoteBalance:                            lndChannel.RemoteBalance * 1000,
-			RemotePubkey:                             lndChannel.RemotePubkey,
-			Id:                                       strconv.FormatUint(lndChannel.ChanId, 10),
-			Active:                                   lndChannel.Active,
-			Public:                                   !lndChannel.Private,
-			FundingTxId:                              channelPoint.GetFundingTxidStr(),
-			FundingTxVout:                            channelPoint.GetOutputIndex(),
-			Confirmations:                            &confirmations,
-			ConfirmationsRequired:                    &confirmationsRequired,
-			UnspendablePunishmentReserve:             lndChannel.LocalConstraints.ChanReserveSat,
-			CounterpartyUnspendablePunishmentReserve: lndChannel.RemoteConstraints.ChanReserveSat,
-			IsOutbound:                               lndChannel.Initiator,
-			ForwardingFeeBaseMsat:                    forwardingFeeBaseMsat,
-			ForwardingFeeProportionalMillionths:      forwardingFeeProportionalMillionths,
+			InternalChannel:                 lndChannel,
+			LocalBalanceMsat:                lndChannel.LocalBalance * 1000,
+			LocalSpendableBalanceMsat:       int64(math.Max(float64((lndChannel.LocalBalance-int64(lndChannel.LocalConstraints.ChanReserveSat))*1000), float64(0))),
+			RemoteBalanceMsat:               lndChannel.RemoteBalance * 1000,
+			RemotePubkey:                    lndChannel.RemotePubkey,
+			Id:                              strconv.FormatUint(lndChannel.ChanId, 10),
+			Active:                          lndChannel.Active,
+			Public:                          !lndChannel.Private,
+			FundingTxId:                     channelPoint.GetFundingTxidStr(),
+			FundingTxVout:                   channelPoint.GetOutputIndex(),
+			Confirmations:                   &confirmations,
+			ConfirmationsRequired:           &confirmationsRequired,
+			UnspendablePunishmentReserveSat: lndChannel.LocalConstraints.ChanReserveSat,
+			CounterpartyUnspendablePunishmentReserveSat: lndChannel.RemoteConstraints.ChanReserveSat,
+			IsOutbound:                          lndChannel.Initiator,
+			ForwardingFeeBaseMsat:               forwardingFeeBaseMsat,
+			ForwardingFeeProportionalMillionths: forwardingFeeProportionalMillionths,
 		}
 	}
 
@@ -980,8 +980,8 @@ func (svc *LNDService) ListChannels(ctx context.Context) ([]lnclient.Channel, er
 
 		channels[j+len(activeResp.Channels)] = lnclient.Channel{
 			InternalChannel:       lndChannel,
-			LocalBalance:          lndChannel.Channel.LocalBalance * 1000,
-			RemoteBalance:         lndChannel.Channel.RemoteBalance * 1000,
+			LocalBalanceMsat:      lndChannel.Channel.LocalBalance * 1000,
+			RemoteBalanceMsat:     lndChannel.Channel.RemoteBalance * 1000,
 			RemotePubkey:          lndChannel.Channel.RemoteNodePub,
 			Public:                !lndChannel.Channel.Private,
 			FundingTxId:           fundingTxId,
@@ -1291,11 +1291,11 @@ func (svc *LNDService) GetOnchainBalance(ctx context.Context) (*lnclient.Onchain
 	}, nil
 }
 
-func (svc *LNDService) RedeemOnchainFunds(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool) (txId string, err error) {
+func (svc *LNDService) RedeemOnchainFunds(ctx context.Context, toAddress string, amountSat uint64, feeRate *uint64, sendAll bool) (txId string, err error) {
 	sendCoinsRequest := &lnrpc.SendCoinsRequest{
 		Addr:    toAddress,
 		SendAll: sendAll,
-		Amount:  int64(amount),
+		Amount:  int64(amountSat),
 	}
 
 	if feeRate != nil {
@@ -1596,8 +1596,8 @@ func lndPaymentToTransaction(payment *lnrpc.Payment) (*lnclient.Transaction, err
 		Invoice:         payment.PaymentRequest,
 		Preimage:        payment.PaymentPreimage,
 		PaymentHash:     payment.PaymentHash,
-		Amount:          payment.ValueMsat,
-		FeesPaid:        payment.FeeMsat,
+		AmountMsat:      payment.ValueMsat,
+		FeesPaidMsat:    payment.FeeMsat,
 		CreatedAt:       time.Unix(0, payment.CreationTimeNs).Unix(),
 		Description:     description,
 		DescriptionHash: descriptionHash,
@@ -1641,7 +1641,7 @@ func lndInvoiceToTransaction(invoice *lnrpc.Invoice) *lnclient.Transaction {
 		DescriptionHash: hex.EncodeToString(invoice.DescriptionHash),
 		Preimage:        preimage,
 		PaymentHash:     hex.EncodeToString(invoice.RHash),
-		Amount:          invoice.ValueMsat,
+		AmountMsat:      invoice.ValueMsat,
 		CreatedAt:       invoice.CreationDate,
 		SettledAt:       settledAt,
 		ExpiresAt:       expiresAt,

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -32,8 +32,8 @@ type Transaction struct {
 	DescriptionHash string
 	Preimage        string
 	PaymentHash     string
-	Amount          int64
-	FeesPaid        int64
+	AmountMsat      int64
+	FeesPaidMsat    int64
 	CreatedAt       int64
 	ExpiresAt       *int64
 	SettledAt       *int64
@@ -57,12 +57,12 @@ type NodeConnectionInfo struct {
 }
 
 type LNClient interface {
-	SendPaymentSync(payReq string, amount *uint64) (*PayInvoiceResponse, error)
-	SendKeysend(amount uint64, destination string, customRecords []TLVRecord, preimage string) (*PayKeysendResponse, error)
+	SendPaymentSync(payReq string, amountMsat *uint64) (*PayInvoiceResponse, error)
+	SendKeysend(amountMsat uint64, destination string, customRecords []TLVRecord, preimage string) (*PayKeysendResponse, error)
 	GetPubkey() string
 	GetInfo(ctx context.Context) (info *NodeInfo, err error)
-	MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *Transaction, err error)
-	MakeHoldInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *Transaction, err error)
+	MakeInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *Transaction, err error)
+	MakeHoldInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *Transaction, err error)
 	SettleHoldInvoice(ctx context.Context, preimage string) (err error)
 	CancelHoldInvoice(ctx context.Context, paymentHash string) (err error)
 	LookupInvoice(ctx context.Context, paymentHash string) (transaction *Transaction, err error)
@@ -81,7 +81,7 @@ type LNClient interface {
 	ResetRouter(key string) error
 	GetOnchainBalance(ctx context.Context) (*OnchainBalanceResponse, error)
 	GetBalances(ctx context.Context, includeInactiveChannels bool) (*BalancesResponse, error)
-	RedeemOnchainFunds(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool) (txId string, err error)
+	RedeemOnchainFunds(ctx context.Context, toAddress string, amountSat uint64, feeRate *uint64, sendAll bool) (txId string, err error)
 	SendPaymentProbes(ctx context.Context, invoice string) error
 	SendSpontaneousPaymentProbes(ctx context.Context, amountMsat uint64, nodeId string) error
 	ListPeers(ctx context.Context) ([]PeerDetails, error)
@@ -97,24 +97,24 @@ type LNClient interface {
 }
 
 type Channel struct {
-	LocalBalance                             int64
-	LocalSpendableBalance                    int64
-	RemoteBalance                            int64
-	Id                                       string
-	RemotePubkey                             string
-	FundingTxId                              string
-	FundingTxVout                            uint32
-	Active                                   bool
-	Public                                   bool
-	InternalChannel                          interface{}
-	Confirmations                            *uint32
-	ConfirmationsRequired                    *uint32
-	ForwardingFeeBaseMsat                    uint32
-	ForwardingFeeProportionalMillionths      uint32
-	UnspendablePunishmentReserve             uint64
-	CounterpartyUnspendablePunishmentReserve uint64
-	Error                                    *string
-	IsOutbound                               bool
+	LocalBalanceMsat                            int64
+	LocalSpendableBalanceMsat                   int64
+	RemoteBalanceMsat                           int64
+	Id                                          string
+	RemotePubkey                                string
+	FundingTxId                                 string
+	FundingTxVout                               uint32
+	Active                                      bool
+	Public                                      bool
+	InternalChannel                             interface{}
+	Confirmations                               *uint32
+	ConfirmationsRequired                       *uint32
+	ForwardingFeeBaseMsat                       uint32
+	ForwardingFeeProportionalMillionths         uint32
+	UnspendablePunishmentReserveSat             uint64
+	CounterpartyUnspendablePunishmentReserveSat uint64
+	Error                                       *string
+	IsOutbound                                  bool
 }
 
 type NodeStatus struct {
@@ -207,17 +207,17 @@ type LightningBalanceResponse struct {
 
 type PayInvoiceResponse struct {
 	Preimage string `json:"preimage"`
-	Fee      uint64 `json:"fee"`
+	FeeMsat  uint64 `json:"feeMsat"`
 }
 
 type PayOfferResponse = struct {
 	Preimage    string `json:"preimage"`
-	Fee         uint64 `json:"fee"`
-	PaymentHash string `json:"payment_hash"`
+	FeeMsat     uint64 `json:"feeMsat"`
+	PaymentHash string `json:"paymentHash"`
 }
 
 type PayKeysendResponse struct {
-	Fee uint64 `json:"fee"`
+	FeeMsat uint64 `json:"feeMsat"`
 }
 
 type BalancesResponse struct {

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -82,8 +82,6 @@ type LNClient interface {
 	GetOnchainBalance(ctx context.Context) (*OnchainBalanceResponse, error)
 	GetBalances(ctx context.Context, includeInactiveChannels bool) (*BalancesResponse, error)
 	RedeemOnchainFunds(ctx context.Context, toAddress string, amountSat uint64, feeRate *uint64, sendAll bool) (txId string, err error)
-	SendPaymentProbes(ctx context.Context, invoice string) error
-	SendSpontaneousPaymentProbes(ctx context.Context, amountMsat uint64, nodeId string) error
 	ListPeers(ctx context.Context) ([]PeerDetails, error)
 	GetLogOutput(ctx context.Context, maxLen int) ([]byte, error)
 	SignMessage(ctx context.Context, message string) (string, error)

--- a/lnclient/phoenixd/phoenixd.go
+++ b/lnclient/phoenixd/phoenixd.go
@@ -29,7 +29,7 @@ type InvoiceResponse struct {
 	Invoice     string `json:"invoice"`
 	IsPaid      bool   `json:"isPaid"`
 	ReceivedSat int64  `json:"receivedSat"`
-	Fees        int64  `json:"fees"`
+	FeesSat     int64  `json:"fees"`
 	CompletedAt int64  `json:"completedAt"`
 	CreatedAt   int64  `json:"createdAt"`
 }
@@ -192,13 +192,13 @@ func (svc *PhoenixService) ListChannels(ctx context.Context) ([]lnclient.Channel
 	return channels, nil
 }
 
-func (svc *PhoenixService) MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
+func (svc *PhoenixService) MakeInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
 	// TODO: support expiry
 	if expiry == 0 {
 		expiry = lnclient.DEFAULT_INVOICE_EXPIRY
 	}
 	form := url.Values{}
-	amountSat := strconv.FormatInt(amount/1000, 10)
+	amountSat := strconv.FormatInt(amountMsat/1000, 10)
 	form.Add("amountSat", amountSat)
 	if description != "" {
 		form.Add("description", description)
@@ -253,7 +253,7 @@ func (svc *PhoenixService) MakeInvoice(ctx context.Context, amount int64, descri
 	return tx, nil
 }
 
-func (svc *PhoenixService) MakeHoldInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *lnclient.Transaction, err error) {
+func (svc *PhoenixService) MakeHoldInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *lnclient.Transaction, err error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -303,9 +303,9 @@ func (svc *PhoenixService) LookupInvoice(ctx context.Context, paymentHash string
 	return transaction, nil
 }
 
-func (svc *PhoenixService) SendPaymentSync(payReq string, amount *uint64) (*lnclient.PayInvoiceResponse, error) {
+func (svc *PhoenixService) SendPaymentSync(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
 	// TODO: support 0-amount invoices
-	if amount != nil {
+	if amountMsat != nil {
 		return nil, errors.New("0-amount invoices not supported")
 	}
 	form := url.Values{}
@@ -338,15 +338,15 @@ func (svc *PhoenixService) SendPaymentSync(payReq string, amount *uint64) (*lncl
 
 	return &lnclient.PayInvoiceResponse{
 		Preimage: payRes.PaymentPreimage,
-		Fee:      uint64(payRes.RoutingFeeSat) * 1000,
+		FeeMsat:  uint64(payRes.RoutingFeeSat) * 1000,
 	}, nil
 }
 
-func (svc *PhoenixService) SendKeysend(amount uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
+func (svc *PhoenixService) SendKeysend(amountMsat uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (svc *PhoenixService) RedeemOnchainFunds(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool) (txId string, err error) {
+func (svc *PhoenixService) RedeemOnchainFunds(ctx context.Context, toAddress string, amountSat uint64, feeRate *uint64, sendAll bool) (txId string, err error) {
 	return "", errors.New("not implemented")
 }
 
@@ -492,8 +492,8 @@ func phoenixInvoiceToTransaction(invoiceRes *InvoiceResponse) (*lnclient.Transac
 		Invoice:         invoiceRes.Invoice,
 		Preimage:        invoiceRes.Preimage,
 		PaymentHash:     invoiceRes.PaymentHash,
-		Amount:          paymentRequest.MSatoshi,
-		FeesPaid:        invoiceRes.Fees * 1000,
+		AmountMsat:      paymentRequest.MSatoshi,
+		FeesPaidMsat:    invoiceRes.FeesSat * 1000,
 		CreatedAt:       time.UnixMilli(invoiceRes.CreatedAt).Unix(),
 		Description:     invoiceRes.Description,
 		SettledAt:       settledAt,

--- a/lnclient/phoenixd/phoenixd.go
+++ b/lnclient/phoenixd/phoenixd.go
@@ -412,14 +412,6 @@ func (svc *PhoenixService) SignMessage(ctx context.Context, message string) (str
 	return "", errors.New("not implemented")
 }
 
-func (svc *PhoenixService) SendPaymentProbes(ctx context.Context, invoice string) error {
-	return nil
-}
-
-func (svc *PhoenixService) SendSpontaneousPaymentProbes(ctx context.Context, amountMsat uint64, nodeId string) error {
-	return nil
-}
-
 func (svc *PhoenixService) ListPeers(ctx context.Context) ([]lnclient.PeerDetails, error) {
 	return nil, nil
 }

--- a/nip47/controllers/list_transactions_controller_test.go
+++ b/nip47/controllers/list_transactions_controller_test.go
@@ -57,8 +57,8 @@ func TestHandleListTransactionsEvent(t *testing.T) {
 			DescriptionHash: tests.MockLNClientTransactions[i].DescriptionHash,
 			Preimage:        &tests.MockLNClientTransactions[i].Preimage,
 			PaymentHash:     tests.MockLNClientTransactions[i].PaymentHash,
-			AmountMsat:      uint64(tests.MockLNClientTransactions[i].Amount),
-			FeeMsat:         uint64(tests.MockLNClientTransactions[i].FeesPaid),
+			AmountMsat:      uint64(tests.MockLNClientTransactions[i].AmountMsat),
+			FeeMsat:         uint64(tests.MockLNClientTransactions[i].FeesPaidMsat),
 			SettledAt:       &settledAt,
 			State:           constants.TRANSACTION_STATE_SETTLED,
 			AppId:           &app.ID,
@@ -86,8 +86,8 @@ func TestHandleListTransactionsEvent(t *testing.T) {
 	assert.Equal(t, tests.MockLNClientTransactions[0].DescriptionHash, transaction.DescriptionHash)
 	assert.Equal(t, tests.MockLNClientTransactions[0].Preimage, transaction.Preimage)
 	assert.Equal(t, tests.MockLNClientTransactions[0].PaymentHash, transaction.PaymentHash)
-	assert.Equal(t, tests.MockLNClientTransactions[0].Amount, transaction.Amount)
-	assert.Equal(t, tests.MockLNClientTransactions[0].FeesPaid, transaction.FeesPaid)
+	assert.Equal(t, tests.MockLNClientTransactions[0].AmountMsat, transaction.Amount)
+	assert.Equal(t, tests.MockLNClientTransactions[0].FeesPaidMsat, transaction.FeesPaid)
 	assert.Equal(t, tests.MockLNClientTransactions[0].SettledAt, transaction.SettledAt)
 	assert.Equal(t, "settled", transaction.State)
 }

--- a/nip47/controllers/lookup_invoice_controller_test.go
+++ b/nip47/controllers/lookup_invoice_controller_test.go
@@ -51,8 +51,8 @@ func TestHandleLookupInvoiceEvent(t *testing.T) {
 		DescriptionHash: tests.MockLNClientTransaction.DescriptionHash,
 		Preimage:        &tests.MockLNClientTransaction.Preimage,
 		PaymentHash:     tests.MockLNClientTransaction.PaymentHash,
-		AmountMsat:      uint64(tests.MockLNClientTransaction.Amount),
-		FeeMsat:         uint64(tests.MockLNClientTransaction.FeesPaid),
+		AmountMsat:      uint64(tests.MockLNClientTransaction.AmountMsat),
+		FeeMsat:         uint64(tests.MockLNClientTransaction.FeesPaidMsat),
 		SettledAt:       &settledAt,
 		AppId:           &app.ID,
 	}).Error
@@ -75,7 +75,7 @@ func TestHandleLookupInvoiceEvent(t *testing.T) {
 	assert.Equal(t, tests.MockLNClientTransaction.DescriptionHash, transaction.DescriptionHash)
 	assert.Equal(t, tests.MockLNClientTransaction.Preimage, transaction.Preimage)
 	assert.Equal(t, tests.MockLNClientTransaction.PaymentHash, transaction.PaymentHash)
-	assert.Equal(t, tests.MockLNClientTransaction.Amount, transaction.Amount)
-	assert.Equal(t, tests.MockLNClientTransaction.FeesPaid, transaction.FeesPaid)
+	assert.Equal(t, tests.MockLNClientTransaction.AmountMsat, transaction.Amount)
+	assert.Equal(t, tests.MockLNClientTransaction.FeesPaidMsat, transaction.FeesPaid)
 	assert.Equal(t, tests.MockLNClientTransaction.SettledAt, transaction.SettledAt)
 }

--- a/nip47/notifications/nip47_notifier_test.go
+++ b/nip47/notifications/nip47_notifier_test.go
@@ -54,8 +54,8 @@ func doTestSendNotificationPaymentReceived(t *testing.T, svc *tests.TestService,
 		DescriptionHash: tests.MockLNClientTransaction.DescriptionHash,
 		Preimage:        &tests.MockLNClientTransaction.Preimage,
 		PaymentHash:     tests.MockLNClientTransaction.PaymentHash,
-		AmountMsat:      uint64(tests.MockLNClientTransaction.Amount),
-		FeeMsat:         uint64(tests.MockLNClientTransaction.FeesPaid),
+		AmountMsat:      uint64(tests.MockLNClientTransaction.AmountMsat),
+		FeeMsat:         uint64(tests.MockLNClientTransaction.FeesPaidMsat),
 		SettledAt:       &settledAt,
 		AppId:           &app.ID,
 		State:           constants.TRANSACTION_STATE_SETTLED,
@@ -110,8 +110,8 @@ func doTestSendNotificationPaymentReceived(t *testing.T, svc *tests.TestService,
 	assert.Equal(t, tests.MockLNClientTransaction.DescriptionHash, transaction.DescriptionHash)
 	assert.Equal(t, tests.MockLNClientTransaction.Preimage, transaction.Preimage)
 	assert.Equal(t, tests.MockLNClientTransaction.PaymentHash, transaction.PaymentHash)
-	assert.Equal(t, tests.MockLNClientTransaction.Amount, transaction.Amount)
-	assert.Equal(t, tests.MockLNClientTransaction.FeesPaid, transaction.FeesPaid)
+	assert.Equal(t, tests.MockLNClientTransaction.AmountMsat, transaction.Amount)
+	assert.Equal(t, tests.MockLNClientTransaction.FeesPaidMsat, transaction.FeesPaid)
 	assert.Equal(t, tests.MockLNClientTransaction.SettledAt, transaction.SettledAt)
 }
 
@@ -169,8 +169,8 @@ func doTestSendNotificationPaymentSent(t *testing.T, svc *tests.TestService, cre
 		DescriptionHash: tests.MockLNClientTransaction.DescriptionHash,
 		Preimage:        &tests.MockLNClientTransaction.Preimage,
 		PaymentHash:     tests.MockLNClientTransaction.PaymentHash,
-		AmountMsat:      uint64(tests.MockLNClientTransaction.Amount),
-		FeeMsat:         uint64(tests.MockLNClientTransaction.FeesPaid),
+		AmountMsat:      uint64(tests.MockLNClientTransaction.AmountMsat),
+		FeeMsat:         uint64(tests.MockLNClientTransaction.FeesPaidMsat),
 		SettledAt:       &settledAt,
 		AppId:           &app.ID,
 	}
@@ -224,8 +224,8 @@ func doTestSendNotificationPaymentSent(t *testing.T, svc *tests.TestService, cre
 	assert.Equal(t, tests.MockLNClientTransaction.DescriptionHash, transaction.DescriptionHash)
 	assert.Equal(t, tests.MockLNClientTransaction.Preimage, transaction.Preimage)
 	assert.Equal(t, tests.MockLNClientTransaction.PaymentHash, transaction.PaymentHash)
-	assert.Equal(t, tests.MockLNClientTransaction.Amount, transaction.Amount)
-	assert.Equal(t, tests.MockLNClientTransaction.FeesPaid, transaction.FeesPaid)
+	assert.Equal(t, tests.MockLNClientTransaction.AmountMsat, transaction.Amount)
+	assert.Equal(t, tests.MockLNClientTransaction.FeesPaidMsat, transaction.FeesPaid)
 	assert.Equal(t, tests.MockLNClientTransaction.SettledAt, transaction.SettledAt)
 }
 

--- a/swaps/swaps_service.go
+++ b/swaps/swaps_service.go
@@ -56,8 +56,8 @@ type swapsService struct {
 type SwapsService interface {
 	StopAutoSwapOut()
 	EnableAutoSwapOut(encryptionKey string) error
-	SwapOut(amount uint64, destination string, autoSwap, usedXpubDerivation bool) (*SwapResponse, error)
-	SwapIn(amount uint64, autoSwap bool) (*SwapResponse, error)
+	SwapOut(amountSat uint64, destination string, autoSwap, usedXpubDerivation bool) (*SwapResponse, error)
+	SwapIn(amountSat uint64, autoSwap bool) (*SwapResponse, error)
 	GetSwapOutInfo() (*SwapInfo, error)
 	GetSwapInInfo() (*SwapInfo, error)
 	RefundSwap(swapId, address string, enableRetries bool) error
@@ -93,11 +93,11 @@ type MempoolTx struct {
 }
 
 type SwapInfo struct {
-	AlbyServiceFee  float64 `json:"albyServiceFee"`
-	BoltzServiceFee float64 `json:"boltzServiceFee"`
-	BoltzNetworkFee uint64  `json:"boltzNetworkFee"`
-	MinAmount       uint64  `json:"minAmount"`
-	MaxAmount       uint64  `json:"maxAmount"`
+	AlbyServiceFee     float64 `json:"albyServiceFee"`
+	BoltzServiceFee    float64 `json:"boltzServiceFee"`
+	BoltzNetworkFeeSat uint64  `json:"boltzNetworkFeeSat"`
+	MinAmountSat       uint64  `json:"minAmountSat"`
+	MaxAmountSat       uint64  `json:"maxAmountSat"`
 }
 
 type SwapResponse struct {
@@ -195,7 +195,7 @@ func (svc *swapsService) EnableAutoSwapOut(encryptionKey string) error {
 		return errors.New("invalid auto swap configuration")
 	}
 
-	amount, err := strconv.ParseUint(amountStr, 10, 64)
+	amountSat, err := strconv.ParseUint(amountStr, 10, 64)
 	if err != nil {
 		cancelFn()
 		return errors.New("invalid auto swap configuration")
@@ -236,10 +236,10 @@ func (svc *swapsService) EnableAutoSwapOut(encryptionKey string) error {
 				}
 
 				logger.Logger.WithFields(logrus.Fields{
-					"amount":      amount,
+					"amountSat":   amountSat,
 					"destination": actualDestination,
 				}).Info("Initiating swap")
-				_, err = svc.SwapOut(amount, actualDestination, true, usedXpubDerivation)
+				_, err = svc.SwapOut(amountSat, actualDestination, true, usedXpubDerivation)
 				if err != nil {
 					logger.Logger.WithError(err).Error("Failed to initiate swap")
 					continue
@@ -256,7 +256,7 @@ func (svc *swapsService) EnableAutoSwapOut(encryptionKey string) error {
 	return nil
 }
 
-func (svc *swapsService) SwapOut(amount uint64, destination string, autoSwap, usedXpubDerivation bool) (*SwapResponse, error) {
+func (svc *swapsService) SwapOut(amountSat uint64, destination string, autoSwap, usedXpubDerivation bool) (*SwapResponse, error) {
 	if destination == "" {
 		var err error
 		destination, err = svc.lnClient.GetNewOnchainAddress(svc.ctx)
@@ -287,12 +287,12 @@ func (svc *swapsService) SwapOut(amount uint64, destination string, autoSwap, us
 	fees := pairInfo.Fees
 	serviceFeePercentage := boltz.Percentage(fees.Percentage)
 
-	serviceFee := boltz.CalculatePercentage(serviceFeePercentage, amount)
-	networkFee := fees.MinerFees.Lockup + fees.MinerFees.Claim
+	serviceFeeSat := boltz.CalculatePercentage(serviceFeePercentage, amountSat)
+	networkFeeSat := fees.MinerFees.Lockup + fees.MinerFees.Claim
 
 	logger.Logger.WithFields(logrus.Fields{
-		"serviceFee": serviceFee,
-		"networkFee": networkFee,
+		"serviceFeeSat": serviceFeeSat,
+		"networkFeeSat": networkFeeSat,
 	}).Info("Calculated fees for swap out")
 
 	albyFee := &boltz.ExtraFees{
@@ -308,7 +308,7 @@ func (svc *swapsService) SwapOut(amount uint64, destination string, autoSwap, us
 		Preimage:           hex.EncodeToString(preimage),
 		AutoSwap:           autoSwap,
 		UsedXpub:           usedXpubDerivation,
-		ReceiveAmount:      amount,
+		ReceiveAmountSat:   amountSat,
 	}
 
 	var ourKeys *btcec.PrivateKey
@@ -341,7 +341,7 @@ func (svc *swapsService) SwapOut(amount uint64, destination string, autoSwap, us
 			PairHash:       pairInfo.Hash,
 			ReferralId:     "alby",
 			ExtraFees:      albyFee,
-			OnchainAmount:  amount + fees.MinerFees.Claim,
+			OnchainAmount:  amountSat + fees.MinerFees.Claim,
 		}
 
 		swap, err = svc.boltzApi.CreateReverseSwap(swapRequest)
@@ -362,7 +362,7 @@ func (svc *swapsService) SwapOut(amount uint64, destination string, autoSwap, us
 
 		err = tx.Model(&dbSwap).Updates(&db.Swap{
 			SwapId:             swap.Id,
-			SendAmount:         uint64(paymentRequest.MSatoshi / 1000),
+			SendAmountSat:      uint64(paymentRequest.MSatoshi / 1000),
 			Invoice:            swap.Invoice,
 			LockupAddress:      swap.LockupAddress,
 			TimeoutBlockHeight: swap.TimeoutBlockHeight,
@@ -400,9 +400,9 @@ func (svc *swapsService) SwapOut(amount uint64, destination string, autoSwap, us
 	}, nil
 }
 
-func (svc *swapsService) SwapIn(amount uint64, autoSwap bool) (*SwapResponse, error) {
-	amountMSat := amount * 1000
-	invoice, err := svc.transactionsService.MakeInvoice(svc.ctx, amountMSat, "On-chain to lightning swap", "", 0, nil, svc.lnClient, nil, nil, nil)
+func (svc *swapsService) SwapIn(amountSat uint64, autoSwap bool) (*SwapResponse, error) {
+	amountMsat := amountSat * 1000
+	invoice, err := svc.transactionsService.MakeInvoice(svc.ctx, amountMsat, "On-chain to lightning swap", "", 0, nil, svc.lnClient, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -421,12 +421,12 @@ func (svc *swapsService) SwapIn(amount uint64, autoSwap bool) (*SwapResponse, er
 	fees := pairInfo.Fees
 	serviceFeePercentage := boltz.Percentage(fees.Percentage)
 
-	serviceFee := boltz.CalculatePercentage(serviceFeePercentage, amount)
-	networkFee := fees.MinerFees
+	serviceFeeSat := boltz.CalculatePercentage(serviceFeePercentage, amountSat)
+	networkFeeSat := fees.MinerFees
 
 	logger.Logger.WithFields(logrus.Fields{
-		"serviceFee": serviceFee,
-		"networkFee": networkFee,
+		"serviceFeeSat": serviceFeeSat,
+		"networkFeeSat": networkFeeSat,
 	}).Info("Calculated fees for swap in")
 
 	albyFee := &boltz.ExtraFees{
@@ -483,7 +483,7 @@ func (svc *swapsService) SwapIn(amount uint64, autoSwap bool) (*SwapResponse, er
 
 		err = tx.Model(&dbSwap).Updates(&db.Swap{
 			SwapId:             swap.Id,
-			SendAmount:         swap.ExpectedAmount,
+			SendAmountSat:      swap.ExpectedAmount,
 			LockupAddress:      swap.Address,
 			TimeoutBlockHeight: swap.TimeoutBlockHeight,
 			BoltzPubkey:        hex.EncodeToString(swap.ClaimPublicKey),
@@ -540,15 +540,14 @@ func (svc *swapsService) GetSwapOutInfo() (*SwapInfo, error) {
 	}
 
 	fees := pairInfo.Fees
-	networkFee := fees.MinerFees.Lockup + fees.MinerFees.Claim
 	limits := pairInfo.Limits
 
 	return &SwapInfo{
-		AlbyServiceFee:  AlbySwapServiceFee,
-		BoltzServiceFee: fees.Percentage,
-		BoltzNetworkFee: networkFee,
-		MinAmount:       limits.Minimal,
-		MaxAmount:       limits.Maximal,
+		AlbyServiceFee:     AlbySwapServiceFee,
+		BoltzServiceFee:    fees.Percentage,
+		BoltzNetworkFeeSat: fees.MinerFees.Lockup + fees.MinerFees.Claim,
+		MinAmountSat:       limits.Minimal,
+		MaxAmountSat:       limits.Maximal,
 	}, nil
 }
 
@@ -568,11 +567,11 @@ func (svc *swapsService) GetSwapInInfo() (*SwapInfo, error) {
 	limits := pairInfo.Limits
 
 	return &SwapInfo{
-		AlbyServiceFee:  AlbySwapServiceFee,
-		BoltzServiceFee: fees.Percentage,
-		BoltzNetworkFee: fees.MinerFees,
-		MinAmount:       limits.Minimal,
-		MaxAmount:       limits.Maximal,
+		AlbyServiceFee:     AlbySwapServiceFee,
+		BoltzServiceFee:    fees.Percentage,
+		BoltzNetworkFeeSat: fees.MinerFees,
+		MinAmountSat:       limits.Minimal,
+		MaxAmountSat:       limits.Maximal,
 	}, nil
 }
 
@@ -776,7 +775,7 @@ func (svc *swapsService) RefundSwap(swapId, address string, enableRetries bool) 
 	}
 
 	vout, _, _ = refundTransaction.FindVout(network, address)
-	refundAmount, _ := refundTransaction.VoutValue(vout)
+	refundAmountSat, _ := refundTransaction.VoutValue(vout)
 
 	txHex, err := refundTransaction.Serialize()
 	if err != nil {
@@ -797,9 +796,9 @@ func (svc *swapsService) RefundSwap(swapId, address string, enableRetries bool) 
 	}).Info("Claim transaction broadcasted for refund")
 
 	err = svc.db.Model(&swap).Updates(&db.Swap{
-		ClaimTxId:     claimTxId,
-		ReceiveAmount: refundAmount,
-		State:         constants.SWAP_STATE_REFUNDED,
+		ClaimTxId:        claimTxId,
+		ReceiveAmountSat: refundAmountSat,
+		State:            constants.SWAP_STATE_REFUNDED,
 	}).Error
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
@@ -998,7 +997,7 @@ func (svc *swapsService) startSwapInListener(swap *db.Swap) {
 			case boltz.InvoicePaid:
 				svc.markSwapState(swap, constants.SWAP_STATE_SUCCESS)
 				err = svc.db.Model(swap).Updates(&db.Swap{
-					ReceiveAmount: amount,
+					ReceiveAmountSat: amount,
 				}).Error
 				if err != nil {
 					logger.Logger.WithFields(logrus.Fields{
@@ -1253,16 +1252,16 @@ func (svc *swapsService) startSwapOutListener(swap *db.Swap) {
 				}
 
 				var boltzFee boltz.Fee
-				if swap.ReceiveAmount != 0 {
-					lockupAmount, err := lockupTransaction.VoutValue(vout)
+				if swap.ReceiveAmountSat != 0 {
+					lockupAmountSat, err := lockupTransaction.VoutValue(vout)
 					if err != nil {
 						logger.Logger.WithError(err).WithFields(logrus.Fields{
 							"swapId": swap.SwapId,
 						}).Error("Failed to find lockup output value")
 						return
 					}
-					fee := lockupAmount - swap.ReceiveAmount
-					boltzFee.Sats = &fee
+					feeSat := lockupAmountSat - swap.ReceiveAmountSat
+					boltzFee.Sats = &feeSat
 				} else {
 					var feeRates *FeeRates
 					feeRates, err = svc.getFeeRates()
@@ -1286,7 +1285,7 @@ func (svc *swapsService) startSwapOutListener(swap *db.Swap) {
 				}
 
 				vout, _, _ = claimTransaction.FindVout(network, swap.DestinationAddress)
-				claimAmount, _ := claimTransaction.VoutValue(vout)
+				claimAmountSat, _ := claimTransaction.VoutValue(vout)
 
 				var txHex string
 				txHex, err = claimTransaction.Serialize()
@@ -1325,14 +1324,14 @@ func (svc *swapsService) startSwapOutListener(swap *db.Swap) {
 				}).Info("Claim transaction broadcasted")
 
 				err = svc.db.Model(swap).Updates(&db.Swap{
-					ClaimTxId:     claimTxId,
-					ReceiveAmount: claimAmount,
+					ClaimTxId:        claimTxId,
+					ReceiveAmountSat: claimAmountSat,
 				}).Error
 				if err != nil {
 					logger.Logger.WithFields(logrus.Fields{
-						"swapId":      swap.SwapId,
-						"claimTxId":   claimTxId,
-						"claimAmount": claimAmount,
+						"swapId":         swap.SwapId,
+						"claimTxId":      claimTxId,
+						"claimAmountSat": claimAmountSat,
 					}).WithError(err).Error("Failed to save claim info to swap")
 					return
 				}

--- a/swaps/swaps_service.go
+++ b/swaps/swaps_service.go
@@ -93,11 +93,11 @@ type MempoolTx struct {
 }
 
 type SwapInfo struct {
-	AlbyServiceFee     float64 `json:"albyServiceFee"`
-	BoltzServiceFee    float64 `json:"boltzServiceFee"`
-	BoltzNetworkFeeSat uint64  `json:"boltzNetworkFeeSat"`
-	MinAmountSat       uint64  `json:"minAmountSat"`
-	MaxAmountSat       uint64  `json:"maxAmountSat"`
+	AlbyServiceFee     float64
+	BoltzServiceFee    float64
+	BoltzNetworkFeeSat uint64
+	MinAmountSat       uint64
+	MaxAmountSat       uint64
 }
 
 type SwapResponse struct {

--- a/tests/mock_ln_client.go
+++ b/tests/mock_ln_client.go
@@ -46,8 +46,8 @@ var MockLNClientTransactions = []lnclient.Transaction{
 		DescriptionHash: "hash1",
 		Preimage:        "preimage1",
 		PaymentHash:     MockPaymentHash,
-		Amount:          1000,
-		FeesPaid:        50,
+		AmountMsat:      1000,
+		FeesPaidMsat:    50,
 		SettledAt:       &MockTimeUnix,
 		Metadata: map[string]interface{}{
 			"key1": "value1",
@@ -61,8 +61,8 @@ var MockLNClientTransactions = []lnclient.Transaction{
 		DescriptionHash: "hash2",
 		Preimage:        "preimage2",
 		PaymentHash:     MockPaymentHash,
-		Amount:          2000,
-		FeesPaid:        75,
+		AmountMsat:      2000,
+		FeesPaidMsat:    75,
 		SettledAt:       &MockTimeUnix,
 	},
 }
@@ -75,7 +75,7 @@ var MockLNClientHoldTransaction = &lnclient.Transaction{
 	DescriptionHash: "",
 	Preimage:        "4aa083cad11038359b4f614f3a3d6a8298ae17d5275412bc3eca4f5f4d27f2d4",
 	PaymentHash:     "2779f32f463c795e3cca0e2d40911e4b4d7941baa60bfdf15d28df405df847f5",
-	Amount:          2000,
+	AmountMsat:      2000,
 }
 
 type MockLn struct {
@@ -94,7 +94,7 @@ func NewMockLn() (*MockLn, error) {
 	return &MockLn{}, nil
 }
 
-func (mln *MockLn) SendPaymentSync(payReq string, amount *uint64) (*lnclient.PayInvoiceResponse, error) {
+func (mln *MockLn) SendPaymentSync(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
 	if len(mln.PayInvoiceResponses) > 0 {
 		response := mln.PayInvoiceResponses[0]
 		err := mln.PayInvoiceErrors[0]
@@ -111,9 +111,9 @@ func (mln *MockLn) SendPaymentSync(payReq string, amount *uint64) (*lnclient.Pay
 	}, nil
 }
 
-func (mln *MockLn) SendKeysend(amount uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
+func (mln *MockLn) SendKeysend(amountMsat uint64, destination string, custom_records []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
 	return &lnclient.PayKeysendResponse{
-		Fee: 1,
+		FeeMsat: 1,
 	}, nil
 }
 
@@ -121,7 +121,7 @@ func (mln *MockLn) GetInfo(ctx context.Context) (info *lnclient.NodeInfo, err er
 	return &MockNodeInfo, nil
 }
 
-func (mln *MockLn) MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
+func (mln *MockLn) MakeInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (transaction *lnclient.Transaction, err error) {
 	if len(mln.MakeInvoiceResponses) > 0 {
 		response := mln.MakeInvoiceResponses[0]
 		err := mln.MakeInvoiceErrors[0]
@@ -132,7 +132,7 @@ func (mln *MockLn) MakeInvoice(ctx context.Context, amount int64, description st
 	return MockLNClientTransaction, nil
 }
 
-func (mln *MockLn) MakeHoldInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *lnclient.Transaction, err error) {
+func (mln *MockLn) MakeHoldInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (transaction *lnclient.Transaction, err error) {
 	if minCltvExpiryDelta == nil {
 		mln.LastMinCltvExpiryDelta = nil
 	} else {
@@ -193,7 +193,7 @@ func (mln *MockLn) GetBalances(ctx context.Context, includeInactiveChannels bool
 func (mln *MockLn) GetOnchainBalance(ctx context.Context) (*lnclient.OnchainBalanceResponse, error) {
 	return nil, nil
 }
-func (mln *MockLn) RedeemOnchainFunds(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool) (txId string, err error) {
+func (mln *MockLn) RedeemOnchainFunds(ctx context.Context, toAddress string, amountSat uint64, feeRate *uint64, sendAll bool) (txId string, err error) {
 	return "", nil
 }
 func (mln *MockLn) ResetRouter(key string) error {

--- a/tests/mock_ln_client.go
+++ b/tests/mock_ln_client.go
@@ -199,12 +199,6 @@ func (mln *MockLn) RedeemOnchainFunds(ctx context.Context, toAddress string, amo
 func (mln *MockLn) ResetRouter(key string) error {
 	return nil
 }
-func (mln *MockLn) SendPaymentProbes(ctx context.Context, invoice string) error {
-	return nil
-}
-func (mln *MockLn) SendSpontaneousPaymentProbes(ctx context.Context, amountMsat uint64, nodeId string) error {
-	return nil
-}
 func (mln *MockLn) ListPeers(ctx context.Context) ([]lnclient.PeerDetails, error) {
 	return nil, nil
 }

--- a/tests/mocks/AlbyOAuthService.go
+++ b/tests/mocks/AlbyOAuthService.go
@@ -826,8 +826,8 @@ func (_c *MockAlbyOAuthService_IsConnected_Call) RunAndReturn(run func(ctx conte
 }
 
 // LinkAccount provides a mock function for the type MockAlbyOAuthService
-func (_mock *MockAlbyOAuthService) LinkAccount(ctx context.Context, lnClient lnclient.LNClient, budget uint64, renewal string) error {
-	ret := _mock.Called(ctx, lnClient, budget, renewal)
+func (_mock *MockAlbyOAuthService) LinkAccount(ctx context.Context, lnClient lnclient.LNClient, budgetSat uint64, renewal string) error {
+	ret := _mock.Called(ctx, lnClient, budgetSat, renewal)
 
 	if len(ret) == 0 {
 		panic("no return value specified for LinkAccount")
@@ -835,7 +835,7 @@ func (_mock *MockAlbyOAuthService) LinkAccount(ctx context.Context, lnClient lnc
 
 	var r0 error
 	if returnFunc, ok := ret.Get(0).(func(context.Context, lnclient.LNClient, uint64, string) error); ok {
-		r0 = returnFunc(ctx, lnClient, budget, renewal)
+		r0 = returnFunc(ctx, lnClient, budgetSat, renewal)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -850,13 +850,13 @@ type MockAlbyOAuthService_LinkAccount_Call struct {
 // LinkAccount is a helper method to define mock.On call
 //   - ctx context.Context
 //   - lnClient lnclient.LNClient
-//   - budget uint64
+//   - budgetSat uint64
 //   - renewal string
-func (_e *MockAlbyOAuthService_Expecter) LinkAccount(ctx interface{}, lnClient interface{}, budget interface{}, renewal interface{}) *MockAlbyOAuthService_LinkAccount_Call {
-	return &MockAlbyOAuthService_LinkAccount_Call{Call: _e.mock.On("LinkAccount", ctx, lnClient, budget, renewal)}
+func (_e *MockAlbyOAuthService_Expecter) LinkAccount(ctx interface{}, lnClient interface{}, budgetSat interface{}, renewal interface{}) *MockAlbyOAuthService_LinkAccount_Call {
+	return &MockAlbyOAuthService_LinkAccount_Call{Call: _e.mock.On("LinkAccount", ctx, lnClient, budgetSat, renewal)}
 }
 
-func (_c *MockAlbyOAuthService_LinkAccount_Call) Run(run func(ctx context.Context, lnClient lnclient.LNClient, budget uint64, renewal string)) *MockAlbyOAuthService_LinkAccount_Call {
+func (_c *MockAlbyOAuthService_LinkAccount_Call) Run(run func(ctx context.Context, lnClient lnclient.LNClient, budgetSat uint64, renewal string)) *MockAlbyOAuthService_LinkAccount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -889,7 +889,7 @@ func (_c *MockAlbyOAuthService_LinkAccount_Call) Return(err error) *MockAlbyOAut
 	return _c
 }
 
-func (_c *MockAlbyOAuthService_LinkAccount_Call) RunAndReturn(run func(ctx context.Context, lnClient lnclient.LNClient, budget uint64, renewal string) error) *MockAlbyOAuthService_LinkAccount_Call {
+func (_c *MockAlbyOAuthService_LinkAccount_Call) RunAndReturn(run func(ctx context.Context, lnClient lnclient.LNClient, budgetSat uint64, renewal string) error) *MockAlbyOAuthService_LinkAccount_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/tests/mocks/LNClient.go
+++ b/tests/mocks/LNClient.go
@@ -1885,63 +1885,6 @@ func (_c *MockLNClient_SendKeysend_Call) RunAndReturn(run func(amountMsat uint64
 	return _c
 }
 
-// SendPaymentProbes provides a mock function for the type MockLNClient
-func (_mock *MockLNClient) SendPaymentProbes(ctx context.Context, invoice string) error {
-	ret := _mock.Called(ctx, invoice)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SendPaymentProbes")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = returnFunc(ctx, invoice)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockLNClient_SendPaymentProbes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendPaymentProbes'
-type MockLNClient_SendPaymentProbes_Call struct {
-	*mock.Call
-}
-
-// SendPaymentProbes is a helper method to define mock.On call
-//   - ctx context.Context
-//   - invoice string
-func (_e *MockLNClient_Expecter) SendPaymentProbes(ctx interface{}, invoice interface{}) *MockLNClient_SendPaymentProbes_Call {
-	return &MockLNClient_SendPaymentProbes_Call{Call: _e.mock.On("SendPaymentProbes", ctx, invoice)}
-}
-
-func (_c *MockLNClient_SendPaymentProbes_Call) Run(run func(ctx context.Context, invoice string)) *MockLNClient_SendPaymentProbes_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockLNClient_SendPaymentProbes_Call) Return(err error) *MockLNClient_SendPaymentProbes_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockLNClient_SendPaymentProbes_Call) RunAndReturn(run func(ctx context.Context, invoice string) error) *MockLNClient_SendPaymentProbes_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // SendPaymentSync provides a mock function for the type MockLNClient
 func (_mock *MockLNClient) SendPaymentSync(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
 	ret := _mock.Called(payReq, amountMsat)
@@ -2006,69 +1949,6 @@ func (_c *MockLNClient_SendPaymentSync_Call) Return(payInvoiceResponse *lnclient
 }
 
 func (_c *MockLNClient_SendPaymentSync_Call) RunAndReturn(run func(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error)) *MockLNClient_SendPaymentSync_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// SendSpontaneousPaymentProbes provides a mock function for the type MockLNClient
-func (_mock *MockLNClient) SendSpontaneousPaymentProbes(ctx context.Context, amountMsat uint64, nodeId string) error {
-	ret := _mock.Called(ctx, amountMsat, nodeId)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SendSpontaneousPaymentProbes")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint64, string) error); ok {
-		r0 = returnFunc(ctx, amountMsat, nodeId)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockLNClient_SendSpontaneousPaymentProbes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendSpontaneousPaymentProbes'
-type MockLNClient_SendSpontaneousPaymentProbes_Call struct {
-	*mock.Call
-}
-
-// SendSpontaneousPaymentProbes is a helper method to define mock.On call
-//   - ctx context.Context
-//   - amountMsat uint64
-//   - nodeId string
-func (_e *MockLNClient_Expecter) SendSpontaneousPaymentProbes(ctx interface{}, amountMsat interface{}, nodeId interface{}) *MockLNClient_SendSpontaneousPaymentProbes_Call {
-	return &MockLNClient_SendSpontaneousPaymentProbes_Call{Call: _e.mock.On("SendSpontaneousPaymentProbes", ctx, amountMsat, nodeId)}
-}
-
-func (_c *MockLNClient_SendSpontaneousPaymentProbes_Call) Run(run func(ctx context.Context, amountMsat uint64, nodeId string)) *MockLNClient_SendSpontaneousPaymentProbes_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 uint64
-		if args[1] != nil {
-			arg1 = args[1].(uint64)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *MockLNClient_SendSpontaneousPaymentProbes_Call) Return(err error) *MockLNClient_SendSpontaneousPaymentProbes_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockLNClient_SendSpontaneousPaymentProbes_Call) RunAndReturn(run func(ctx context.Context, amountMsat uint64, nodeId string) error) *MockLNClient_SendSpontaneousPaymentProbes_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/tests/mocks/LNClient.go
+++ b/tests/mocks/LNClient.go
@@ -1347,8 +1347,8 @@ func (_c *MockLNClient_LookupInvoice_Call) RunAndReturn(run func(ctx context.Con
 }
 
 // MakeHoldInvoice provides a mock function for the type MockLNClient
-func (_mock *MockLNClient) MakeHoldInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (*lnclient.Transaction, error) {
-	ret := _mock.Called(ctx, amount, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)
+func (_mock *MockLNClient) MakeHoldInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (*lnclient.Transaction, error) {
+	ret := _mock.Called(ctx, amountMsat, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)
 
 	if len(ret) == 0 {
 		panic("no return value specified for MakeHoldInvoice")
@@ -1357,17 +1357,17 @@ func (_mock *MockLNClient) MakeHoldInvoice(ctx context.Context, amount int64, de
 	var r0 *lnclient.Transaction
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func(context.Context, int64, string, string, int64, string, *uint64) (*lnclient.Transaction, error)); ok {
-		return returnFunc(ctx, amount, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)
+		return returnFunc(ctx, amountMsat, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, int64, string, string, int64, string, *uint64) *lnclient.Transaction); ok {
-		r0 = returnFunc(ctx, amount, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)
+		r0 = returnFunc(ctx, amountMsat, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*lnclient.Transaction)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, int64, string, string, int64, string, *uint64) error); ok {
-		r1 = returnFunc(ctx, amount, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)
+		r1 = returnFunc(ctx, amountMsat, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1381,17 +1381,17 @@ type MockLNClient_MakeHoldInvoice_Call struct {
 
 // MakeHoldInvoice is a helper method to define mock.On call
 //   - ctx context.Context
-//   - amount int64
+//   - amountMsat int64
 //   - description string
 //   - descriptionHash string
 //   - expiry int64
 //   - paymentHash string
 //   - minCltvExpiryDelta *uint64
-func (_e *MockLNClient_Expecter) MakeHoldInvoice(ctx interface{}, amount interface{}, description interface{}, descriptionHash interface{}, expiry interface{}, paymentHash interface{}, minCltvExpiryDelta interface{}) *MockLNClient_MakeHoldInvoice_Call {
-	return &MockLNClient_MakeHoldInvoice_Call{Call: _e.mock.On("MakeHoldInvoice", ctx, amount, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)}
+func (_e *MockLNClient_Expecter) MakeHoldInvoice(ctx interface{}, amountMsat interface{}, description interface{}, descriptionHash interface{}, expiry interface{}, paymentHash interface{}, minCltvExpiryDelta interface{}) *MockLNClient_MakeHoldInvoice_Call {
+	return &MockLNClient_MakeHoldInvoice_Call{Call: _e.mock.On("MakeHoldInvoice", ctx, amountMsat, description, descriptionHash, expiry, paymentHash, minCltvExpiryDelta)}
 }
 
-func (_c *MockLNClient_MakeHoldInvoice_Call) Run(run func(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64)) *MockLNClient_MakeHoldInvoice_Call {
+func (_c *MockLNClient_MakeHoldInvoice_Call) Run(run func(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64)) *MockLNClient_MakeHoldInvoice_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1439,14 +1439,14 @@ func (_c *MockLNClient_MakeHoldInvoice_Call) Return(transaction *lnclient.Transa
 	return _c
 }
 
-func (_c *MockLNClient_MakeHoldInvoice_Call) RunAndReturn(run func(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (*lnclient.Transaction, error)) *MockLNClient_MakeHoldInvoice_Call {
+func (_c *MockLNClient_MakeHoldInvoice_Call) RunAndReturn(run func(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, paymentHash string, minCltvExpiryDelta *uint64) (*lnclient.Transaction, error)) *MockLNClient_MakeHoldInvoice_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // MakeInvoice provides a mock function for the type MockLNClient
-func (_mock *MockLNClient) MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (*lnclient.Transaction, error) {
-	ret := _mock.Called(ctx, amount, description, descriptionHash, expiry, throughNodePubkey)
+func (_mock *MockLNClient) MakeInvoice(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (*lnclient.Transaction, error) {
+	ret := _mock.Called(ctx, amountMsat, description, descriptionHash, expiry, throughNodePubkey)
 
 	if len(ret) == 0 {
 		panic("no return value specified for MakeInvoice")
@@ -1455,17 +1455,17 @@ func (_mock *MockLNClient) MakeInvoice(ctx context.Context, amount int64, descri
 	var r0 *lnclient.Transaction
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func(context.Context, int64, string, string, int64, *string) (*lnclient.Transaction, error)); ok {
-		return returnFunc(ctx, amount, description, descriptionHash, expiry, throughNodePubkey)
+		return returnFunc(ctx, amountMsat, description, descriptionHash, expiry, throughNodePubkey)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, int64, string, string, int64, *string) *lnclient.Transaction); ok {
-		r0 = returnFunc(ctx, amount, description, descriptionHash, expiry, throughNodePubkey)
+		r0 = returnFunc(ctx, amountMsat, description, descriptionHash, expiry, throughNodePubkey)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*lnclient.Transaction)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, int64, string, string, int64, *string) error); ok {
-		r1 = returnFunc(ctx, amount, description, descriptionHash, expiry, throughNodePubkey)
+		r1 = returnFunc(ctx, amountMsat, description, descriptionHash, expiry, throughNodePubkey)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1479,16 +1479,16 @@ type MockLNClient_MakeInvoice_Call struct {
 
 // MakeInvoice is a helper method to define mock.On call
 //   - ctx context.Context
-//   - amount int64
+//   - amountMsat int64
 //   - description string
 //   - descriptionHash string
 //   - expiry int64
 //   - throughNodePubkey *string
-func (_e *MockLNClient_Expecter) MakeInvoice(ctx interface{}, amount interface{}, description interface{}, descriptionHash interface{}, expiry interface{}, throughNodePubkey interface{}) *MockLNClient_MakeInvoice_Call {
-	return &MockLNClient_MakeInvoice_Call{Call: _e.mock.On("MakeInvoice", ctx, amount, description, descriptionHash, expiry, throughNodePubkey)}
+func (_e *MockLNClient_Expecter) MakeInvoice(ctx interface{}, amountMsat interface{}, description interface{}, descriptionHash interface{}, expiry interface{}, throughNodePubkey interface{}) *MockLNClient_MakeInvoice_Call {
+	return &MockLNClient_MakeInvoice_Call{Call: _e.mock.On("MakeInvoice", ctx, amountMsat, description, descriptionHash, expiry, throughNodePubkey)}
 }
 
-func (_c *MockLNClient_MakeInvoice_Call) Run(run func(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string)) *MockLNClient_MakeInvoice_Call {
+func (_c *MockLNClient_MakeInvoice_Call) Run(run func(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string)) *MockLNClient_MakeInvoice_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1531,7 +1531,7 @@ func (_c *MockLNClient_MakeInvoice_Call) Return(transaction *lnclient.Transactio
 	return _c
 }
 
-func (_c *MockLNClient_MakeInvoice_Call) RunAndReturn(run func(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (*lnclient.Transaction, error)) *MockLNClient_MakeInvoice_Call {
+func (_c *MockLNClient_MakeInvoice_Call) RunAndReturn(run func(ctx context.Context, amountMsat int64, description string, descriptionHash string, expiry int64, throughNodePubkey *string) (*lnclient.Transaction, error)) *MockLNClient_MakeInvoice_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1671,8 +1671,8 @@ func (_c *MockLNClient_OpenChannel_Call) RunAndReturn(run func(ctx context.Conte
 }
 
 // RedeemOnchainFunds provides a mock function for the type MockLNClient
-func (_mock *MockLNClient) RedeemOnchainFunds(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool) (string, error) {
-	ret := _mock.Called(ctx, toAddress, amount, feeRate, sendAll)
+func (_mock *MockLNClient) RedeemOnchainFunds(ctx context.Context, toAddress string, amountSat uint64, feeRate *uint64, sendAll bool) (string, error) {
+	ret := _mock.Called(ctx, toAddress, amountSat, feeRate, sendAll)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RedeemOnchainFunds")
@@ -1681,15 +1681,15 @@ func (_mock *MockLNClient) RedeemOnchainFunds(ctx context.Context, toAddress str
 	var r0 string
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, uint64, *uint64, bool) (string, error)); ok {
-		return returnFunc(ctx, toAddress, amount, feeRate, sendAll)
+		return returnFunc(ctx, toAddress, amountSat, feeRate, sendAll)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, uint64, *uint64, bool) string); ok {
-		r0 = returnFunc(ctx, toAddress, amount, feeRate, sendAll)
+		r0 = returnFunc(ctx, toAddress, amountSat, feeRate, sendAll)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string, uint64, *uint64, bool) error); ok {
-		r1 = returnFunc(ctx, toAddress, amount, feeRate, sendAll)
+		r1 = returnFunc(ctx, toAddress, amountSat, feeRate, sendAll)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1704,14 +1704,14 @@ type MockLNClient_RedeemOnchainFunds_Call struct {
 // RedeemOnchainFunds is a helper method to define mock.On call
 //   - ctx context.Context
 //   - toAddress string
-//   - amount uint64
+//   - amountSat uint64
 //   - feeRate *uint64
 //   - sendAll bool
-func (_e *MockLNClient_Expecter) RedeemOnchainFunds(ctx interface{}, toAddress interface{}, amount interface{}, feeRate interface{}, sendAll interface{}) *MockLNClient_RedeemOnchainFunds_Call {
-	return &MockLNClient_RedeemOnchainFunds_Call{Call: _e.mock.On("RedeemOnchainFunds", ctx, toAddress, amount, feeRate, sendAll)}
+func (_e *MockLNClient_Expecter) RedeemOnchainFunds(ctx interface{}, toAddress interface{}, amountSat interface{}, feeRate interface{}, sendAll interface{}) *MockLNClient_RedeemOnchainFunds_Call {
+	return &MockLNClient_RedeemOnchainFunds_Call{Call: _e.mock.On("RedeemOnchainFunds", ctx, toAddress, amountSat, feeRate, sendAll)}
 }
 
-func (_c *MockLNClient_RedeemOnchainFunds_Call) Run(run func(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool)) *MockLNClient_RedeemOnchainFunds_Call {
+func (_c *MockLNClient_RedeemOnchainFunds_Call) Run(run func(ctx context.Context, toAddress string, amountSat uint64, feeRate *uint64, sendAll bool)) *MockLNClient_RedeemOnchainFunds_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1749,7 +1749,7 @@ func (_c *MockLNClient_RedeemOnchainFunds_Call) Return(txId string, err error) *
 	return _c
 }
 
-func (_c *MockLNClient_RedeemOnchainFunds_Call) RunAndReturn(run func(ctx context.Context, toAddress string, amount uint64, feeRate *uint64, sendAll bool) (string, error)) *MockLNClient_RedeemOnchainFunds_Call {
+func (_c *MockLNClient_RedeemOnchainFunds_Call) RunAndReturn(run func(ctx context.Context, toAddress string, amountSat uint64, feeRate *uint64, sendAll bool) (string, error)) *MockLNClient_RedeemOnchainFunds_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1806,8 +1806,8 @@ func (_c *MockLNClient_ResetRouter_Call) RunAndReturn(run func(key string) error
 }
 
 // SendKeysend provides a mock function for the type MockLNClient
-func (_mock *MockLNClient) SendKeysend(amount uint64, destination string, customRecords []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
-	ret := _mock.Called(amount, destination, customRecords, preimage)
+func (_mock *MockLNClient) SendKeysend(amountMsat uint64, destination string, customRecords []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
+	ret := _mock.Called(amountMsat, destination, customRecords, preimage)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendKeysend")
@@ -1816,17 +1816,17 @@ func (_mock *MockLNClient) SendKeysend(amount uint64, destination string, custom
 	var r0 *lnclient.PayKeysendResponse
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func(uint64, string, []lnclient.TLVRecord, string) (*lnclient.PayKeysendResponse, error)); ok {
-		return returnFunc(amount, destination, customRecords, preimage)
+		return returnFunc(amountMsat, destination, customRecords, preimage)
 	}
 	if returnFunc, ok := ret.Get(0).(func(uint64, string, []lnclient.TLVRecord, string) *lnclient.PayKeysendResponse); ok {
-		r0 = returnFunc(amount, destination, customRecords, preimage)
+		r0 = returnFunc(amountMsat, destination, customRecords, preimage)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*lnclient.PayKeysendResponse)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(uint64, string, []lnclient.TLVRecord, string) error); ok {
-		r1 = returnFunc(amount, destination, customRecords, preimage)
+		r1 = returnFunc(amountMsat, destination, customRecords, preimage)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1839,15 +1839,15 @@ type MockLNClient_SendKeysend_Call struct {
 }
 
 // SendKeysend is a helper method to define mock.On call
-//   - amount uint64
+//   - amountMsat uint64
 //   - destination string
 //   - customRecords []lnclient.TLVRecord
 //   - preimage string
-func (_e *MockLNClient_Expecter) SendKeysend(amount interface{}, destination interface{}, customRecords interface{}, preimage interface{}) *MockLNClient_SendKeysend_Call {
-	return &MockLNClient_SendKeysend_Call{Call: _e.mock.On("SendKeysend", amount, destination, customRecords, preimage)}
+func (_e *MockLNClient_Expecter) SendKeysend(amountMsat interface{}, destination interface{}, customRecords interface{}, preimage interface{}) *MockLNClient_SendKeysend_Call {
+	return &MockLNClient_SendKeysend_Call{Call: _e.mock.On("SendKeysend", amountMsat, destination, customRecords, preimage)}
 }
 
-func (_c *MockLNClient_SendKeysend_Call) Run(run func(amount uint64, destination string, customRecords []lnclient.TLVRecord, preimage string)) *MockLNClient_SendKeysend_Call {
+func (_c *MockLNClient_SendKeysend_Call) Run(run func(amountMsat uint64, destination string, customRecords []lnclient.TLVRecord, preimage string)) *MockLNClient_SendKeysend_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 uint64
 		if args[0] != nil {
@@ -1880,7 +1880,7 @@ func (_c *MockLNClient_SendKeysend_Call) Return(payKeysendResponse *lnclient.Pay
 	return _c
 }
 
-func (_c *MockLNClient_SendKeysend_Call) RunAndReturn(run func(amount uint64, destination string, customRecords []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error)) *MockLNClient_SendKeysend_Call {
+func (_c *MockLNClient_SendKeysend_Call) RunAndReturn(run func(amountMsat uint64, destination string, customRecords []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error)) *MockLNClient_SendKeysend_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1943,8 +1943,8 @@ func (_c *MockLNClient_SendPaymentProbes_Call) RunAndReturn(run func(ctx context
 }
 
 // SendPaymentSync provides a mock function for the type MockLNClient
-func (_mock *MockLNClient) SendPaymentSync(payReq string, amount *uint64) (*lnclient.PayInvoiceResponse, error) {
-	ret := _mock.Called(payReq, amount)
+func (_mock *MockLNClient) SendPaymentSync(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
+	ret := _mock.Called(payReq, amountMsat)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendPaymentSync")
@@ -1953,17 +1953,17 @@ func (_mock *MockLNClient) SendPaymentSync(payReq string, amount *uint64) (*lncl
 	var r0 *lnclient.PayInvoiceResponse
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func(string, *uint64) (*lnclient.PayInvoiceResponse, error)); ok {
-		return returnFunc(payReq, amount)
+		return returnFunc(payReq, amountMsat)
 	}
 	if returnFunc, ok := ret.Get(0).(func(string, *uint64) *lnclient.PayInvoiceResponse); ok {
-		r0 = returnFunc(payReq, amount)
+		r0 = returnFunc(payReq, amountMsat)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*lnclient.PayInvoiceResponse)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(string, *uint64) error); ok {
-		r1 = returnFunc(payReq, amount)
+		r1 = returnFunc(payReq, amountMsat)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1977,12 +1977,12 @@ type MockLNClient_SendPaymentSync_Call struct {
 
 // SendPaymentSync is a helper method to define mock.On call
 //   - payReq string
-//   - amount *uint64
-func (_e *MockLNClient_Expecter) SendPaymentSync(payReq interface{}, amount interface{}) *MockLNClient_SendPaymentSync_Call {
-	return &MockLNClient_SendPaymentSync_Call{Call: _e.mock.On("SendPaymentSync", payReq, amount)}
+//   - amountMsat *uint64
+func (_e *MockLNClient_Expecter) SendPaymentSync(payReq interface{}, amountMsat interface{}) *MockLNClient_SendPaymentSync_Call {
+	return &MockLNClient_SendPaymentSync_Call{Call: _e.mock.On("SendPaymentSync", payReq, amountMsat)}
 }
 
-func (_c *MockLNClient_SendPaymentSync_Call) Run(run func(payReq string, amount *uint64)) *MockLNClient_SendPaymentSync_Call {
+func (_c *MockLNClient_SendPaymentSync_Call) Run(run func(payReq string, amountMsat *uint64)) *MockLNClient_SendPaymentSync_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -2005,7 +2005,7 @@ func (_c *MockLNClient_SendPaymentSync_Call) Return(payInvoiceResponse *lnclient
 	return _c
 }
 
-func (_c *MockLNClient_SendPaymentSync_Call) RunAndReturn(run func(payReq string, amount *uint64) (*lnclient.PayInvoiceResponse, error)) *MockLNClient_SendPaymentSync_Call {
+func (_c *MockLNClient_SendPaymentSync_Call) RunAndReturn(run func(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error)) *MockLNClient_SendPaymentSync_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/transactions/make_invoice_test.go
+++ b/transactions/make_invoice_test.go
@@ -33,7 +33,7 @@ func TestMakeInvoice_NoApp(t *testing.T) {
 	err = json.Unmarshal(transaction.Metadata, &metadata)
 	assert.NoError(t, err)
 
-	assert.Equal(t, uint64(tests.MockLNClientTransaction.Amount), transaction.AmountMsat)
+	assert.Equal(t, uint64(tests.MockLNClientTransaction.AmountMsat), transaction.AmountMsat)
 	assert.Equal(t, constants.TRANSACTION_STATE_PENDING, transaction.State)
 	assert.Equal(t, tests.MockLNClientTransaction.Preimage, *transaction.Preimage)
 	assert.Equal(t, txMetadata["randomkey"], metadata["randomkey"])
@@ -75,7 +75,7 @@ func TestMakeInvoice_App(t *testing.T) {
 	transaction, err := transactionsService.MakeInvoice(ctx, 1234, "Hello world", "", 0, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
 
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(tests.MockLNClientTransaction.Amount), transaction.AmountMsat)
+	assert.Equal(t, uint64(tests.MockLNClientTransaction.AmountMsat), transaction.AmountMsat)
 	assert.Equal(t, constants.TRANSACTION_STATE_PENDING, transaction.State)
 	assert.Equal(t, tests.MockLNClientTransaction.Preimage, *transaction.Preimage)
 	assert.Equal(t, app.ID, *transaction.AppId)

--- a/transactions/notifications_test.go
+++ b/transactions/notifications_test.go
@@ -69,7 +69,7 @@ func TestNotifications_ReceivedUnknownPayment(t *testing.T) {
 	transactionType := constants.TRANSACTION_TYPE_INCOMING
 	incomingTransaction, err := transactionsService.LookupTransaction(ctx, tests.MockLNClientTransaction.PaymentHash, &transactionType, svc.LNClient, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(tests.MockLNClientTransaction.Amount), incomingTransaction.AmountMsat)
+	assert.Equal(t, uint64(tests.MockLNClientTransaction.AmountMsat), incomingTransaction.AmountMsat)
 	assert.Equal(t, constants.TRANSACTION_STATE_SETTLED, incomingTransaction.State)
 	assert.Equal(t, tests.MockLNClientTransaction.Preimage, *incomingTransaction.Preimage)
 	assert.Zero(t, incomingTransaction.FeeReserveMsat)
@@ -104,8 +104,8 @@ func TestNotifications_ReceivedKeysend(t *testing.T) {
 		DescriptionHash: "",
 		Preimage:        tests.MockLNClientTransaction.Preimage,
 		PaymentHash:     tests.MockLNClientTransaction.PaymentHash,
-		Amount:          2000,
-		FeesPaid:        75,
+		AmountMsat:      2000,
+		FeesPaidMsat:    75,
 		SettledAt:       &tests.MockTimeUnix,
 		Metadata:        metadata,
 	}
@@ -202,7 +202,7 @@ func TestNotifications_SentUnknownPayment(t *testing.T) {
 	transactionType := constants.TRANSACTION_TYPE_OUTGOING
 	outgoingTransaction, err := transactionsService.LookupTransaction(ctx, tests.MockLNClientTransaction.PaymentHash, &transactionType, svc.LNClient, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(tests.MockLNClientTransaction.Amount), outgoingTransaction.AmountMsat)
+	assert.Equal(t, uint64(tests.MockLNClientTransaction.AmountMsat), outgoingTransaction.AmountMsat)
 	assert.Equal(t, constants.TRANSACTION_STATE_SETTLED, outgoingTransaction.State)
 	assert.Equal(t, tests.MockLNClientTransaction.Preimage, *outgoingTransaction.Preimage)
 	assert.Zero(t, outgoingTransaction.FeeReserveMsat)

--- a/transactions/payments_test.go
+++ b/transactions/payments_test.go
@@ -444,8 +444,8 @@ func TestConsumeEvent_FailedMarkedAsSuccessful(t *testing.T) {
 			DescriptionHash: tests.MockLNClientTransaction.DescriptionHash,
 			Preimage:        tests.MockLNClientTransaction.Preimage,
 			PaymentHash:     tests.MockLNClientTransaction.PaymentHash,
-			Amount:          tests.MockLNClientTransaction.Amount,
-			FeesPaid:        tests.MockLNClientTransaction.FeesPaid,
+			AmountMsat:      tests.MockLNClientTransaction.AmountMsat,
+			FeesPaidMsat:    tests.MockLNClientTransaction.FeesPaidMsat,
 		},
 	}, nil)
 

--- a/transactions/receive_keysend_test.go
+++ b/transactions/receive_keysend_test.go
@@ -31,13 +31,13 @@ func TestReceiveKeysend_ValidBoostagram(t *testing.T) {
 		},
 	}
 	tx := lnclient.Transaction{
-		Type:        "incoming",
-		Description: "mock invoice 1",
-		Preimage:    "9f59b18f80a77c2930deb8be5ff1143eacdd1891c63c23d61bc9f99c64e57325",
-		PaymentHash: "ae4277b7be3ca1420cafd24c143866190f52b996856b0e4164763f936e61ea1b",
-		Amount:      1000,
-		FeesPaid:    50,
-		SettledAt:   &tests.MockTimeUnix,
+		Type:         "incoming",
+		Description:  "mock invoice 1",
+		Preimage:     "9f59b18f80a77c2930deb8be5ff1143eacdd1891c63c23d61bc9f99c64e57325",
+		PaymentHash:  "ae4277b7be3ca1420cafd24c143866190f52b996856b0e4164763f936e61ea1b",
+		AmountMsat:   1000,
+		FeesPaidMsat: 50,
+		SettledAt:    &tests.MockTimeUnix,
 		Metadata: map[string]interface{}{
 			"tlv_records": tlv,
 		},
@@ -72,13 +72,13 @@ func TestReceiveKeysend_InvalidBoostagram(t *testing.T) {
 		},
 	}
 	tx := lnclient.Transaction{
-		Type:        "incoming",
-		Description: "mock invoice 1",
-		Preimage:    "9f59b18f80a77c2930deb8be5ff1143eacdd1891c63c23d61bc9f99c64e57325",
-		PaymentHash: "ae4277b7be3ca1420cafd24c143866190f52b996856b0e4164763f936e61ea1b",
-		Amount:      1000,
-		FeesPaid:    50,
-		SettledAt:   &tests.MockTimeUnix,
+		Type:         "incoming",
+		Description:  "mock invoice 1",
+		Preimage:     "9f59b18f80a77c2930deb8be5ff1143eacdd1891c63c23d61bc9f99c64e57325",
+		PaymentHash:  "ae4277b7be3ca1420cafd24c143866190f52b996856b0e4164763f936e61ea1b",
+		AmountMsat:   1000,
+		FeesPaidMsat: 50,
+		SettledAt:    &tests.MockTimeUnix,
 		Metadata: map[string]interface{}{
 			"tlv_records": tlv,
 		},
@@ -118,13 +118,13 @@ func TestReceiveKeysendWithCustomKey(t *testing.T) {
 		},
 	}
 	tx := lnclient.Transaction{
-		Type:        "incoming",
-		Description: "mock invoice 1",
-		Preimage:    "9f59b18f80a77c2930deb8be5ff1143eacdd1891c63c23d61bc9f99c64e57325",
-		PaymentHash: "ae4277b7be3ca1420cafd24c143866190f52b996856b0e4164763f936e61ea1b",
-		Amount:      1000,
-		FeesPaid:    50,
-		SettledAt:   &tests.MockTimeUnix,
+		Type:         "incoming",
+		Description:  "mock invoice 1",
+		Preimage:     "9f59b18f80a77c2930deb8be5ff1143eacdd1891c63c23d61bc9f99c64e57325",
+		PaymentHash:  "ae4277b7be3ca1420cafd24c143866190f52b996856b0e4164763f936e61ea1b",
+		AmountMsat:   1000,
+		FeesPaidMsat: 50,
+		SettledAt:    &tests.MockTimeUnix,
 		Metadata: map[string]interface{}{
 			"tlv_records": tlv,
 		},

--- a/transactions/self_hold_payments_test.go
+++ b/transactions/self_hold_payments_test.go
@@ -169,7 +169,7 @@ func TestWrappedInvoice(t *testing.T) {
 		DescriptionHash: "",
 		Preimage:        "fcf200c74d9900dc77af17eb1f57c02eec0f94b5b169d3eee23df9a216a3411b",
 		PaymentHash:     "8f3cfa1cdcf19de4b6fdb9ec339b7470e724d0c755b7c7568164d5df1b70ea6e",
-		Amount:          1000_000,
+		AmountMsat:      1000_000,
 	}
 
 	// Bob's 1100 sat invoice
@@ -182,7 +182,7 @@ func TestWrappedInvoice(t *testing.T) {
 		DescriptionHash: "",
 		Preimage:        "",
 		PaymentHash:     "8f3cfa1cdcf19de4b6fdb9ec339b7470e724d0c755b7c7568164d5df1b70ea6e",
-		Amount:          1100_000,
+		AmountMsat:      1100_000,
 	}
 
 	svc.LNClient.(*tests.MockLn).MakeInvoiceResponses = []*lnclient.Transaction{

--- a/transactions/transactions_service.go
+++ b/transactions/transactions_service.go
@@ -36,12 +36,12 @@ type transactionsService struct {
 
 type TransactionsService interface {
 	events.EventSubscriber
-	MakeInvoice(ctx context.Context, amount uint64, description string, descriptionHash string, expiry uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint, throughNodePubkey *string) (*Transaction, error)
+	MakeInvoice(ctx context.Context, amountMsat uint64, description string, descriptionHash string, expiry uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint, throughNodePubkey *string) (*Transaction, error)
 	LookupTransaction(ctx context.Context, paymentHash string, transactionType *string, lnClient lnclient.LNClient, appId *uint) (*Transaction, error)
 	ListTransactions(ctx context.Context, from, until, limit, offset uint64, unpaidOutgoing bool, unpaidIncoming bool, transactionType *string, lnClient lnclient.LNClient, appId *uint, forceFilterByAppId bool) (transactions []Transaction, totalCount uint64, err error)
 	SendPaymentSync(payReq string, amountMsat *uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error)
-	SendKeysend(amount uint64, destination string, customRecords []lnclient.TLVRecord, preimage string, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error)
-	MakeHoldInvoice(ctx context.Context, amount uint64, description string, descriptionHash string, expiry uint64, paymentHash string, minCltvExpiryDelta *uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error)
+	SendKeysend(amountMsat uint64, destination string, customRecords []lnclient.TLVRecord, preimage string, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error)
+	MakeHoldInvoice(ctx context.Context, amountMsat uint64, description string, descriptionHash string, expiry uint64, paymentHash string, minCltvExpiryDelta *uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error)
 	SettleHoldInvoice(ctx context.Context, preimage string, lnClient lnclient.LNClient) (*Transaction, error)
 	CancelHoldInvoice(ctx context.Context, paymentHash string, lnClient lnclient.LNClient) error
 	SetTransactionMetadata(ctx context.Context, id uint, metadata map[string]interface{}) error
@@ -140,11 +140,11 @@ func NewTransactionsService(db *gorm.DB, eventPublisher events.EventPublisher) *
 	}
 }
 
-func (svc *transactionsService) MakeInvoice(ctx context.Context, amount uint64, description string, descriptionHash string, expiry uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint, throughNodePubkey *string) (*Transaction, error) {
+func (svc *transactionsService) MakeInvoice(ctx context.Context, amountMsat uint64, description string, descriptionHash string, expiry uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint, throughNodePubkey *string) (*Transaction, error) {
 	logger.Logger.WithFields(logrus.Fields{
 		"app_id":           appId,
 		"request_event_id": requestEventId,
-		"amount":           amount,
+		"amount_msat":      amountMsat,
 		"description":      description,
 		"description_hash": descriptionHash,
 		"expiry":           expiry,
@@ -174,7 +174,7 @@ func (svc *transactionsService) MakeInvoice(ctx context.Context, amount uint64, 
 		appId = &overwriteAppId
 	}
 
-	lnClientTransaction, err := lnClient.MakeInvoice(ctx, int64(amount), description, descriptionHash, int64(expiry), throughNodePubkey)
+	lnClientTransaction, err := lnClient.MakeInvoice(ctx, int64(amountMsat), description, descriptionHash, int64(expiry), throughNodePubkey)
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to create transaction")
 		return nil, err
@@ -196,7 +196,7 @@ func (svc *transactionsService) MakeInvoice(ctx context.Context, amount uint64, 
 		RequestEventId:  requestEventId,
 		Type:            lnClientTransaction.Type,
 		State:           constants.TRANSACTION_STATE_PENDING,
-		AmountMsat:      uint64(lnClientTransaction.Amount),
+		AmountMsat:      uint64(lnClientTransaction.AmountMsat),
 		Description:     description,
 		DescriptionHash: descriptionHash,
 		PaymentRequest:  lnClientTransaction.Invoice,
@@ -213,7 +213,7 @@ func (svc *transactionsService) MakeInvoice(ctx context.Context, amount uint64, 
 	return &dbTransaction, nil
 }
 
-func (svc *transactionsService) MakeHoldInvoice(ctx context.Context, amount uint64, description string, descriptionHash string, expiry uint64, paymentHash string, minCltvExpiryDelta *uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error) {
+func (svc *transactionsService) MakeHoldInvoice(ctx context.Context, amountMsat uint64, description string, descriptionHash string, expiry uint64, paymentHash string, minCltvExpiryDelta *uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error) {
 	var err error
 	var metadataBytes []byte
 	if metadata != nil {
@@ -227,7 +227,7 @@ func (svc *transactionsService) MakeHoldInvoice(ctx context.Context, amount uint
 		}
 	}
 
-	lnClientTransaction, err := lnClient.MakeHoldInvoice(ctx, int64(amount), description, descriptionHash, int64(expiry), paymentHash, minCltvExpiryDelta)
+	lnClientTransaction, err := lnClient.MakeHoldInvoice(ctx, int64(amountMsat), description, descriptionHash, int64(expiry), paymentHash, minCltvExpiryDelta)
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to create hold invoice via LN client")
 		return nil, err
@@ -249,7 +249,7 @@ func (svc *transactionsService) MakeHoldInvoice(ctx context.Context, amount uint
 		RequestEventId:  requestEventId,
 		Type:            constants.TRANSACTION_TYPE_INCOMING,
 		State:           constants.TRANSACTION_STATE_PENDING,
-		AmountMsat:      uint64(lnClientTransaction.Amount),
+		AmountMsat:      uint64(lnClientTransaction.AmountMsat),
 		Description:     description,
 		DescriptionHash: descriptionHash,
 		PaymentRequest:  lnClientTransaction.Invoice,
@@ -314,9 +314,9 @@ func (svc *transactionsService) SendPaymentSync(payReq string, amountMsat *uint6
 
 	var dbTransaction db.Transaction
 
-	paymentAmount := uint64(paymentRequest.MSatoshi)
+	paymentAmountMsat := uint64(paymentRequest.MSatoshi)
 	if amountMsat != nil && paymentRequest.MSatoshi == 0 {
-		paymentAmount = *amountMsat
+		paymentAmountMsat = *amountMsat
 	}
 
 	err = func() error {
@@ -341,7 +341,7 @@ func (svc *transactionsService) SendPaymentSync(payReq string, amountMsat *uint6
 				return errors.New("there is already a payment pending for this invoice")
 			}
 
-			err := svc.validateCanPay(tx, appId, paymentAmount, paymentRequest.Description, selfPayment)
+			err := svc.validateCanPay(tx, appId, paymentAmountMsat, paymentRequest.Description, selfPayment)
 			if err != nil {
 				return err
 			}
@@ -356,8 +356,8 @@ func (svc *transactionsService) SendPaymentSync(payReq string, amountMsat *uint6
 				RequestEventId:  requestEventId,
 				Type:            constants.TRANSACTION_TYPE_OUTGOING,
 				State:           constants.TRANSACTION_STATE_PENDING,
-				FeeReserveMsat:  CalculateFeeReserveMsat(paymentAmount),
-				AmountMsat:      paymentAmount,
+				FeeReserveMsat:  CalculateFeeReserveMsat(paymentAmountMsat),
+				AmountMsat:      paymentAmountMsat,
 				PaymentRequest:  payReq,
 				PaymentHash:     paymentRequest.PaymentHash,
 				Description:     paymentRequest.Description,
@@ -381,7 +381,7 @@ func (svc *transactionsService) SendPaymentSync(payReq string, amountMsat *uint6
 	logger.Logger.WithFields(logrus.Fields{
 		"app_id":           appId,
 		"request_event_id": requestEventId,
-		"amount":           paymentAmount,
+		"amount_msat":      paymentAmountMsat,
 		"description":      paymentRequest.Description,
 		"description_hash": paymentRequest.DescriptionHash,
 		"expiry":           paymentRequest.Expiry,
@@ -411,7 +411,7 @@ func (svc *transactionsService) SendPaymentSync(payReq string, amountMsat *uint6
 	// the payment definitely succeeded
 	var settledTransaction *db.Transaction
 	err = svc.db.Transaction(func(tx *gorm.DB) error {
-		settledTransaction, err = svc.markTransactionSettled(tx, &dbTransaction, response.Preimage, response.Fee, selfPayment)
+		settledTransaction, err = svc.markTransactionSettled(tx, &dbTransaction, response.Preimage, response.FeeMsat, selfPayment)
 		return err
 	})
 	if err != nil {
@@ -421,7 +421,7 @@ func (svc *transactionsService) SendPaymentSync(payReq string, amountMsat *uint6
 	return settledTransaction, nil
 }
 
-func (svc *transactionsService) SendKeysend(amount uint64, destination string, customRecords []lnclient.TLVRecord, preimage string, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error) {
+func (svc *transactionsService) SendKeysend(amountMsat uint64, destination string, customRecords []lnclient.TLVRecord, preimage string, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error) {
 	if preimage == "" {
 		preImageBytes, err := makePreimageHex()
 		if err != nil {
@@ -463,7 +463,7 @@ func (svc *transactionsService) SendKeysend(amount uint64, destination string, c
 		balanceValidationLock.Lock()
 		defer balanceValidationLock.Unlock()
 		return svc.db.Transaction(func(tx *gorm.DB) error {
-			err := svc.validateCanPay(tx, appId, amount, "", selfPayment)
+			err := svc.validateCanPay(tx, appId, amountMsat, "", selfPayment)
 			if err != nil {
 				return err
 			}
@@ -474,8 +474,8 @@ func (svc *transactionsService) SendKeysend(amount uint64, destination string, c
 				RequestEventId: requestEventId,
 				Type:           constants.TRANSACTION_TYPE_OUTGOING,
 				State:          constants.TRANSACTION_STATE_PENDING,
-				FeeReserveMsat: CalculateFeeReserveMsat(uint64(amount)),
-				AmountMsat:     amount,
+				FeeReserveMsat: CalculateFeeReserveMsat(uint64(amountMsat)),
+				AmountMsat:     amountMsat,
 				Metadata:       datatypes.JSON(metadataBytes),
 				Boostagram:     datatypes.JSON(boostagramBytes),
 				PaymentHash:    paymentHash,
@@ -491,7 +491,7 @@ func (svc *transactionsService) SendKeysend(amount uint64, destination string, c
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
 			"destination": destination,
-			"amount":      amount,
+			"amount_msat": amountMsat,
 		}).WithError(err).Error("Failed to create DB transaction")
 		return nil, err
 	}
@@ -506,7 +506,7 @@ func (svc *transactionsService) SendKeysend(amount uint64, destination string, c
 			RequestEventId: nil, // it is related to this request but for a different app
 			Type:           constants.TRANSACTION_TYPE_INCOMING,
 			State:          constants.TRANSACTION_STATE_PENDING,
-			AmountMsat:     amount,
+			AmountMsat:     amountMsat,
 			PaymentHash:    paymentHash,
 			Preimage:       &preimage,
 			Description:    svc.getDescriptionFromCustomRecords(customRecords),
@@ -523,17 +523,17 @@ func (svc *transactionsService) SendKeysend(amount uint64, destination string, c
 		_, err = svc.interceptSelfPayment("", paymentHash, lnClient)
 		if err == nil {
 			payKeysendResponse = &lnclient.PayKeysendResponse{
-				Fee: 0,
+				FeeMsat: 0,
 			}
 		}
 	} else {
-		payKeysendResponse, err = lnClient.SendKeysend(amount, destination, customRecords, preimage)
+		payKeysendResponse, err = lnClient.SendKeysend(amountMsat, destination, customRecords, preimage)
 	}
 
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
 			"destination": destination,
-			"amount":      amount,
+			"amount_msat": amountMsat,
 		}).WithError(err).Error("Failed to send payment")
 
 		dbErr := svc.db.Model(&dbTransaction).Updates(&db.Transaction{
@@ -543,7 +543,7 @@ func (svc *transactionsService) SendKeysend(amount uint64, destination string, c
 		if dbErr != nil {
 			logger.Logger.WithFields(logrus.Fields{
 				"destination": destination,
-				"amount":      amount,
+				"amount_msat": amountMsat,
 			}).WithError(dbErr).Error("Failed to update DB transaction")
 		}
 
@@ -553,7 +553,7 @@ func (svc *transactionsService) SendKeysend(amount uint64, destination string, c
 	// the payment definitely succeeded
 	var settledTransaction *db.Transaction
 	err = svc.db.Transaction(func(tx *gorm.DB) error {
-		settledTransaction, err = svc.markTransactionSettled(tx, &dbTransaction, preimage, payKeysendResponse.Fee, selfPayment)
+		settledTransaction, err = svc.markTransactionSettled(tx, &dbTransaction, preimage, payKeysendResponse.FeeMsat, selfPayment)
 		return err
 	})
 
@@ -721,7 +721,7 @@ func (svc *transactionsService) checkUnsettledTransaction(ctx context.Context, t
 	// update transaction state
 	if lnClientTransaction.SettledAt != nil {
 		err = svc.db.Transaction(func(tx *gorm.DB) error {
-			_, err = svc.markTransactionSettled(tx, transaction, lnClientTransaction.Preimage, uint64(lnClientTransaction.FeesPaid), false)
+			_, err = svc.markTransactionSettled(tx, transaction, lnClientTransaction.Preimage, uint64(lnClientTransaction.FeesPaidMsat), false)
 			return err
 		})
 
@@ -778,7 +778,7 @@ func (svc *transactionsService) ConsumeEvent(ctx context.Context, event *events.
 				}
 				dbTransaction = db.Transaction{
 					Type:            constants.TRANSACTION_TYPE_INCOMING,
-					AmountMsat:      uint64(lnClientTransaction.Amount),
+					AmountMsat:      uint64(lnClientTransaction.AmountMsat),
 					PaymentRequest:  lnClientTransaction.Invoice,
 					PaymentHash:     lnClientTransaction.PaymentHash,
 					Description:     description,
@@ -797,7 +797,7 @@ func (svc *transactionsService) ConsumeEvent(ctx context.Context, event *events.
 				}
 			}
 
-			_, err := svc.markTransactionSettled(tx, &dbTransaction, lnClientTransaction.Preimage, uint64(lnClientTransaction.FeesPaid), false)
+			_, err := svc.markTransactionSettled(tx, &dbTransaction, lnClientTransaction.Preimage, uint64(lnClientTransaction.FeesPaidMsat), false)
 			return err
 		})
 
@@ -867,7 +867,7 @@ func (svc *transactionsService) ConsumeEvent(ctx context.Context, event *events.
 						dbTransaction = db.Transaction{
 							Type:            constants.TRANSACTION_TYPE_OUTGOING,
 							State:           constants.TRANSACTION_STATE_PENDING,
-							AmountMsat:      uint64(lnClientTransaction.Amount),
+							AmountMsat:      uint64(lnClientTransaction.AmountMsat),
 							FeeReserveMsat:  0,
 							PaymentRequest:  lnClientTransaction.Invoice,
 							PaymentHash:     lnClientTransaction.PaymentHash,
@@ -891,7 +891,7 @@ func (svc *transactionsService) ConsumeEvent(ctx context.Context, event *events.
 				}
 			}
 
-			_, err := svc.markTransactionSettled(tx, &dbTransaction, lnClientTransaction.Preimage, uint64(lnClientTransaction.FeesPaid), false)
+			_, err := svc.markTransactionSettled(tx, &dbTransaction, lnClientTransaction.Preimage, uint64(lnClientTransaction.FeesPaidMsat), false)
 			return err
 		})
 
@@ -1022,7 +1022,7 @@ func (svc *transactionsService) interceptSelfPayment(paymentRequest string, paym
 
 	return &lnclient.PayInvoiceResponse{
 		Preimage: *incomingTransaction.Preimage,
-		Fee:      0,
+		FeeMsat:  0,
 	}, nil
 }
 
@@ -1056,7 +1056,7 @@ func (svc *transactionsService) interceptSelfHoldPayment(paymentRequest string, 
 
 		return &lnclient.PayInvoiceResponse{
 			Preimage: *settledTransaction.Preimage,
-			Fee:      0,
+			FeeMsat:  0,
 		}, nil
 	case canceledTransaction := <-canceledChannel:
 		logger.Logger.WithField("canceled_transaction", canceledTransaction).Info("self hold payment was canceled")
@@ -1064,10 +1064,10 @@ func (svc *transactionsService) interceptSelfHoldPayment(paymentRequest string, 
 	}
 }
 
-func (svc *transactionsService) validateCanPay(tx *gorm.DB, appId *uint, amount uint64, description string, selfPayment bool) error {
-	amountWithFeeReserve := amount
+func (svc *transactionsService) validateCanPay(tx *gorm.DB, appId *uint, amountMsat uint64, description string, selfPayment bool) error {
+	amountWithFeeReserveMsat := amountMsat
 	if !selfPayment {
-		amountWithFeeReserve += CalculateFeeReserveMsat(amount)
+		amountWithFeeReserveMsat += CalculateFeeReserveMsat(amountMsat)
 	}
 
 	// ensure balance for isolated apps
@@ -1095,12 +1095,12 @@ func (svc *transactionsService) validateCanPay(tx *gorm.DB, appId *uint, amount 
 				return fmt.Errorf("failed to calculate isolated balance for app: %w", err)
 			}
 
-			if int64(amountWithFeeReserve) > balanceMsat {
+			if int64(amountWithFeeReserveMsat) > balanceMsat {
 				logger.Logger.WithFields(logrus.Fields{
-					"balance_msat":            balanceMsat,
-					"self_payment":            selfPayment,
-					"amount":                  amount,
-					"amount_with_fee_reserve": amountWithFeeReserve,
+					"balance_msat":                 balanceMsat,
+					"self_payment":                 selfPayment,
+					"amount_msat":                  amountMsat,
+					"amount_with_fee_reserve_msat": amountWithFeeReserveMsat,
 				}).Debug("Insufficient budget to make payment from isolated app")
 				message := NewInsufficientBalanceError().Error()
 				if description != "" {
@@ -1124,7 +1124,7 @@ func (svc *transactionsService) validateCanPay(tx *gorm.DB, appId *uint, amount 
 			if err != nil {
 				return fmt.Errorf("failed to calculate budget usage for app: %w", err)
 			}
-			if int(amountWithFeeReserve/1000) > appPermission.MaxAmountSat-int(budgetUsageMsat/1000) {
+			if int(amountWithFeeReserveMsat/1000) > appPermission.MaxAmountSat-int(budgetUsageMsat/1000) {
 				message := NewQuotaExceededError().Error()
 				if description != "" {
 					message += " " + description
@@ -1379,7 +1379,7 @@ func (svc *transactionsService) SetTransactionMetadata(ctx context.Context, id u
 	return nil
 }
 
-func (svc *transactionsService) markTransactionSettled(tx *gorm.DB, dbTransaction *db.Transaction, preimage string, fee uint64, selfPayment bool) (*db.Transaction, error) {
+func (svc *transactionsService) markTransactionSettled(tx *gorm.DB, dbTransaction *db.Transaction, preimage string, feeMsat uint64, selfPayment bool) (*db.Transaction, error) {
 	if preimage == "" {
 		return nil, errors.New("no preimage in payment")
 	}
@@ -1408,7 +1408,7 @@ func (svc *transactionsService) markTransactionSettled(tx *gorm.DB, dbTransactio
 	err := tx.Model(dbTransaction).Updates(map[string]interface{}{
 		"State":          constants.TRANSACTION_STATE_SETTLED,
 		"Preimage":       &preimage,
-		"FeeMsat":        fee,
+		"FeeMsat":        feeMsat,
 		"FeeReserveMsat": 0,
 		"SettledAt":      &settledAt,
 		"SelfPayment":    selfPayment,

--- a/wails/wails_handlers.go
+++ b/wails/wails_handlers.go
@@ -344,7 +344,7 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 				return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 			}
 		}
-		amountMsat, _ := api.ResolveToMsat(payRequest.AmountSat, payRequest.AmountMsat, nil, payRequest.Amount)
+		amountMsat := api.ResolveToMsat(payRequest.AmountSat, payRequest.AmountMsat, nil, payRequest.Amount)
 		paymentResponse, err := app.api.SendPayment(ctx, invoice, amountMsat, payRequest.Metadata)
 		if err != nil {
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
@@ -384,8 +384,11 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			}).WithError(err).Error("Failed to decode request to wails router")
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
-		resolvedAmountMsat, _ := api.ResolveToMsat(transferRequest.AmountSat, transferRequest.AmountMsat, nil, nil)
-		amountMsat := *resolvedAmountMsat
+		amountMsat := uint64(0)
+		resolvedAmountMsat := api.ResolveToMsat(transferRequest.AmountSat, transferRequest.AmountMsat, nil, nil)
+		if resolvedAmountMsat != nil {
+			amountMsat = *resolvedAmountMsat
+		}
 
 		err = app.api.Transfer(ctx, transferRequest.FromAppId, transferRequest.ToAppId, amountMsat, transferRequest.Description)
 		if err != nil {
@@ -550,8 +553,11 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			}).WithError(err).Error("Failed to decode request to wails router")
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
-		resolvedAmountMsat, _ := api.ResolveToMsat(makeInvoiceRequest.AmountSat, makeInvoiceRequest.AmountMsat, nil, makeInvoiceRequest.Amount)
-		amountMsat := *resolvedAmountMsat
+		amountMsat := uint64(0)
+		resolvedAmountMsat := api.ResolveToMsat(makeInvoiceRequest.AmountSat, makeInvoiceRequest.AmountMsat, nil, makeInvoiceRequest.Amount)
+		if resolvedAmountMsat != nil {
+			amountMsat = *resolvedAmountMsat
+		}
 		invoice, err := app.api.CreateInvoice(ctx, amountMsat, makeInvoiceRequest.Description)
 		if err != nil {
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
@@ -585,8 +591,11 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
 
-		resolvedAmountSat, _ := api.ResolveToSat(redeemOnchainFundsRequest.AmountSat, nil, redeemOnchainFundsRequest.Amount, nil)
-		amountSat := *resolvedAmountSat
+		amountSat := uint64(0)
+		resolvedAmountSat := api.ResolveToSat(redeemOnchainFundsRequest.AmountSat, nil, redeemOnchainFundsRequest.Amount, nil)
+		if resolvedAmountSat != nil {
+			amountSat = *resolvedAmountSat
+		}
 
 		redeemOnchainFundsResponse, err := app.api.RedeemOnchainFunds(ctx, redeemOnchainFundsRequest.ToAddress, amountSat, redeemOnchainFundsRequest.FeeRate, redeemOnchainFundsRequest.SendAll)
 		if err != nil {

--- a/wails/wails_handlers.go
+++ b/wails/wails_handlers.go
@@ -344,7 +344,8 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 				return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 			}
 		}
-		paymentResponse, err := app.api.SendPayment(ctx, invoice, payRequest.Amount, payRequest.Metadata)
+		amountMsat, _ := api.ResolveToMsat(payRequest.AmountSat, payRequest.AmountMsat, nil, payRequest.Amount)
+		paymentResponse, err := app.api.SendPayment(ctx, invoice, amountMsat, payRequest.Metadata)
 		if err != nil {
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
@@ -383,8 +384,10 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			}).WithError(err).Error("Failed to decode request to wails router")
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
+		resolvedAmountMsat, _ := api.ResolveToMsat(transferRequest.AmountSat, transferRequest.AmountMsat, nil, nil)
+		amountMsat := *resolvedAmountMsat
 
-		err = app.api.Transfer(ctx, transferRequest.FromAppId, transferRequest.ToAppId, transferRequest.AmountSat*1000, transferRequest.Description)
+		err = app.api.Transfer(ctx, transferRequest.FromAppId, transferRequest.ToAppId, amountMsat, transferRequest.Description)
 		if err != nil {
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
@@ -547,7 +550,9 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			}).WithError(err).Error("Failed to decode request to wails router")
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
-		invoice, err := app.api.CreateInvoice(ctx, makeInvoiceRequest.Amount, makeInvoiceRequest.Description)
+		resolvedAmountMsat, _ := api.ResolveToMsat(makeInvoiceRequest.AmountSat, makeInvoiceRequest.AmountMsat, nil, makeInvoiceRequest.Amount)
+		amountMsat := *resolvedAmountMsat
+		invoice, err := app.api.CreateInvoice(ctx, amountMsat, makeInvoiceRequest.Description)
 		if err != nil {
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
@@ -580,7 +585,10 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
 
-		redeemOnchainFundsResponse, err := app.api.RedeemOnchainFunds(ctx, redeemOnchainFundsRequest.ToAddress, redeemOnchainFundsRequest.AmountSat, redeemOnchainFundsRequest.FeeRate, redeemOnchainFundsRequest.SendAll)
+		resolvedAmountSat, _ := api.ResolveToSat(redeemOnchainFundsRequest.AmountSat, nil, redeemOnchainFundsRequest.Amount, nil)
+		amountSat := *resolvedAmountSat
+
+		redeemOnchainFundsResponse, err := app.api.RedeemOnchainFunds(ctx, redeemOnchainFundsRequest.ToAddress, amountSat, redeemOnchainFundsRequest.FeeRate, redeemOnchainFundsRequest.SendAll)
 		if err != nil {
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}

--- a/wails/wails_handlers.go
+++ b/wails/wails_handlers.go
@@ -580,7 +580,7 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
 
-		redeemOnchainFundsResponse, err := app.api.RedeemOnchainFunds(ctx, redeemOnchainFundsRequest.ToAddress, redeemOnchainFundsRequest.Amount, redeemOnchainFundsRequest.FeeRate, redeemOnchainFundsRequest.SendAll)
+		redeemOnchainFundsResponse, err := app.api.RedeemOnchainFunds(ctx, redeemOnchainFundsRequest.ToAddress, redeemOnchainFundsRequest.AmountSat, redeemOnchainFundsRequest.FeeRate, redeemOnchainFundsRequest.SendAll)
 		if err != nil {
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}

--- a/wails/wails_handlers.go
+++ b/wails/wails_handlers.go
@@ -884,48 +884,6 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
 		return WailsRequestRouterResponse{Body: nil, Error: ""}
-	case "/api/send-payment-probes":
-		sendPaymentProbesRequest := &api.SendPaymentProbesRequest{}
-		err := json.Unmarshal([]byte(body), sendPaymentProbesRequest)
-		if err != nil {
-			logger.Logger.WithFields(logrus.Fields{
-				"route":  route,
-				"method": method,
-				"body":   body,
-			}).WithError(err).Error("Failed to decode request to wails router")
-			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
-		}
-		sendPaymentProbesResponse, err := app.api.SendPaymentProbes(ctx, sendPaymentProbesRequest)
-		if err != nil {
-			logger.Logger.WithFields(logrus.Fields{
-				"route":  route,
-				"method": method,
-				"body":   body,
-			}).WithError(err).Error("Failed to send payment probes")
-			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
-		}
-		return WailsRequestRouterResponse{Body: sendPaymentProbesResponse, Error: ""}
-	case "/api/send-spontaneous-payment-probes":
-		sendSpontaneousPaymentProbesRequest := &api.SendSpontaneousPaymentProbesRequest{}
-		err := json.Unmarshal([]byte(body), sendSpontaneousPaymentProbesRequest)
-		if err != nil {
-			logger.Logger.WithFields(logrus.Fields{
-				"route":  route,
-				"method": method,
-				"body":   body,
-			}).WithError(err).Error("Failed to decode request to wails router")
-			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
-		}
-		sendSpontaneousPaymentProbesResponse, err := app.api.SendSpontaneousPaymentProbes(ctx, sendSpontaneousPaymentProbesRequest)
-		if err != nil {
-			logger.Logger.WithFields(logrus.Fields{
-				"route":  route,
-				"method": method,
-				"body":   body,
-			}).WithError(err).Error("Failed to send spontaneous payment probes")
-			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
-		}
-		return WailsRequestRouterResponse{Body: sendSpontaneousPaymentProbesResponse, Error: ""}
 	case "/api/backup":
 		backupRequest := &api.BasicBackupRequest{}
 		err := json.Unmarshal([]byte(body), backupRequest)


### PR DESCRIPTION
Fixes #2223 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit Sat and Msat fields across APIs and UI types; handlers now resolve canonical Sat/Msat values for payments, invoices, swaps, transfers and redemptions.

* **Deprecations**
  * Legacy generic amount fields marked deprecated; use the new Sat/Msat fields.

* **Bug Fixes / Improvements**
  * Consistent unit resolution and mapping across channels, swaps, transactions and autoswap configs to prevent unit mismatches.

* **Removals**
  * Removed probe endpoints for sending payment probes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->