### PR TITLE
fix: clarify connected peers navigation in LDK alert

### DIFF
--- a/frontend/src/components/channels/LDKChannelWithoutPeerAlert.tsx
+++ b/frontend/src/components/channels/LDKChannelWithoutPeerAlert.tsx
@@ -54,11 +54,11 @@ function ChannelWithoutPeerAlertInternal({ channel }: { channel: Channel }) {
           </ExternalLink>{" "}
         </p>
         <p>
-          2. Open{" "}
+          2. Open <span className="font-semibold">Advanced</span> and click{" "}
           <Link to="/peers" className="font-semibold">
-            Peers
+            Connected Peers
           </Link>{" "}
-          to re-connect the peer.
+          to reconnect the peer.
         </p>
       </AlertDescription>
     </Alert>


### PR DESCRIPTION
## Summary
- update the LDK disconnected-peer alert to mention the **Advanced** menu
- rename the destination from **Peers** to **Connected Peers** to match the current UI
- tighten the wording from "re-connect" to "reconnect"

## Testing
- `cd frontend && corepack yarn prepare:http`
- `cd frontend && corepack yarn lint`

Closes #2249


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated alert instructions to correctly guide users to the Advanced section and Connected Peers option when reconnecting peers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->