### PR TITLE
feat(home): daily lightning streak widget

### DIFF
--- a/frontend/src/components/home/widgets/DailyStreakWidget.tsx
+++ b/frontend/src/components/home/widgets/DailyStreakWidget.tsx
@@ -1,0 +1,194 @@
+import { Share2Icon, ZapIcon } from "lucide-react";
+import * as React from "react";
+import { Button } from "src/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "src/components/ui/card";
+import { Skeleton } from "src/components/ui/skeleton";
+import {
+  IS_STREAK_STUBBED,
+  useActivityStreak,
+} from "src/hooks/useActivityStreak";
+import { cn } from "src/lib/utils";
+
+const MILESTONES = [7, 30, 100, 365, 1000];
+
+type PillState = "kept" | "atRisk" | "start";
+
+function getSubtitle(count: number): string {
+  if (count === 0) {
+    return "Send or receive a payment to start your streak.";
+  }
+  if (count === 1) {
+    return "You've used lightning today — keep it going tomorrow.";
+  }
+  return `You've used lightning every day for ${count} days.`;
+}
+
+function getNextMilestone(
+  streak: number
+): { target: number; remaining: number } | null {
+  for (const target of MILESTONES) {
+    if (streak < target) {
+      return { target, remaining: target - streak };
+    }
+  }
+  return null;
+}
+
+function getPillState(currentStreak: number, keptToday: boolean): PillState {
+  if (keptToday) {
+    return "kept";
+  }
+  if (currentStreak > 0) {
+    return "atRisk";
+  }
+  return "start";
+}
+
+const PILL_COPY: Record<PillState, string> = {
+  kept: "Kept today",
+  atRisk: "Keep it going",
+  start: "Start today",
+};
+
+const PILL_CLASSES: Record<PillState, string> = {
+  kept: "bg-green-500/15 text-green-700 dark:text-green-400",
+  atRisk: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
+  start: "bg-muted text-muted-foreground",
+};
+
+const PILL_DOT_CLASSES: Record<PillState, string> = {
+  kept: "bg-green-500",
+  atRisk: "bg-amber-500",
+  start: "bg-muted-foreground",
+};
+
+export function DailyStreakWidget() {
+  const [stubTick, setStubTick] = React.useState(0);
+  const { isLoading, currentStreak, keptToday, weekDays } =
+    useActivityStreak(stubTick);
+
+  const handleStubReroll = IS_STREAK_STUBBED
+    ? () => setStubTick((t) => t + 1)
+    : undefined;
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Daily streak</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-4">
+            <Skeleton className="h-10 w-32" />
+            <Skeleton className="h-4 w-64" />
+            <div className="grid grid-cols-7 gap-2">
+              {Array.from({ length: 7 }).map((_, i) => (
+                <Skeleton key={i} className="h-12" />
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const pillState = getPillState(currentStreak, keptToday);
+  const nextMilestone = getNextMilestone(currentStreak);
+
+  return (
+    <Card
+      onClick={handleStubReroll}
+      className={cn(handleStubReroll && "cursor-pointer select-none")}
+      title={handleStubReroll ? "Click to randomize (stub)" : undefined}
+    >
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle>Daily streak</CardTitle>
+          <div
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium",
+              PILL_CLASSES[pillState]
+            )}
+          >
+            <span
+              className={cn(
+                "h-1.5 w-1.5 rounded-full",
+                PILL_DOT_CLASSES[pillState]
+              )}
+            />
+            {PILL_COPY[pillState]}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col gap-4">
+          <div>
+            <div className="flex items-baseline gap-2">
+              <span className="text-4xl font-semibold tabular-nums">
+                {currentStreak}
+              </span>
+              <span className="text-muted-foreground text-sm">
+                {currentStreak === 1 ? "day" : "days"}
+              </span>
+            </div>
+            <p className="text-muted-foreground mt-1 text-sm">
+              {getSubtitle(currentStreak)}
+            </p>
+          </div>
+          <div className="grid grid-cols-7 gap-2">
+            {weekDays.map((day) => (
+              <div
+                key={day.dateKey}
+                className="flex flex-col items-center gap-1.5"
+              >
+                <span className="text-muted-foreground text-xs">
+                  {day.weekdayLabel}
+                </span>
+                <div
+                  title={day.dateKey}
+                  className={cn(
+                    "flex h-10 w-full items-center justify-center rounded-md",
+                    day.hasActivity
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted text-muted-foreground",
+                    day.isFuture && "opacity-40",
+                    day.isToday &&
+                      "ring-2 ring-primary ring-offset-2 ring-offset-background"
+                  )}
+                >
+                  {day.hasActivity && (
+                    <ZapIcon className="h-4 w-4 fill-current" />
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="flex items-end justify-between gap-2">
+            {nextMilestone ? (
+              <p className="text-muted-foreground text-xs">
+                {nextMilestone.remaining}{" "}
+                {nextMilestone.remaining === 1 ? "day" : "days"} to{" "}
+                {nextMilestone.target}-day badge
+              </p>
+            ) : (
+              <span />
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Share2Icon className="mr-1.5 h-3.5 w-3.5" />
+              Share
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/hooks/useActivityStreak.ts
+++ b/frontend/src/hooks/useActivityStreak.ts
@@ -1,0 +1,127 @@
+import * as React from "react";
+
+import { useTransactions } from "src/hooks/useTransactions";
+
+export type WeekDay = {
+  dateKey: string;
+  weekdayLabel: string;
+  hasActivity: boolean;
+  isToday: boolean;
+  isFuture: boolean;
+};
+
+export type UseActivityStreakResult = {
+  isLoading: boolean;
+  currentStreak: number;
+  keptToday: boolean;
+  weekDays: WeekDay[];
+};
+
+const TRANSACTION_LIMIT = 500;
+const WEEKDAY_LABELS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
+
+// TEMP STUB — seeds a randomized streak for visual preview.
+// Revert before merging.
+export const IS_STREAK_STUBBED = true;
+
+function generateStubStreakLength(): number {
+  const r = Math.random();
+  if (r < 0.15) {
+    return 0;
+  }
+  if (r < 0.25) {
+    return 1;
+  }
+  if (r < 0.5) {
+    return Math.floor(Math.random() * 10) + 2;
+  }
+  if (r < 0.8) {
+    return Math.floor(Math.random() * 50) + 10;
+  }
+  return Math.floor(Math.random() * 500) + 50;
+}
+
+function formatLocalDateKey(date: Date, timeZone: string): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    timeZone,
+  }).format(date);
+}
+
+function addDaysToKey(key: string, delta: number): string {
+  const [year, month, day] = key.split("-").map(Number);
+  const dt = new Date(year, month - 1, day);
+  dt.setDate(dt.getDate() + delta);
+  const y = dt.getFullYear();
+  const m = String(dt.getMonth() + 1).padStart(2, "0");
+  const d = String(dt.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+export function useActivityStreak(stubTick = 0): UseActivityStreakResult {
+  const { data, isLoading } = useTransactions(
+    undefined,
+    false,
+    TRANSACTION_LIMIT,
+    1
+  );
+
+  return React.useMemo(() => {
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const now = new Date();
+    const todayKey = formatLocalDateKey(now, timeZone);
+
+    const dayOfWeek = now.getDay(); // 0 = Sun … 6 = Sat
+    const daysFromMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+    const mondayKey = addDaysToKey(todayKey, -daysFromMonday);
+
+    const activeDays = new Set<string>();
+    if (IS_STREAK_STUBBED) {
+      const streakLen = generateStubStreakLength();
+      const keptToday = streakLen > 0 && Math.random() > 0.3;
+      const startOffset = keptToday ? 0 : 1;
+      for (let i = 0; i < streakLen; i++) {
+        activeDays.add(addDaysToKey(todayKey, -(i + startOffset)));
+      }
+    } else {
+      for (const tx of data?.transactions ?? []) {
+        if (tx.state !== "settled" || !tx.settledAt) {
+          continue;
+        }
+        activeDays.add(formatLocalDateKey(new Date(tx.settledAt), timeZone));
+      }
+    }
+
+    let currentStreak = 0;
+    let cursor = todayKey;
+    if (!activeDays.has(cursor)) {
+      cursor = addDaysToKey(cursor, -1);
+    }
+    while (activeDays.has(cursor)) {
+      currentStreak += 1;
+      cursor = addDaysToKey(cursor, -1);
+    }
+
+    const weekDays: WeekDay[] = WEEKDAY_LABELS.map((label, i) => {
+      const dateKey = addDaysToKey(mondayKey, i);
+      return {
+        dateKey,
+        weekdayLabel: label,
+        hasActivity: activeDays.has(dateKey),
+        isToday: dateKey === todayKey,
+        isFuture: dateKey > todayKey,
+      };
+    });
+
+    return {
+      isLoading: isLoading && !data && !IS_STREAK_STUBBED,
+      currentStreak,
+      keptToday: activeDays.has(todayKey),
+      weekDays,
+    };
+    // stubTick intentionally re-seeds the memo to reroll the stub.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, isLoading, stubTick]);
+}

--- a/frontend/src/screens/Home.tsx
+++ b/frontend/src/screens/Home.tsx
@@ -21,6 +21,7 @@ import React from "react";
 import albyGo from "src/assets/suggested-apps/alby-go.png";
 import { AppOfTheDayWidget } from "src/components/home/widgets/AppOfTheDayWidget";
 import { BlockHeightWidget } from "src/components/home/widgets/BlockHeightWidget";
+import { DailyStreakWidget } from "src/components/home/widgets/DailyStreakWidget";
 import { ForwardsWidget } from "src/components/home/widgets/ForwardsWidget";
 import { LatestUsedAppsWidget } from "src/components/home/widgets/LatestUsedAppsWidget";
 import { LightningMessageboardWidget } from "src/components/home/widgets/LightningMessageboardWidget";
@@ -68,6 +69,7 @@ function Home() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 items-start justify-start">
         {/* LEFT */}
         <div className="grid gap-3">
+          <DailyStreakWidget />
           <OnboardingChecklist />
           <WhatsNewWidget />
           <SupportAlbyWidget />


### PR DESCRIPTION
## Summary

Adds a Duolingo-style **Daily streak** widget to the Home dashboard to nudge users toward daily lightning engagement.

Computed entirely frontend-side from settled transactions, bucketed by the user's local timezone, with a one-day grace window so a streak doesn't reset in the middle of the day.

![placeholder — grab a screenshot from the stubbed randomizer before promoting to ready-for-review]

## What's in here

- **`useActivityStreak` hook** — returns `currentStreak`, `keptToday`, and the current Mo–Su week with per-day activity. Reads from `useTransactions(limit=500)`.
- **`DailyStreakWidget`** — hero count, status pill (Kept today / Keep it going / Start today), weekly strip with lightning-bolt cells, next-milestone footer (`[7, 30, 100, 365, 1000]`), and an **unwired Share button** (download-a-shareable-card behavior is intentionally deferred).
- **Home mount** — first card in the left column, above the onboarding checklist.

## Decisions

| Question | Choice |
|---|---|
| Scope | Medium: number + weekly strip + pill + milestone |
| Compute location | Frontend (prototype); move to `/api/activity/streak` if the idea sticks |
| What counts | Any settled tx (incoming or outgoing) |
| Day boundary | User's local timezone (via `Intl`) |

## ⚠️ Draft blockers (before promoting to ready)

- [ ] Flip `IS_STREAK_STUBBED` to `false` in `frontend/src/hooks/useActivityStreak.ts` — currently the widget renders a randomized streak and rerolls on click for visual review.
- [ ] Decide Share button fate: wire the download (html-to-image → PNG) or remove for now.
- [ ] Capture a real screenshot with production data.

## Out of scope (follow-ups)

- Backend SQL-driven streak endpoint (accurate beyond 500 tx)
- Best-streak-ever tracking
- "Streak at risk late in the day" notifications
- Actual Share download implementation

## Test plan

- [ ] With stub ON, click the card repeatedly to sanity-check the three pill states (Kept / Keep it going / Start today), singular vs plural copy, milestone boundaries (6→7, 29→30, 99→100), and that future days in the current week render muted.
- [ ] Flip stub OFF locally; verify streak count matches a manual walk-back of `/api/transactions` `settledAt`s.
- [ ] Make a real payment and confirm the streak increments on refresh.
- [ ] Temporarily change OS timezone and confirm day buckets shift to local wall-clock, not UTC.
- [ ] Loading and zero states render without layout shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)