### PR TITLE
chore: update ldk-node-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/btcsuite/btcd v0.24.3-0.20250318170759-4f4ea81776d6
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/elnosh/gonuts v0.4.2
-	github.com/getAlby/ldk-node-go v0.0.0-20260325180303-fbe7fe6a114d
+	github.com/getAlby/ldk-node-go v0.0.0-20260424111754-3690cdb3031c
 	github.com/go-gormigrate/gormigrate/v2 v2.1.5
 	github.com/labstack/echo/v4 v4.15.1
 	github.com/mattn/go-sqlite3 v1.14.42

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
-github.com/getAlby/ldk-node-go v0.0.0-20260325180303-fbe7fe6a114d h1:u7m25pstQSZiDIViKGrIpxnQBu01asJIl25EbzljVtE=
-github.com/getAlby/ldk-node-go v0.0.0-20260325180303-fbe7fe6a114d/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20260424111754-3690cdb3031c h1:ikai5+taiPSgbaocdVMdxPkmOhnXs5V/gCX+J/P8iRw=
+github.com/getAlby/ldk-node-go v0.0.0-20260424111754-3690cdb3031c/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gormigrate/gormigrate/v2 v2.1.5 h1:1OyorA5LtdQw12cyJDEHuTrEV3GiXiIhS4/QTTa/SM8=
 github.com/go-gormigrate/gormigrate/v2 v2.1.5/go.mod h1:mj9ekk/7CPF3VjopaFvWKN2v7fN3D9d3eEOAXRhi/+M=


### PR DESCRIPTION
## Summary
- Update `github.com/getAlby/ldk-node-go` to `v0.0.0-20260424111754-3690cdb3031c`
- Consumes the LDK-Node bindings published by the successful action run: https://github.com/getAlby/ldk-node/actions/runs/24881352152
- Includes the inbound channel limit change from https://github.com/getAlby/ldk-node/pull/94

Closes getAlby/hub#2016.

## Test Plan
- `GOTOOLCHAIN=go1.25.0 go mod tidy`
- `GOTOOLCHAIN=go1.25.0 go test ./lnclient/ldk`
- `GOTOOLCHAIN=go1.25.0 go test ./...` *(fails for existing setup reason: `frontend/frontend.go:11:12: pattern dist: no matching files found` in packages that embed the frontend dist; non-frontend-dist packages passed)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go module dependency for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->