### PR TITLE
feat: simplify onchain receive routing

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -154,7 +154,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           </CommandItem>
           <CommandItem
             onSelect={() =>
-              runCommand(() => navigate("/wallet/receive/onchain"))
+              runCommand(() => navigate("/wallet/receive?type=onchain"))
             }
           >
             <LinkIcon />

--- a/frontend/src/components/OnchainTransactionsList.tsx
+++ b/frontend/src/components/OnchainTransactionsList.tsx
@@ -22,7 +22,7 @@ export function OnchainTransactionsList() {
           title="No on-chain transactions yet"
           description="Your most recent incoming and outgoing on-chain transactions will show up here."
           buttonText="Receive to On-chain Balance"
-          buttonLink="/wallet/receive/onchain?type=onchain"
+          buttonLink="/wallet/receive?type=onchain"
           showBorder={false}
         />
       </div>

--- a/frontend/src/components/ReceiveToOnchain.tsx
+++ b/frontend/src/components/ReceiveToOnchain.tsx
@@ -1,0 +1,255 @@
+import {
+  ArrowLeftIcon,
+  CopyIcon,
+  ExternalLinkIcon,
+  HandCoinsIcon,
+  RefreshCwIcon,
+} from "lucide-react";
+import TickSVG from "public/images/illustrations/tick.svg";
+import { useEffect, useRef, useState } from "react";
+import { FixedFloatButton } from "src/components/FixedFloatButton";
+import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
+import FormattedFiatAmount from "src/components/FormattedFiatAmount";
+import Loading from "src/components/Loading";
+import LottieLoading from "src/components/LottieLoading";
+import OnchainAddressDisplay from "src/components/OnchainAddressDisplay";
+import QRCode from "src/components/QRCode";
+import { Button } from "src/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "src/components/ui/card";
+import { ExternalLinkButton } from "src/components/ui/custom/external-link-button";
+import { LinkButton } from "src/components/ui/custom/link-button";
+import { Separator } from "src/components/ui/separator";
+import { useInfo } from "src/hooks/useInfo";
+import { useMempoolApi } from "src/hooks/useMempoolApi";
+import { useOnchainAddress } from "src/hooks/useOnchainAddress";
+import { copyToClipboard } from "src/lib/clipboard";
+import { MempoolUtxo } from "src/types";
+
+export function ReceiveToOnchain() {
+  const { data: onchainAddress, getNewAddress } = useOnchainAddress();
+  const { data: mempoolAddressUtxos } = useMempoolApi<MempoolUtxo[]>(
+    onchainAddress ? `/address/${onchainAddress}/utxo` : undefined,
+    3000
+  );
+
+  const [txId, setTxId] = useState("");
+  const [confirmedAmount, setConfirmedAmount] = useState<number | null>(null);
+  const [pendingAmount, setPendingAmount] = useState<number | null>(null);
+  const startTimeRef = useRef(0);
+
+  useEffect(() => {
+    if (startTimeRef.current === 0) {
+      startTimeRef.current = Math.floor(Date.now() / 1000);
+    }
+  }, []);
+
+  const receiveAnother = async () => {
+    setTxId("");
+    setConfirmedAmount(null);
+    setPendingAmount(null);
+    startTimeRef.current = Math.floor(Date.now() / 1000);
+    await getNewAddress();
+  };
+
+  useEffect(() => {
+    if (
+      !mempoolAddressUtxos ||
+      mempoolAddressUtxos.length === 0 ||
+      startTimeRef.current === 0
+    ) {
+      return;
+    }
+
+    if (txId) {
+      const utxo = mempoolAddressUtxos.find((utxo) => utxo.txid === txId);
+      if (utxo?.status.confirmed) {
+        setConfirmedAmount(utxo.value);
+        setPendingAmount(null);
+      }
+    } else {
+      const unconfirmed = mempoolAddressUtxos.find(
+        (utxo) => !utxo.status.confirmed
+      );
+      if (unconfirmed) {
+        setTxId(unconfirmed.txid);
+        setPendingAmount(unconfirmed.value);
+        return;
+      }
+
+      const confirmed = mempoolAddressUtxos.find(
+        (utxo) =>
+          utxo.status.confirmed &&
+          !!utxo.status.block_time &&
+          utxo.status.block_time >= startTimeRef.current
+      );
+      if (confirmed) {
+        setTxId(confirmed.txid);
+        setConfirmedAmount(confirmed.value);
+        setPendingAmount(null);
+      }
+    }
+  }, [mempoolAddressUtxos, txId]);
+
+  if (!onchainAddress) {
+    return <Loading />;
+  }
+
+  return (
+    <>
+      {confirmedAmount ? (
+        <DepositSuccess
+          amount={confirmedAmount}
+          txId={txId}
+          onReceiveAnother={receiveAnother}
+        />
+      ) : txId ? (
+        <DepositPending amount={pendingAmount} txId={txId} />
+      ) : (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-6">
+            <a
+              href={`bitcoin:${onchainAddress}`}
+              target="_blank"
+              className="flex justify-center"
+            >
+              <QRCode value={onchainAddress} />
+            </a>
+            <div className="flex flex-wrap max-w-64 gap-2 items-center justify-center">
+              <OnchainAddressDisplay address={onchainAddress} />
+            </div>
+          </CardContent>
+          <CardFooter className="flex flex-col gap-2 pt-2">
+            <Button
+              className="w-full"
+              onClick={() => {
+                copyToClipboard(onchainAddress);
+              }}
+              variant="secondary"
+            >
+              <CopyIcon className="w-4 h-4" />
+              Copy Address
+            </Button>
+            <Button
+              className="w-full"
+              variant="outline"
+              onClick={getNewAddress}
+            >
+              <RefreshCwIcon className="h-4 w-4" />
+              New Address
+            </Button>
+            <Separator className="my-4" />
+            <FixedFloatButton
+              to="BTC"
+              address={onchainAddress}
+              className="w-full"
+              variant="secondary"
+            >
+              <ExternalLinkIcon className="size-4" />
+              Top up using other Cryptocurrency
+            </FixedFloatButton>
+          </CardFooter>
+        </Card>
+      )}
+    </>
+  );
+}
+
+function DepositPending({
+  amount,
+  txId,
+}: {
+  amount: number | null;
+  txId: string;
+}) {
+  const { data: info } = useInfo();
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle className="flex items-center justify-center gap-2">
+          <Loading className="w-4 h-4" />
+          Waiting for On-chain Confirmation...
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center gap-4">
+        <LottieLoading size={288} />
+        {amount && (
+          <div className="flex flex-col gap-1 items-center">
+            <p className="text-2xl font-medium slashed-zero">
+              <FormattedBitcoinAmount amount={amount * 1000} />
+            </p>
+            <FormattedFiatAmount amount={amount} className="text-xl" />
+          </div>
+        )}
+      </CardContent>
+      <CardFooter className="flex flex-col gap-2 pt-2">
+        <ExternalLinkButton
+          to={`${info?.mempoolUrl}/tx/${txId}`}
+          variant="outline"
+          className="w-full"
+        >
+          <ExternalLinkIcon className="w-4 h-4 mr-2" />
+          View on Mempool
+        </ExternalLinkButton>
+      </CardFooter>
+    </Card>
+  );
+}
+
+function DepositSuccess({
+  amount,
+  txId,
+  onReceiveAnother,
+}: {
+  amount: number;
+  txId: string;
+  onReceiveAnother: () => void;
+}) {
+  const { data: info } = useInfo();
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle className="text-center">Transaction Received!</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center gap-6">
+        <img src={TickSVG} className="w-48" />
+        <div className="flex flex-col gap-1 items-center">
+          <p className="text-2xl font-medium slashed-zero">
+            <FormattedBitcoinAmount amount={amount * 1000} />
+          </p>
+          <FormattedFiatAmount amount={amount} className="text-xl" />
+        </div>
+      </CardContent>
+      <CardFooter className="flex flex-col gap-2 pt-2">
+        <ExternalLinkButton
+          to={`${info?.mempoolUrl}/tx/${txId}`}
+          variant="outline"
+          className="w-full"
+        >
+          <ExternalLinkIcon className="w-4 h-4 mr-2" />
+          View on Mempool
+        </ExternalLinkButton>
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full"
+          onClick={onReceiveAnother}
+        >
+          <HandCoinsIcon className="w-4 h-4 mr-2" />
+          Receive Another Payment
+        </Button>
+        <LinkButton to="/wallet" variant="link" className="w-full">
+          <ArrowLeftIcon className="w-4 h-4 mr-2" />
+          Back to Wallet
+        </LinkButton>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/frontend/src/components/ReceiveToSpending.tsx
+++ b/frontend/src/components/ReceiveToSpending.tsx
@@ -1,0 +1,60 @@
+import { CopyIcon, LinkIcon, ReceiptTextIcon, ZapIcon } from "lucide-react";
+import Loading from "src/components/Loading";
+import QRCode from "src/components/QRCode";
+import { Button } from "src/components/ui/button";
+import { Card, CardContent, CardFooter } from "src/components/ui/card";
+import { LinkButton } from "src/components/ui/custom/link-button";
+import { Separator } from "src/components/ui/separator";
+import { useAlbyMe } from "src/hooks/useAlbyMe";
+import { useInfo } from "src/hooks/useInfo";
+import { copyToClipboard } from "src/lib/clipboard";
+
+export function ReceiveToSpending() {
+  const { data: info } = useInfo();
+  const { data: me } = useAlbyMe();
+
+  if (!info || !me) {
+    return <Loading />;
+  }
+
+  return (
+    <Card>
+      <CardContent className="flex flex-col items-center gap-6">
+        <QRCode value={me.lightning_address} className="w-full h-auto" />
+        <p className="text-center font-medium text-lg break-all">
+          {me.lightning_address}
+        </p>
+      </CardContent>
+      <CardFooter className="flex flex-col gap-2 pt-2">
+        <Button
+          variant="secondary"
+          onClick={() => {
+            copyToClipboard(me.lightning_address);
+          }}
+          className="w-full"
+        >
+          <CopyIcon className="size-4" /> Copy Lightning Address
+        </Button>
+        <Separator className="my-4" />
+        <LinkButton to="invoice" variant="outline" className="w-full">
+          <ZapIcon className="w-4 h-4 mr-2" />
+          Create Invoice
+        </LinkButton>
+        {info.backendType === "LDK" && (
+          <LinkButton
+            to="/wallet/receive/offer"
+            variant="outline"
+            className="w-full"
+          >
+            <ReceiptTextIcon className="h-4 w-4 mr-2" />
+            Lightning Offer
+          </LinkButton>
+        )}
+        <LinkButton to="onchain" variant="outline" className="w-full">
+          <LinkIcon className="w-4 h-4 mr-2" />
+          Receive from On-chain / Other Cryptocurrency
+        </LinkButton>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/frontend/src/screens/wallet/Onchain.tsx
+++ b/frontend/src/screens/wallet/Onchain.tsx
@@ -40,7 +40,7 @@ export default function Onchain() {
           </div>
         </div>
         <div className="grid w-full max-w-100 grid-cols-2 items-center gap-3">
-          <LinkButton to="/wallet/receive/onchain?type=onchain" size="lg">
+          <LinkButton to="/wallet/receive?type=onchain" size="lg">
             <ArrowDownIcon />
             Receive
           </LinkButton>

--- a/frontend/src/screens/wallet/Receive.tsx
+++ b/frontend/src/screens/wallet/Receive.tsx
@@ -1,21 +1,25 @@
-import { CopyIcon, LinkIcon, ReceiptTextIcon, ZapIcon } from "lucide-react";
-import React from "react";
+import { LinkIcon, ZapIcon } from "lucide-react";
+import React, { useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
 import Loading from "src/components/Loading";
-import QRCode from "src/components/QRCode";
-import { Button } from "src/components/ui/button";
-import { Card, CardContent } from "src/components/ui/card";
-import { LinkButton } from "src/components/ui/custom/link-button";
+import { ReceiveToOnchain } from "src/components/ReceiveToOnchain";
+import { ReceiveToSpending } from "src/components/ReceiveToSpending";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "src/components/ui/tabs";
 import { useAlbyMe } from "src/hooks/useAlbyMe";
 import { useInfo } from "src/hooks/useInfo";
-import { copyToClipboard } from "src/lib/clipboard";
 
 export default function Receive() {
   const { data: info } = useInfo();
   const { data: me, error: meError } = useAlbyMe();
   const navigate = useNavigate();
+  const [tab, setTab] = useState("spending");
 
   // TODO: remove this once we have a CTA to connect an Alby Account to use a lightning address
   React.useEffect(() => {
@@ -37,45 +41,36 @@ export default function Receive() {
       <AppHeader pageTitle="Receive" title="Receive" />
       <div className="w-full max-w-lg">
         {info?.albyAccountConnected && me?.lightning_address && (
-          <Card>
-            <CardContent className="flex flex-col items-center gap-6 pt-6">
-              <QRCode value={me.lightning_address} className="w-full h-auto" />
-              <p className="text-center font-medium text-lg break-all my-1">
-                {me.lightning_address}
-              </p>
-              <div className="flex gap-4 w-full">
-                <Button
-                  variant="secondary"
-                  onClick={() => {
-                    copyToClipboard(me.lightning_address);
-                  }}
-                  className="flex-1 flex gap-2 items-center justify-center"
-                >
-                  <CopyIcon className="size-4" /> Copy Lightning Address
-                </Button>
-              </div>
-              <div className="flex flex-col gap-2 w-full border-t pt-6">
-                <LinkButton to="invoice" variant="outline" className="flex-1">
-                  <ZapIcon className="w-4 h-4 mr-2" />
-                  Create Invoice
-                </LinkButton>
-                {info.backendType === "LDK" && (
-                  <LinkButton
-                    to="/wallet/receive/offer"
-                    variant="outline"
-                    className="flex-1"
-                  >
-                    <ReceiptTextIcon className="h-4 w-4 mr-2" />
-                    Lightning Offer
-                  </LinkButton>
-                )}
-                <LinkButton to="onchain" variant="outline" className="flex-1">
-                  <LinkIcon className="w-4 h-4 mr-2" />
-                  Receive from On-chain / Other Cryptocurrency
-                </LinkButton>
-              </div>
-            </CardContent>
-          </Card>
+          <Tabs
+            value={tab}
+            onValueChange={(value) => {
+              setTab(value);
+            }}
+            className="w-full"
+          >
+            <TabsList className="w-full mb-2">
+              <TabsTrigger
+                value="spending"
+                className="flex gap-2 items-center w-full"
+              >
+                <ZapIcon className="size-4" />
+                To Spending Balance
+              </TabsTrigger>
+              <TabsTrigger
+                value="onchain"
+                className="flex gap-2 items-center w-full"
+              >
+                <LinkIcon className="size-4" />
+                To On-chain Balance
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="spending">
+              <ReceiveToSpending />
+            </TabsContent>
+            <TabsContent value="onchain">
+              <ReceiveToOnchain />
+            </TabsContent>
+          </Tabs>
         )}
       </div>
     </div>

--- a/frontend/src/screens/wallet/Receive.tsx
+++ b/frontend/src/screens/wallet/Receive.tsx
@@ -1,6 +1,6 @@
 import { LinkIcon, ZapIcon } from "lucide-react";
-import React, { useState } from "react";
-import { useNavigate } from "react-router";
+import { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
 import Loading from "src/components/Loading";
@@ -19,20 +19,31 @@ export default function Receive() {
   const { data: info } = useInfo();
   const { data: me, error: meError } = useAlbyMe();
   const navigate = useNavigate();
-  const [tab, setTab] = useState("spending");
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const activeTab =
+    searchParams.get("type") === "onchain" ? "onchain" : "spending";
+
+  const isSpendingTab = activeTab === "spending";
+  const isLightningAddressLoading =
+    isSpendingTab && info?.albyAccountConnected && !me && !meError;
 
   // TODO: remove this once we have a CTA to connect an Alby Account to use a lightning address
-  React.useEffect(() => {
-    if (info && (!info.albyAccountConnected || meError)) {
-      if (meError) {
-        toast.error("Failed to load lightning address");
-      }
-
+  useEffect(() => {
+    if (!isSpendingTab || !info || isLightningAddressLoading) {
+      return;
+    }
+    if (!info.albyAccountConnected) {
+      navigate("/wallet/receive/invoice", { replace: true });
+      return;
+    }
+    if (meError) {
+      toast.error("Failed to load lightning address");
       navigate("/wallet/receive/invoice", { replace: true });
     }
-  }, [info, meError, navigate]);
+  }, [info, isLightningAddressLoading, isSpendingTab, meError, navigate]);
 
-  if (!info || (info.albyAccountConnected && !me)) {
+  if (!info || isLightningAddressLoading) {
     return <Loading />;
   }
 
@@ -40,38 +51,38 @@ export default function Receive() {
     <div className="grid gap-5">
       <AppHeader pageTitle="Receive" title="Receive" />
       <div className="w-full max-w-lg">
-        {info?.albyAccountConnected && me?.lightning_address && (
-          <Tabs
-            value={tab}
-            onValueChange={(value) => {
-              setTab(value);
-            }}
-            className="w-full"
-          >
-            <TabsList className="w-full mb-2">
-              <TabsTrigger
-                value="spending"
-                className="flex gap-2 items-center w-full"
-              >
-                <ZapIcon className="size-4" />
-                To Spending Balance
-              </TabsTrigger>
-              <TabsTrigger
-                value="onchain"
-                className="flex gap-2 items-center w-full"
-              >
-                <LinkIcon className="size-4" />
-                To On-chain Balance
-              </TabsTrigger>
-            </TabsList>
-            <TabsContent value="spending">
-              <ReceiveToSpending />
-            </TabsContent>
-            <TabsContent value="onchain">
-              <ReceiveToOnchain />
-            </TabsContent>
-          </Tabs>
-        )}
+        <Tabs
+          value={activeTab}
+          onValueChange={() => {
+            setSearchParams(isSpendingTab ? { type: "onchain" } : {}, {
+              replace: true,
+            });
+          }}
+          className="w-full"
+        >
+          <TabsList className="w-full mb-2">
+            <TabsTrigger
+              value="spending"
+              className="flex gap-2 items-center w-full"
+            >
+              <ZapIcon className="size-4" />
+              To Spending Balance
+            </TabsTrigger>
+            <TabsTrigger
+              value="onchain"
+              className="flex gap-2 items-center w-full"
+            >
+              <LinkIcon className="size-4" />
+              To On-chain Balance
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="spending">
+            <ReceiveToSpending />
+          </TabsContent>
+          <TabsContent value="onchain">
+            <ReceiveToOnchain />
+          </TabsContent>
+        </Tabs>
       </div>
     </div>
   );

--- a/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
@@ -1,362 +1,26 @@
-import {
-  ArrowLeftIcon,
-  CopyIcon,
-  ExternalLinkIcon,
-  HandCoinsIcon,
-  LinkIcon,
-  RefreshCwIcon,
-  ZapIcon,
-} from "lucide-react";
-import TickSVG from "public/images/illustrations/tick.svg";
-import { useEffect, useRef, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
-import { FixedFloatButton } from "src/components/FixedFloatButton";
 import { FixedFloatSwapInFlow } from "src/components/FixedFloatSwapInFlow";
 import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
 import Loading from "src/components/Loading";
-import LottieLoading from "src/components/LottieLoading";
 import LowReceivingCapacityAlert from "src/components/LowReceivingCapacityAlert";
 import { MempoolAlert } from "src/components/MempoolAlert";
-import OnchainAddressDisplay from "src/components/OnchainAddressDisplay";
-import QRCode from "src/components/QRCode";
-import { Button } from "src/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "src/components/ui/card";
-import { ExternalLinkButton } from "src/components/ui/custom/external-link-button";
 import { InputWithAdornment } from "src/components/ui/custom/input-with-adornment";
-import { LinkButton } from "src/components/ui/custom/link-button";
 import { LoadingButton } from "src/components/ui/custom/loading-button";
 import { Label } from "src/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "src/components/ui/radio-group";
-import { Separator } from "src/components/ui/separator";
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "src/components/ui/tabs";
 import { useBalances } from "src/hooks/useBalances";
 import { useInfo } from "src/hooks/useInfo";
 import { useMempoolApi } from "src/hooks/useMempoolApi";
-import { useOnchainAddress } from "src/hooks/useOnchainAddress";
 import { useSwapInfo } from "src/hooks/useSwaps";
-import { copyToClipboard } from "src/lib/clipboard";
-import {
-  CreateInvoiceRequest,
-  MempoolUtxo,
-  SwapResponse,
-  Transaction,
-} from "src/types";
+import { CreateInvoiceRequest, SwapResponse, Transaction } from "src/types";
 import { openLink } from "src/utils/openLink";
 import { request } from "src/utils/request";
 
-type ReceiveOnchainTab = "spending" | "onchain";
-
-function tabFromSearchParam(value: string | null): ReceiveOnchainTab | null {
-  if (value === "spending" || value === "onchain") {
-    return value;
-  }
-  return null;
-}
-
 export default function ReceiveOnchain() {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const [tab, setTab] = useState<ReceiveOnchainTab>(() => {
-    return tabFromSearchParam(searchParams.get("type")) ?? "spending";
-  });
-
-  useEffect(() => {
-    const fromParam = tabFromSearchParam(searchParams.get("type"));
-    if (fromParam) {
-      setTab(fromParam);
-      setSearchParams({}, { replace: true });
-    }
-  }, [searchParams, setSearchParams]);
-
-  return (
-    <div className="grid gap-5">
-      <AppHeader
-        pageTitle="Receive from On-chain"
-        title="Receive from On-chain"
-      />
-      <div className="w-full max-w-lg grid gap-5">
-        <MempoolAlert />
-        <Tabs
-          value={tab}
-          onValueChange={(value) => {
-            const next = tabFromSearchParam(value);
-            if (next) {
-              setTab(next);
-            }
-          }}
-          className="w-full"
-        >
-          <TabsList className="w-full mb-2">
-            <TabsTrigger
-              value="spending"
-              className="flex gap-2 items-center w-full"
-            >
-              <ZapIcon className="size-4" />
-              To Spending Balance
-            </TabsTrigger>
-            <TabsTrigger
-              value="onchain"
-              className="flex gap-2 items-center w-full"
-            >
-              <LinkIcon className="size-4" />
-              To On-chain Balance
-            </TabsTrigger>
-          </TabsList>
-          <TabsContent value="spending">
-            <ReceiveToSpending />
-          </TabsContent>
-          <TabsContent value="onchain">
-            <ReceiveToOnchain />
-          </TabsContent>
-        </Tabs>
-      </div>
-    </div>
-  );
-}
-
-function ReceiveToOnchain() {
-  const { data: onchainAddress, getNewAddress } = useOnchainAddress();
-  const { data: mempoolAddressUtxos } = useMempoolApi<MempoolUtxo[]>(
-    onchainAddress ? `/address/${onchainAddress}/utxo` : undefined,
-    3000
-  );
-
-  const [txId, setTxId] = useState("");
-  const [confirmedAmount, setConfirmedAmount] = useState<number | null>(null);
-  const [pendingAmount, setPendingAmount] = useState<number | null>(null);
-  const startTimeRef = useRef(0);
-
-  useEffect(() => {
-    if (startTimeRef.current === 0) {
-      startTimeRef.current = Math.floor(Date.now() / 1000);
-    }
-  }, []);
-
-  const receiveAnother = async () => {
-    setTxId("");
-    setConfirmedAmount(null);
-    setPendingAmount(null);
-    startTimeRef.current = Math.floor(Date.now() / 1000);
-    await getNewAddress();
-  };
-
-  useEffect(() => {
-    if (
-      !mempoolAddressUtxos ||
-      mempoolAddressUtxos.length === 0 ||
-      startTimeRef.current === 0
-    ) {
-      return;
-    }
-
-    if (txId) {
-      const utxo = mempoolAddressUtxos.find((utxo) => utxo.txid === txId);
-      if (utxo?.status.confirmed) {
-        setConfirmedAmount(utxo.value);
-        setPendingAmount(null);
-      }
-    } else {
-      const unconfirmed = mempoolAddressUtxos.find(
-        (utxo) => !utxo.status.confirmed
-      );
-      if (unconfirmed) {
-        setTxId(unconfirmed.txid);
-        setPendingAmount(unconfirmed.value);
-        return;
-      }
-
-      const confirmed = mempoolAddressUtxos.find(
-        (utxo) =>
-          utxo.status.confirmed &&
-          !!utxo.status.block_time &&
-          utxo.status.block_time >= startTimeRef.current
-      );
-      if (confirmed) {
-        setTxId(confirmed.txid);
-        setConfirmedAmount(confirmed.value);
-        setPendingAmount(null);
-      }
-    }
-  }, [mempoolAddressUtxos, txId]);
-
-  if (!onchainAddress) {
-    return <Loading />;
-  }
-
-  return (
-    <>
-      {confirmedAmount ? (
-        <DepositSuccess
-          amount={confirmedAmount}
-          txId={txId}
-          onReceiveAnother={receiveAnother}
-        />
-      ) : txId ? (
-        <DepositPending amount={pendingAmount} txId={txId} />
-      ) : (
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center justify-center gap-2">
-              <Loading className="w-4 h-4" />
-              Waiting for Payment...
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="flex flex-col items-center gap-6">
-            <a
-              href={`bitcoin:${onchainAddress}`}
-              target="_blank"
-              className="flex justify-center"
-            >
-              <QRCode value={onchainAddress} />
-            </a>
-            <div className="flex flex-wrap max-w-64 gap-2 items-center justify-center">
-              <OnchainAddressDisplay address={onchainAddress} />
-            </div>
-          </CardContent>
-          <CardFooter className="flex flex-col gap-2 pt-2">
-            <Button
-              className="w-full"
-              onClick={() => {
-                copyToClipboard(onchainAddress);
-              }}
-              variant="secondary"
-            >
-              <CopyIcon className="w-4 h-4" />
-              Copy Address
-            </Button>
-            <Button
-              className="w-full"
-              variant="outline"
-              onClick={getNewAddress}
-            >
-              <RefreshCwIcon className="h-4 w-4" />
-              New Address
-            </Button>
-            <Separator className="my-2" />
-            <FixedFloatButton
-              to="BTC"
-              address={onchainAddress}
-              className="w-full"
-              variant="secondary"
-            >
-              <ExternalLinkIcon className="size-4" />
-              Top up using other Cryptocurrency
-            </FixedFloatButton>
-          </CardFooter>
-        </Card>
-      )}
-    </>
-  );
-}
-
-function DepositPending({
-  amount,
-  txId,
-}: {
-  amount: number | null;
-  txId: string;
-}) {
-  const { data: info } = useInfo();
-
-  return (
-    <Card className="w-full">
-      <CardHeader>
-        <CardTitle className="flex items-center justify-center gap-2">
-          <Loading className="w-4 h-4" />
-          Waiting for On-chain Confirmation...
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="flex flex-col items-center gap-4">
-        <LottieLoading size={288} />
-        {amount && (
-          <div className="flex flex-col gap-1 items-center">
-            <p className="text-2xl font-medium slashed-zero">
-              <FormattedBitcoinAmount amount={amount * 1000} />
-            </p>
-            <FormattedFiatAmount amount={amount} className="text-xl" />
-          </div>
-        )}
-      </CardContent>
-      <CardFooter className="flex flex-col gap-2 pt-2">
-        <ExternalLinkButton
-          to={`${info?.mempoolUrl}/tx/${txId}`}
-          variant="outline"
-          className="w-full"
-        >
-          <ExternalLinkIcon className="w-4 h-4 mr-2" />
-          View on Mempool
-        </ExternalLinkButton>
-      </CardFooter>
-    </Card>
-  );
-}
-
-function DepositSuccess({
-  amount,
-  txId,
-  onReceiveAnother,
-}: {
-  amount: number;
-  txId: string;
-  onReceiveAnother: () => void;
-}) {
-  const { data: info } = useInfo();
-
-  return (
-    <Card className="w-full">
-      <CardHeader>
-        <CardTitle className="text-center">Transaction Received!</CardTitle>
-      </CardHeader>
-      <CardContent className="flex flex-col items-center gap-6">
-        <img src={TickSVG} className="w-48" />
-        <div className="flex flex-col gap-1 items-center">
-          <p className="text-2xl font-medium slashed-zero">
-            <FormattedBitcoinAmount amount={amount * 1000} />
-          </p>
-          <FormattedFiatAmount amount={amount} className="text-xl" />
-        </div>
-      </CardContent>
-      <CardFooter className="flex flex-col gap-2 pt-2">
-        <ExternalLinkButton
-          to={`${info?.mempoolUrl}/tx/${txId}`}
-          variant="outline"
-          className="w-full"
-        >
-          <ExternalLinkIcon className="w-4 h-4 mr-2" />
-          View on Mempool
-        </ExternalLinkButton>
-        <Button
-          type="button"
-          variant="outline"
-          className="w-full"
-          onClick={onReceiveAnother}
-        >
-          <HandCoinsIcon className="w-4 h-4 mr-2" />
-          Receive Another Payment
-        </Button>
-        <LinkButton to="/wallet" variant="link" className="w-full">
-          <ArrowLeftIcon className="w-4 h-4 mr-2" />
-          Back to Wallet
-        </LinkButton>
-      </CardFooter>
-    </Card>
-  );
-}
-
-function ReceiveToSpending() {
   const { data: info, hasChannelManagement } = useInfo();
   const { data: balances } = useBalances();
   const { data: swapInfo } = useSwapInfo("in");
@@ -439,104 +103,116 @@ function ReceiveToSpending() {
     swapFrom === "crypto" && cryptoTransaction !== null;
 
   return (
-    <form onSubmit={onSubmit} className="flex flex-col gap-6">
-      {!isCryptoReceiveState && (
-        <>
-          {hasChannelManagement &&
-            parseInt(swapAmount || "0") * 1000 >=
-              0.8 * balances.lightning.totalReceivable && (
-              <LowReceivingCapacityAlert />
-            )}
-          <div className="grid gap-1.5">
-            <Label>Amount</Label>
-            <InputWithAdornment
-              type="number"
-              autoFocus
-              placeholder="Amount in satoshis"
-              value={swapAmount}
-              min={swapFrom === "bitcoin" ? swapInfo.minAmount : undefined}
-              max={
-                swapFrom === "bitcoin"
-                  ? Math.min(
-                      swapInfo.maxAmount,
-                      (balances.lightning.totalReceivable / 1000) * 0.99
-                    )
-                  : (balances.lightning.totalReceivable / 1000) * 0.99
-              }
-              onChange={(e) => setSwapAmount(e.target.value)}
-              required
-              endAdornment={
-                <FormattedFiatAmount amount={+swapAmount} className="mr-2" />
-              }
-            />
-            <div className="grid">
-              <div className="flex justify-between text-muted-foreground text-xs sensitive slashed-zero">
-                <div>
-                  Receiving Capacity:{" "}
-                  <FormattedBitcoinAmount
-                    amount={balances.lightning.totalReceivable}
-                  />
+    <div className="grid gap-5">
+      <AppHeader
+        pageTitle="Receive from On-chain"
+        title="Receive from On-chain"
+      />
+      <div className="w-full max-w-lg grid gap-6">
+        <MempoolAlert />
+        <form onSubmit={onSubmit} className="flex flex-col gap-6">
+          {!isCryptoReceiveState && (
+            <>
+              {hasChannelManagement &&
+                parseInt(swapAmount || "0") * 1000 >=
+                  0.8 * balances.lightning.totalReceivable && (
+                  <LowReceivingCapacityAlert />
+                )}
+              <div className="grid gap-1.5">
+                <Label>Amount</Label>
+                <InputWithAdornment
+                  type="number"
+                  autoFocus
+                  placeholder="Amount in satoshis"
+                  value={swapAmount}
+                  min={swapFrom === "bitcoin" ? swapInfo.minAmount : undefined}
+                  max={
+                    swapFrom === "bitcoin"
+                      ? Math.min(
+                          swapInfo.maxAmount,
+                          (balances.lightning.totalReceivable / 1000) * 0.99
+                        )
+                      : (balances.lightning.totalReceivable / 1000) * 0.99
+                  }
+                  onChange={(e) => setSwapAmount(e.target.value)}
+                  required
+                  endAdornment={
+                    <FormattedFiatAmount
+                      amount={+swapAmount}
+                      className="mr-2"
+                    />
+                  }
+                />
+                <div className="grid">
+                  <div className="flex justify-between text-muted-foreground text-xs sensitive slashed-zero">
+                    <div>
+                      Receiving Capacity:{" "}
+                      <FormattedBitcoinAmount
+                        amount={balances.lightning.totalReceivable}
+                      />
+                    </div>
+                    <FormattedFiatAmount
+                      className="text-xs"
+                      amount={balances.lightning.totalReceivable / 1000}
+                    />
+                  </div>
                 </div>
-                <FormattedFiatAmount
-                  className="text-xs"
-                  amount={balances.lightning.totalReceivable / 1000}
-                />
               </div>
-            </div>
-          </div>
-          <div className="flex flex-col gap-4">
-            <Label>Swap from</Label>
-            <RadioGroup
-              defaultValue="bitcoin"
-              value={swapFrom}
-              onValueChange={(value) => {
-                setSwapFrom(value as "bitcoin" | "crypto");
-              }}
-              className="flex gap-4 flex-row"
-            >
-              <div className="flex items-start space-x-2 mb-2">
-                <RadioGroupItem
-                  value="bitcoin"
-                  id="bitcoin"
-                  className="shrink-0"
-                />
-                <Label htmlFor="bitcoin" className="cursor-pointer">
-                  Bitcoin
-                </Label>
+              <div className="flex flex-col gap-4">
+                <Label>Swap from</Label>
+                <RadioGroup
+                  defaultValue="bitcoin"
+                  value={swapFrom}
+                  onValueChange={(value) => {
+                    setSwapFrom(value as "bitcoin" | "crypto");
+                  }}
+                  className="flex gap-4 flex-row"
+                >
+                  <div className="flex items-start space-x-2 mb-2">
+                    <RadioGroupItem
+                      value="bitcoin"
+                      id="bitcoin"
+                      className="shrink-0"
+                    />
+                    <Label htmlFor="bitcoin" className="cursor-pointer">
+                      Bitcoin
+                    </Label>
+                  </div>
+                  <div className="flex items-start space-x-2">
+                    <RadioGroupItem
+                      value="crypto"
+                      id="crypto"
+                      className="shrink-0"
+                    />
+                    <Label htmlFor="crypto" className="cursor-pointer">
+                      Other Cryptocurrency
+                    </Label>
+                  </div>
+                </RadioGroup>
               </div>
-              <div className="flex items-start space-x-2">
-                <RadioGroupItem
-                  value="crypto"
-                  id="crypto"
-                  className="shrink-0"
-                />
-                <Label htmlFor="crypto" className="cursor-pointer">
-                  Other Cryptocurrency
-                </Label>
-              </div>
-            </RadioGroup>
-          </div>
-        </>
-      )}
+            </>
+          )}
 
-      {swapFrom === "bitcoin" ? (
-        <BitcoinSwapFlow
-          feeRate={feeRate}
-          loading={loading}
-          swapFee={swapInfo.albyServiceFee + swapInfo.boltzServiceFee}
-        />
-      ) : (
-        <FixedFloatSwapInFlow
-          loading={loading}
-          transaction={cryptoTransaction}
-          resetLabel="Receive Another Payment"
-          onReset={() => {
-            setCryptoTransaction(null);
-            setSwapAmount("");
-          }}
-        />
-      )}
-    </form>
+          {swapFrom === "bitcoin" ? (
+            <BitcoinSwapFlow
+              feeRate={feeRate}
+              loading={loading}
+              swapFee={swapInfo.albyServiceFee + swapInfo.boltzServiceFee}
+            />
+          ) : (
+            <FixedFloatSwapInFlow
+              loading={loading}
+              transaction={cryptoTransaction}
+              resetLabel="Receive Another Payment"
+              onReset={() => {
+                setCryptoTransaction(null);
+                setSwapAmount("");
+              }}
+            />
+          )}
+        </form>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
This brings the on-chain receive from on-chain/other crypto screen to the main Receive screen so that we can navigate easily with the new on-chain mode
<table>
<tr>
<td><img src="https://github.com/user-attachments/assets/34a927bf-99a1-42e1-bebf-9f6a87bbb569"/></td>
<td><img src="https://github.com/user-attachments/assets/38cdf343-e79e-4485-bbb2-763a9db44a43"/></td>
</tr>

<tr>
<td><img src="https://github.com/user-attachments/assets/179d7ab5-1a15-423f-a244-907077a35c24"/></td>
</tr>
</table>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added on-chain Bitcoin receiving with QR code generation and transaction monitoring.
  * Added lightning address receiving interface with dedicated navigation options.
  * Introduced tabbed receive interface to switch between spending and on-chain receiving flows.

* **Refactor**
  * Reorganized receive flow routes to use query parameters for improved navigation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->