### PR TITLE
refactor(frontend): extract DetailRow for transaction details dialog

### DIFF
--- a/frontend/src/components/OnchainTransactionItem.tsx
+++ b/frontend/src/components/OnchainTransactionItem.tsx
@@ -1,15 +1,10 @@
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import utc from "dayjs/plugin/utc";
-import {
-  ArrowDownIcon,
-  ArrowUpIcon,
-  CopyIcon,
-  ExternalLinkIcon,
-} from "lucide-react";
+import { ArrowDownIcon, ArrowUpIcon, ExternalLinkIcon } from "lucide-react";
 import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
-import { Button } from "src/components/ui/button";
+import { TransactionDetailRow } from "src/components/TransactionDetailRow";
 import { ExternalLinkButton } from "src/components/ui/custom/external-link-button";
 import {
   Dialog,
@@ -19,7 +14,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "src/components/ui/dialog";
-import { copyToClipboard } from "src/lib/clipboard";
 import { cn } from "src/lib/utils";
 import { OnchainTransaction } from "src/types";
 
@@ -141,39 +135,18 @@ function OnchainTransactionItem({
             </div>
           </div>
 
-          <div>
-            <p>Status</p>
-            <p className="text-muted-foreground">{statusText}</p>
-          </div>
-
-          <div>
-            <p>Confirmations</p>
-            <p className="text-muted-foreground">{tx.numConfirmations}</p>
-          </div>
-
-          <div>
-            <p>Date & Time</p>
-            <p className="text-muted-foreground">
-              {createdAt.format("D MMMM YYYY, HH:mm")}
-            </p>
-          </div>
-
-          <div>
-            <p>Transaction ID</p>
-            <div className="flex items-center gap-4">
-              <p className="text-muted-foreground break-all">{tx.txId}</p>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                className="text-muted-foreground"
-                onClick={() => copyToClipboard(tx.txId)}
-                aria-label="Copy transaction ID"
-              >
-                <CopyIcon />
-              </Button>
-            </div>
-          </div>
+          <TransactionDetailRow label="Status">
+            {statusText}
+          </TransactionDetailRow>
+          <TransactionDetailRow label="Confirmations">
+            {tx.numConfirmations}
+          </TransactionDetailRow>
+          <TransactionDetailRow label="Date & Time">
+            {createdAt.format("D MMMM YYYY, HH:mm")}
+          </TransactionDetailRow>
+          <TransactionDetailRow label="Transaction ID" copyable={tx.txId}>
+            {tx.txId}
+          </TransactionDetailRow>
         </div>
         <DialogFooter>
           <ExternalLinkButton to={`${mempoolUrl}/tx/${tx.txId}`}>

--- a/frontend/src/components/TransactionDetailRow.tsx
+++ b/frontend/src/components/TransactionDetailRow.tsx
@@ -1,0 +1,37 @@
+import { CopyIcon } from "lucide-react";
+import { Button } from "src/components/ui/button";
+import { copyToClipboard } from "src/lib/clipboard";
+
+type TransactionDetailRowProps = {
+  label: React.ReactNode;
+  children: React.ReactNode;
+  // when set, the value is shown next to a copy button that copies this string
+  copyable?: string;
+};
+
+export function TransactionDetailRow({
+  label,
+  children,
+  copyable,
+}: TransactionDetailRowProps) {
+  return (
+    <div>
+      <p>{label}</p>
+      <div className="flex items-center justify-between gap-4">
+        {/* break-all lives on the wrapper so embedded JSX (links, spans) wraps too */}
+        <div className="text-muted-foreground break-all">{children}</div>
+        {copyable !== undefined && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="text-muted-foreground"
+            onClick={() => copyToClipboard(copyable)}
+          >
+            <CopyIcon />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -8,7 +8,6 @@ import {
   ArrowUpIcon,
   ChevronDownIcon,
   ChevronUpIcon,
-  CopyIcon,
   TagIcon,
   XIcon,
 } from "lucide-react";
@@ -21,19 +20,17 @@ import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
 import { PaymentFailedAlert } from "src/components/PaymentFailedAlert";
 import PodcastingInfo from "src/components/PodcastingInfo";
+import { TransactionDetailRow } from "src/components/TransactionDetailRow";
 import TransactionLabels from "src/components/TransactionLabels";
-import { Button } from "src/components/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from "src/components/ui/dialog";
 import { useApp } from "src/hooks/useApp";
 import { useSwap } from "src/hooks/useSwaps";
-import { copyToClipboard } from "src/lib/clipboard";
 import { cn, getAppDisplayName } from "src/lib/utils";
 import { Transaction } from "src/types";
 
@@ -127,10 +124,6 @@ function TransactionItem({ tx, transactionListKey }: Props) {
         : swapId
           ? ArrowDownUpIcon
           : ArrowDownIcon;
-
-  const copy = (text: string) => {
-    copyToClipboard(text);
-  };
 
   const typeStateIcon = (
     <div className="flex items-center">
@@ -239,274 +232,157 @@ function TransactionItem({ tx, transactionListKey }: Props) {
           <DialogTitle
             className={cn(tx.state === "pending" && "animate-pulse")}
           >{`${typeStateText} Bitcoin Payment`}</DialogTitle>
-          <DialogDescription className="text-start text-foreground">
-            <div
-              className={cn(
-                "flex items-center mt-6",
-                tx.state === "pending" && "animate-pulse"
-              )}
-            >
-              {typeStateIcon}
-              <div className="ml-4">
-                <p className="text-xl md:text-2xl font-semibold sensitive">
-                  {tx.type === "outgoing" ? "-" : "+"}
-                  <FormattedBitcoinAmount amount={tx.amount} />
-                </p>
-                <FormattedFiatAmount amount={Math.floor(tx.amount / 1000)} />
-              </div>
-            </div>
-            {app && (
-              <div className="mt-8">
-                <p>App</p>
-                <Link to={`/apps/${app.id}`}>
-                  <p className="font-semibold">{getAppDisplayName(app.name)}</p>
-                </Link>
-              </div>
+        </DialogHeader>
+        <div className="space-y-6 text-sm mt-2">
+          <div
+            className={cn(
+              "flex items-center",
+              tx.state === "pending" && "animate-pulse"
             )}
-            {swapId && (
-              <div className="mt-8">
-                <p>Swap Id</p>
-                <Link
-                  to={`/wallet/swap/${type === "incoming" ? "in" : "out"}/status/${swapId}`}
-                  className="flex items-center gap-1"
-                >
-                  <p className="underline">{swapId}</p>
-                </Link>
-              </div>
-            )}
-            {to && (
-              <div className="mt-6">
-                <p>To</p>
-                <p className="text-muted-foreground">{to}</p>
-              </div>
-            )}
-            {payerName && (
-              <div className="mt-6">
-                <p>From</p>
-                <p className="text-muted-foreground">{payerName}</p>
-              </div>
-            )}
-            <div className="mt-6">
-              <p>Date & Time</p>
-              <p className="text-muted-foreground">
-                {updatedAt.format("D MMMM YYYY, HH:mm")}
+          >
+            {typeStateIcon}
+            <div className="ml-4">
+              <p className="text-xl md:text-2xl font-semibold sensitive">
+                {tx.type === "outgoing" ? "-" : "+"}
+                <FormattedBitcoinAmount amount={tx.amount} />
               </p>
+              <FormattedFiatAmount amount={Math.floor(tx.amount / 1000)} />
             </div>
-            {tx.state != "failed" && type == "outgoing" && (
-              <div className="mt-6">
-                <p>Fee</p>
-                <p className="text-muted-foreground">
-                  <FormattedBitcoinAmount amount={tx.feesPaid} />
-                  {tx.feesPaid > 0 && (
-                    <>&nbsp;({((tx.feesPaid / tx.amount) * 100).toFixed(2)}%)</>
-                  )}
+          </div>
+          {app && (
+            <TransactionDetailRow label="App">
+              <Link to={`/apps/${app.id}`}>
+                <p className="font-semibold text-foreground">
+                  {getAppDisplayName(app.name)}
                 </p>
-              </div>
-            )}
-            {tx.description && (
-              <div className="mt-6">
-                <p>Description</p>
-                <p className="text-muted-foreground break-all">
-                  {tx.description}
-                </p>
-              </div>
-            )}
-            {tx.metadata?.comment && (
-              <div className="mt-6">
-                <p>Comment</p>
-                <p className="text-muted-foreground break-all">
-                  {tx.metadata.comment}
-                </p>
-              </div>
-            )}
-            {bolt12Offer?.payer_note && (
-              <div className="mt-6">
-                <p>Payer Note</p>
-                <p className="text-muted-foreground break-all">
-                  {bolt12Offer.payer_note}
-                </p>
-              </div>
-            )}
-            {/* for Alby lightning addresses the content of the zap request is
-            automatically extracted and already displayed above as description */}
-            {tx.metadata?.nostr && nevent && npub && (
-              <div className="mt-6">
-                <p>
-                  <ExternalLink
-                    to={`https://njump.me/${nevent}`}
-                    className="underline"
-                  >
-                    Nostr Zap
-                  </ExternalLink>{" "}
-                  <span className="text-muted-foreground break-all">
-                    from {npub}
-                  </span>
-                </p>
-              </div>
-            )}
-            {tx.state === "failed" && (
-              <div className="mt-6">
-                <PaymentFailedAlert
-                  errorMessage={tx.failureReason}
-                  invoice={tx.invoice}
-                />
-              </div>
-            )}
-            <TransactionLabels
-              id={tx.id}
-              labels={labels}
-              transactionListKey={transactionListKey}
-            />
-            <div className="mt-6 w-full">
-              <div
-                className="flex items-center gap-2 cursor-pointer"
-                onClick={() => setShowDetails(!showDetails)}
+              </Link>
+            </TransactionDetailRow>
+          )}
+          {swapId && (
+            <TransactionDetailRow label="Swap Id">
+              <Link
+                to={`/wallet/swap/${type === "incoming" ? "in" : "out"}/status/${swapId}`}
+                className="flex items-center gap-1"
               >
-                Details
-                {showDetails ? (
-                  <ChevronUpIcon className="size-4" />
-                ) : (
-                  <ChevronDownIcon className="size-4" />
+                <p className="underline">{swapId}</p>
+              </Link>
+            </TransactionDetailRow>
+          )}
+          {to && <TransactionDetailRow label="To">{to}</TransactionDetailRow>}
+          {payerName && (
+            <TransactionDetailRow label="From">
+              {payerName}
+            </TransactionDetailRow>
+          )}
+          <TransactionDetailRow label="Date & Time">
+            {updatedAt.format("D MMMM YYYY, HH:mm")}
+          </TransactionDetailRow>
+          {tx.state != "failed" && type == "outgoing" && (
+            <TransactionDetailRow label="Fee">
+              <FormattedBitcoinAmount amount={tx.feesPaid} />
+              {tx.feesPaid > 0 && (
+                <>&nbsp;({((tx.feesPaid / tx.amount) * 100).toFixed(2)}%)</>
+              )}
+            </TransactionDetailRow>
+          )}
+          {tx.description && (
+            <TransactionDetailRow label="Description">
+              {tx.description}
+            </TransactionDetailRow>
+          )}
+          {tx.metadata?.comment && (
+            <TransactionDetailRow label="Comment">
+              {tx.metadata.comment}
+            </TransactionDetailRow>
+          )}
+          {bolt12Offer?.payer_note && (
+            <TransactionDetailRow label="Payer Note">
+              {bolt12Offer.payer_note}
+            </TransactionDetailRow>
+          )}
+          {/* for Alby lightning addresses the content of the zap request is
+            automatically extracted and already displayed above as description */}
+          {tx.metadata?.nostr && nevent && npub && (
+            <TransactionDetailRow
+              label={
+                <ExternalLink
+                  to={`https://njump.me/${nevent}`}
+                  className="underline"
+                >
+                  Nostr Zap
+                </ExternalLink>
+              }
+            >
+              from {npub}
+            </TransactionDetailRow>
+          )}
+          {tx.state === "failed" && (
+            <div>
+              <PaymentFailedAlert
+                errorMessage={tx.failureReason}
+                invoice={tx.invoice}
+              />
+            </div>
+          )}
+          <TransactionLabels
+            id={tx.id}
+            labels={labels}
+            transactionListKey={transactionListKey}
+          />
+          <div className="w-full">
+            <div
+              className="flex items-center gap-2 cursor-pointer"
+              onClick={() => setShowDetails(!showDetails)}
+            >
+              Details
+              {showDetails ? (
+                <ChevronUpIcon className="size-4" />
+              ) : (
+                <ChevronDownIcon className="size-4" />
+              )}
+            </div>
+            {showDetails && (
+              <div className="flex flex-col gap-6 mt-6">
+                {tx.boostagram && <PodcastingInfo boost={tx.boostagram} />}
+                {bolt12Offer && (
+                  <TransactionDetailRow
+                    label="BOLT-12 Offer Id"
+                    copyable={bolt12Offer.id}
+                  >
+                    {bolt12Offer.id}
+                  </TransactionDetailRow>
+                )}
+                {tx.preimage && (
+                  <TransactionDetailRow label="Preimage" copyable={tx.preimage}>
+                    {tx.preimage}
+                  </TransactionDetailRow>
+                )}
+                <TransactionDetailRow label="Hash" copyable={tx.paymentHash}>
+                  {tx.paymentHash}
+                </TransactionDetailRow>
+                <TransactionDetailRow label="Invoice" copyable={tx.invoice}>
+                  {tx.invoice}
+                </TransactionDetailRow>
+                {!!tx.failureReason && (
+                  <TransactionDetailRow
+                    label="Failure Reason"
+                    copyable={tx.failureReason}
+                  >
+                    {tx.failureReason}
+                  </TransactionDetailRow>
+                )}
+                {tx.metadata && (
+                  <TransactionDetailRow
+                    label="Metadata"
+                    copyable={JSON.stringify(tx.metadata)}
+                  >
+                    {JSON.stringify(tx.metadata)}
+                  </TransactionDetailRow>
                 )}
               </div>
-              {showDetails && (
-                <>
-                  {tx.boostagram && <PodcastingInfo boost={tx.boostagram} />}
-                  {bolt12Offer && (
-                    <div className="mt-6">
-                      <p>BOLT-12 Offer Id</p>
-                      <div className="flex items-center justify-between gap-4">
-                        <p className="text-muted-foreground break-all">
-                          {bolt12Offer.id}
-                        </p>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-sm"
-                          className="text-muted-foreground"
-                          onClick={() => {
-                            copy(bolt12Offer.id as string);
-                          }}
-                          aria-label="Copy BOLT-12 offer id"
-                        >
-                          <CopyIcon />
-                        </Button>
-                      </div>
-                    </div>
-                  )}
-                  {tx.preimage && (
-                    <div className="mt-6">
-                      <p>Preimage</p>
-                      <div className="flex items-center justify-between gap-4">
-                        <p className="text-muted-foreground break-all">
-                          {tx.preimage}
-                        </p>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-sm"
-                          className="text-muted-foreground"
-                          onClick={() => {
-                            if (tx.preimage) {
-                              copy(tx.preimage);
-                            }
-                          }}
-                          aria-label="Copy preimage"
-                        >
-                          <CopyIcon />
-                        </Button>
-                      </div>
-                    </div>
-                  )}
-                  <div className="mt-6">
-                    <p>Hash</p>
-                    <div className="flex items-center justify-between gap-4">
-                      <p className="text-muted-foreground break-all">
-                        {tx.paymentHash}
-                      </p>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-sm"
-                        className="text-muted-foreground"
-                        onClick={() => {
-                          copy(tx.paymentHash);
-                        }}
-                        aria-label="Copy hash"
-                      >
-                        <CopyIcon />
-                      </Button>
-                    </div>
-                  </div>
-                  <div className="mt-6">
-                    <p>Invoice</p>
-                    <div className="flex items-center justify-between gap-4">
-                      <p className="text-muted-foreground break-all">
-                        {tx.invoice}
-                      </p>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-sm"
-                        className="text-muted-foreground"
-                        onClick={() => {
-                          copy(tx.invoice);
-                        }}
-                        aria-label="Copy invoice"
-                      >
-                        <CopyIcon />
-                      </Button>
-                    </div>
-                  </div>
-                  {!!tx.failureReason && (
-                    <div className="mt-6">
-                      <p>Failure Reason</p>
-                      <div className="flex items-center justify-between gap-4">
-                        <p className="text-muted-foreground break-anywhere">
-                          {tx.failureReason}
-                        </p>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-sm"
-                          className="text-muted-foreground"
-                          onClick={() => {
-                            copy(tx.failureReason);
-                          }}
-                          aria-label="Copy failure reason"
-                        >
-                          <CopyIcon />
-                        </Button>
-                      </div>
-                    </div>
-                  )}
-                  {tx.metadata && (
-                    <div className="mt-6">
-                      <p>Metadata</p>
-                      <div className="flex items-center justify-between gap-4">
-                        <p className="text-muted-foreground break-all">
-                          {JSON.stringify(tx.metadata)}
-                        </p>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-sm"
-                          className="text-muted-foreground"
-                          onClick={() => {
-                            copy(JSON.stringify(tx.metadata));
-                          }}
-                          aria-label="Copy metadata"
-                        >
-                          <CopyIcon />
-                        </Button>
-                      </div>
-                    </div>
-                  )}
-                </>
-              )}
-            </div>
-          </DialogDescription>
-        </DialogHeader>
+            )}
+          </div>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/components/TransactionLabels.tsx
+++ b/frontend/src/components/TransactionLabels.tsx
@@ -111,7 +111,7 @@ function TransactionLabels({
   };
 
   return (
-    <div className="mt-6">
+    <div>
       <div className="flex items-center justify-between">
         <p>Labels</p>
         {!isEditing && (


### PR DESCRIPTION
## Summary

Cleans up the transaction details dialog by extracting a single `DetailRow` component to replace ~16 hand-written rows with the same shape. Moves inter-row spacing to the parent (`gap-6`), dropping the duplicated `mt-6` / `mt-8` margins (the `mt-8` rows looked accidental).

`DetailRow` takes a `copyable` prop for rows that should show a copy icon (BOLT-12 Offer Id, Preimage, Hash, Invoice, Failure Reason, Metadata).

No behavioral change.

## Test plan
- [ ] Open a transaction's details and visually compare against master — spacing and copy icons should match
- [ ] Verify each row renders for transactions of different shapes (incoming, outgoing, failed, with metadata, with bolt12 offer)
- [ ] Confirm copy icons still work