### PR TITLE
fix: avoid highlighted border on menu buttons in Alby theme

### DIFF
--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -22,9 +22,9 @@ import ExternalLink from "src/components/ExternalLink";
 import { AlbyIcon } from "src/components/icons/Alby";
 import { AlbyHubIcon } from "src/components/icons/AlbyHubIcon";
 import { AlbyHubLogo } from "src/components/icons/AlbyHubLogo";
-import { Badge } from "src/components/ui/badge";
 import { ProBadge } from "src/components/ProBadge";
 import SidebarHint from "src/components/SidebarHint";
+import { Badge } from "src/components/ui/badge";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -248,24 +248,16 @@ export function AppSidebar() {
                   </>
                 )}
                 {!info?.albyAccountConnected ? (
-                  <DropdownMenuItem asChild>
-                    <Link
-                      to="/alby/account"
-                      className="w-full flex flex-row items-center gap-2"
-                    >
-                      <PlugZapIcon />
-                      Connect Alby Account
-                    </Link>
+                  <DropdownMenuItem onClick={() => navigate("/alby/account")}>
+                    <PlugZapIcon />
+                    Connect Alby Account
                   </DropdownMenuItem>
                 ) : (
-                  <DropdownMenuItem asChild>
-                    <Link
-                      to="/settings/alby-account"
-                      className="w-full flex flex-row items-center gap-2"
-                    >
-                      <AlbyIcon className="size-4" />
-                      Alby Account Settings
-                    </Link>
+                  <DropdownMenuItem
+                    onClick={() => navigate("/settings/alby-account")}
+                  >
+                    <AlbyIcon className="size-4" />
+                    Alby Account Settings
                   </DropdownMenuItem>
                 )}
                 {!albyMe?.subscription.plan_code && (

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -199,15 +199,17 @@ export default function Channels() {
                   <DropdownMenuSeparator />
                   <DropdownMenuGroup>
                     <DropdownMenuLabel>On-Chain</DropdownMenuLabel>
-                    <DropdownMenuItem asChild>
-                      <Link to="onchain/buy-bitcoin" className="w-full">
-                        Buy
-                      </Link>
+                    <DropdownMenuItem
+                      onClick={() => navigate("/channels/onchain/buy-bitcoin")}
+                    >
+                      Buy
                     </DropdownMenuItem>
-                    <DropdownMenuItem asChild>
-                      <Link to="/channels/onchain/deposit-bitcoin">
-                        Deposit
-                      </Link>
+                    <DropdownMenuItem
+                      onClick={() =>
+                        navigate("/channels/onchain/deposit-bitcoin")
+                      }
+                    >
+                      Deposit
                     </DropdownMenuItem>
                     {(balances?.onchain.spendableSat || 0) >
                       ONCHAIN_DUST_SATS && (


### PR DESCRIPTION
## Screenshots

<table><tr>
<td><img src="https://github.com/user-attachments/assets/901799f4-3f57-453c-9aba-94d7c43a4e41" /></td>
<td><img src="https://github.com/user-attachments/assets/aa85dd4a-a8b8-476f-8a09-09526a50e93e" /></td>
</tr></table>
