### PR TITLE
fix: scope Alby theme default-variant styling to buttons only

### DIFF
--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -248,16 +248,24 @@ export function AppSidebar() {
                   </>
                 )}
                 {!info?.albyAccountConnected ? (
-                  <DropdownMenuItem onClick={() => navigate("/alby/account")}>
-                    <PlugZapIcon />
-                    Connect Alby Account
+                  <DropdownMenuItem asChild>
+                    <Link
+                      to="/alby/account"
+                      className="w-full flex flex-row items-center gap-2"
+                    >
+                      <PlugZapIcon />
+                      Connect Alby Account
+                    </Link>
                   </DropdownMenuItem>
                 ) : (
-                  <DropdownMenuItem
-                    onClick={() => navigate("/settings/alby-account")}
-                  >
-                    <AlbyIcon className="size-4" />
-                    Alby Account Settings
+                  <DropdownMenuItem asChild>
+                    <Link
+                      to="/settings/alby-account"
+                      className="w-full flex flex-row items-center gap-2"
+                    >
+                      <AlbyIcon className="size-4" />
+                      Alby Account Settings
+                    </Link>
                   </DropdownMenuItem>
                 )}
                 {!albyMe?.subscription.plan_code && (

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -199,17 +199,21 @@ export default function Channels() {
                   <DropdownMenuSeparator />
                   <DropdownMenuGroup>
                     <DropdownMenuLabel>On-Chain</DropdownMenuLabel>
-                    <DropdownMenuItem
-                      onClick={() => navigate("/channels/onchain/buy-bitcoin")}
-                    >
-                      Buy
+                    <DropdownMenuItem asChild>
+                      <Link
+                        to="/channels/onchain/buy-bitcoin"
+                        className="w-full"
+                      >
+                        Buy
+                      </Link>
                     </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() =>
-                        navigate("/channels/onchain/deposit-bitcoin")
-                      }
-                    >
-                      Deposit
+                    <DropdownMenuItem asChild>
+                      <Link
+                        to="/channels/onchain/deposit-bitcoin"
+                        className="w-full"
+                      >
+                        Deposit
+                      </Link>
                     </DropdownMenuItem>
                     {(balances?.onchain.spendableSat || 0) >
                       ONCHAIN_DUST_SATS && (

--- a/frontend/src/themes/alby.css
+++ b/frontend/src/themes/alby.css
@@ -34,11 +34,13 @@
 /*
  * Default (primary) buttons: subtle highlight overlay on top of `bg-primary`.
  * Sets `background-image` only so Tailwind's `background-color: var(--primary)`
- * remains the base. Keyed off `data-variant` only so it still matches when
- * `asChild` lets a Radix wrapper (e.g. DialogTrigger) overwrite `data-slot`.
+ * remains the base. Matches `data-slot~="button"` so Radix's Slot forwarding
+ * still picks up `<Button asChild>` (e.g. DialogTrigger asChild) without
+ * leaking onto unrelated items that also expose `data-variant` (e.g.
+ * DropdownMenuItem, Badge).
  */
 .theme-alby
-  :is(button, a, span)[data-variant="default"]:not(
+  :is(button, a, span)[data-slot~="button"][data-variant="default"]:not(
     :disabled,
     [aria-disabled="true"]
   ) {
@@ -51,7 +53,7 @@
 }
 
 .theme-alby
-  :is(button, a, span)[data-variant="default"]:hover:not(
+  :is(button, a, span)[data-slot~="button"][data-variant="default"]:hover:not(
     :disabled,
     [aria-disabled="true"]
   ) {
@@ -65,7 +67,7 @@
 
 /* Keep keyboard focus ring (Button uses ring via box-shadow); stack with brand stroke. */
 .theme-alby
-  :is(button, a, span)[data-variant="default"]:focus-visible:not(
+  :is(button, a, span)[data-slot~="button"][data-variant="default"]:focus-visible:not(
     :disabled,
     [aria-disabled="true"]
   ) {


### PR DESCRIPTION
Fixes #2289 at the root: narrow the Alby theme's default-variant selector to `[data-slot~="button"]` so the gold styling stops leaking onto `DropdownMenuItem asChild` (and Badge) while still matching `<Button asChild>`. Also reverts the symptomatic `Link asChild` → `onClick` rewrites from #2286 — and obsoletes #2295.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation reliability in Alby account and On-Chain channel sections.

* **Style**
  * Enhanced button styling consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->