### PR TITLE
fix: hide transaction ID from on-chain transactions list

### DIFF
--- a/frontend/src/components/OnchainTransactionItem.tsx
+++ b/frontend/src/components/OnchainTransactionItem.tsx
@@ -41,7 +41,6 @@ function OnchainTransactionItem({
   const typeStateText = typeStateLabel(tx);
   const statusText = isPending ? "Pending" : "Confirmed";
   const createdAt = dayjs(tx.createdAt * 1000).local();
-  const subtitle = `${tx.txId.slice(0, 10)}…${tx.txId.slice(-8)}`;
 
   const icon = (
     <div className="flex items-center">
@@ -87,9 +86,6 @@ function OnchainTransactionItem({
                 {createdAt.fromNow()}
               </span>
             </div>
-            <p className="font-mono text-sm md:text-base text-muted-foreground break-all line-clamp-1">
-              {subtitle}
-            </p>
           </div>
           <div className="flex ml-auto space-x-3 shrink-0">
             <div className="flex flex-col items-end md:text-xl">


### PR DESCRIPTION
## Summary
- Removes the truncated transaction ID subtitle from each row in the wallet on-chain tab list — it added noise without much value at a glance.
- The full TX ID is still shown in the transaction detail modal (with copy + link to mempool), so nothing is lost.

The issue also suggested showing the bitcoin address in the detail modal. Holding off on that for now: it'd require extending `lnclient.OnchainTransaction` with an `Address` field, and LDK's `PaymentKindOnchain` doesn't expose the address — so the field would be empty for the main backend. 

Closes #2299

## Test plan
- [ ] Open the wallet on-chain tab — transaction rows show type/state + relative time + amount, no TX ID line.
- [ ] Click a transaction — detail modal still shows full TX ID with copy button and "View on Mempool" link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)