### PR TITLE
chore: rename spending balance to lightning balance

### DIFF
--- a/frontend/src/components/InsufficientLightningBalanceAlert.tsx
+++ b/frontend/src/components/InsufficientLightningBalanceAlert.tsx
@@ -5,7 +5,7 @@ import { LinkButton } from "src/components/ui/custom/link-button";
 import { useBalances } from "src/hooks/useBalances";
 import { useInfo } from "src/hooks/useInfo";
 
-export function SpendingAlert({
+export function InsufficientLightningBalanceAlert({
   className,
   amountSat,
 }: {

--- a/frontend/src/components/IsolatedAppTopupDialog.tsx
+++ b/frontend/src/components/IsolatedAppTopupDialog.tsx
@@ -68,7 +68,7 @@ export function IsolatedAppTopupDialog({
             <DialogTitle>Increase Balance</DialogTitle>
             <DialogDescription>
               Increase the balance of this sub-wallet. Make sure you always
-              maintain enough funds in your spending balance to prevent
+              maintain enough funds in your lightning balance to prevent
               sub-wallets becoming unspendable.
             </DialogDescription>
           </DialogHeader>

--- a/frontend/src/components/RebalanceChannelDialogContent.tsx
+++ b/frontend/src/components/RebalanceChannelDialogContent.tsx
@@ -189,7 +189,7 @@ export function RebalanceChannelDialogContent({
                   You have another channel with less funds
                 </AlertTitle>
                 <AlertDescription>
-                  Consider choosing a channel with less spending balance to
+                  Consider choosing a channel with less local balance to
                   rebalance into.
                 </AlertDescription>
               </Alert>

--- a/frontend/src/components/ReceiveToLightning.tsx
+++ b/frontend/src/components/ReceiveToLightning.tsx
@@ -9,7 +9,7 @@ import { useAlbyMe } from "src/hooks/useAlbyMe";
 import { useInfo } from "src/hooks/useInfo";
 import { copyToClipboard } from "src/lib/clipboard";
 
-export function ReceiveToSpending() {
+export function ReceiveToLightning() {
   const { data: info } = useInfo();
   const { data: me } = useAlbyMe();
 

--- a/frontend/src/components/SpendingAlert.tsx
+++ b/frontend/src/components/SpendingAlert.tsx
@@ -52,7 +52,7 @@ export function SpendingAlert({
             variant="secondary"
             className="w-full"
           >
-            Increase Spending Balance
+            Increase Lightning Balance
           </LinkButton>
         </div>
       </AlertDescription>

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -355,14 +355,14 @@ export default function Channels() {
                         <Tooltip>
                           <TooltipTrigger>
                             <div className="flex flex-row gap-1 items-center justify-start text-sm font-medium">
-                              Spending Balance
+                              Balance
                               <InfoIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
                             </div>
                           </TooltipTrigger>
                           <TooltipContent>
-                            Your spending balance is the funds on your side of
-                            your channels, which you can use to make lightning
-                            payments. Your total lightning balance is{" "}
+                            Your lightning balance is the spendable funds on
+                            your side of your channels. Your total channel
+                            balance is{" "}
                             <FormattedBitcoinAmount
                               amountMsat={
                                 channels

--- a/frontend/src/screens/channels/CurrentChannelOrder.tsx
+++ b/frontend/src/screens/channels/CurrentChannelOrder.tsx
@@ -654,7 +654,7 @@ function PayLightningChannelOrder({ order }: { order: NewChannelOrder }) {
                   {lspOrderResponse.outgoingLiquiditySat > 0 && (
                     <TableRow>
                       <TableCell className="font-medium p-3">
-                        Spending Balance
+                        Lightning Balance
                       </TableCell>
                       <TableCell className="text-right p-3">
                         <FormattedBitcoinAmount
@@ -776,7 +776,7 @@ function PayLightningChannelOrder({ order }: { order: NewChannelOrder }) {
                   variant="secondary"
                   className="w-full"
                 >
-                  Increase Spending Balance
+                  Increase Lightning Balance
                 </LinkButton>
                 <ExternalLinkButton
                   to="https://www.getalby.com/topup"

--- a/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
@@ -496,7 +496,7 @@ function NewChannelInternal({
             className="w-full"
             variant="secondary"
           >
-            Increase Spending Balance
+            Increase Lightning Balance
           </LinkButton>
           <ExternalLinkButton
             to="https://www.getalby.com/topup"

--- a/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
@@ -258,9 +258,9 @@ function NewChannelInternal({
                   </div>
                 </TooltipTrigger>
                 <TooltipContent>
-                  Configure the amount of lightning balance you need. You will
-                  need to deposit on-chain bitcoin to cover the entire channel
-                  size, plus on-chain fees.
+                  Configure the amount of spending balance you need in your new
+                  lightning channel. You will need to deposit on-chain bitcoin
+                  to cover the entire channel size, plus on-chain fees.
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseOutgoingCapacity.tsx
@@ -214,7 +214,7 @@ function NewChannelInternal({
       <AppHeader
         pageTitle="Open Channel with On-Chain"
         title="Open Channel with On-Chain"
-        description="Funds used to open a channel minus fees will be added to your spending balance"
+        description="Funds used to open a channel minus fees will be added to your lightning balance"
         contentRight={
           <div className="flex items-end">
             <Link to="/channels/incoming" className="underline text-sm">
@@ -252,13 +252,13 @@ function NewChannelInternal({
                 <TooltipTrigger type="button">
                   <div className="flex flex-row gap-2 items-center justify-start text-sm">
                     <Label htmlFor="amount">
-                      Increase spending balance (sats)
+                      Increase lightning balance (sats)
                     </Label>
                     <InfoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
                   </div>
                 </TooltipTrigger>
                 <TooltipContent>
-                  Configure the amount of spending capacity you need. You will
+                  Configure the amount of lightning balance you need. You will
                   need to deposit on-chain bitcoin to cover the entire channel
                   size, plus on-chain fees.
                 </TooltipContent>

--- a/frontend/src/screens/settings/Backup.tsx
+++ b/frontend/src/screens/settings/Backup.tsx
@@ -170,9 +170,11 @@ export default function Backup() {
           <div>
             <h3 className="text-lg font-medium">Channels Backup</h3>
             <p className="text-sm text-muted-foreground">
-              Your spending balance is stored in your lightning channels. In
-              case of recovery of your Alby Hub, they need to be backed up every
-              time you open a new channel.
+              Your lightning balance can only be recovered on-chain by closing
+              your lightning channels. In case of recovery of your Alby Hub a
+              request will be sent to your peers to close your existing
+              channels. To recover the funds from these channels, a channel
+              backup needs to be created every time you open a new channel.
             </p>
           </div>
 
@@ -209,7 +211,7 @@ export default function Backup() {
                     <p className="text-sm text-muted-foreground mb-4">
                       When enabled, your channels state is dynamically updated
                       and stored end-to-end encrypted by Alby's Versioned
-                      Storage Service. This allows you to recover your spending
+                      Storage Service. This allows you to recover your lightning
                       balance with your recovery phrase alone, without having to
                       close your channels.
                     </p>
@@ -317,8 +319,8 @@ function DynamicChannelsBackupDialog({ info }: Props) {
                 By enabling dynamic channel backups, your channels state is
                 dynamically updated and stored end-to-end encrypted by Alby's
                 Versioned Storage Service. This allows you to recover your
-                spending balance with your recovery phrase alone, without having
-                to close your channels.
+                lightning balance with your recovery phrase alone, without
+                having to close your channels.
               </p>
               <p className="mt-2">
                 As part of enabling dynamic channels backup your hub will be

--- a/frontend/src/screens/subwallets/SubwalletIntro.tsx
+++ b/frontend/src/screens/subwallets/SubwalletIntro.tsx
@@ -59,8 +59,8 @@ export function SubwalletIntro() {
             <div className="flex flex-row gap-3">
               <HandCoinsIcon className="size-6" />
               <div className="font-medium">
-                Sub-wallets depend on your Alby Hub spending balance and receive
-                limit
+                Sub-wallets depend on your Alby Hub lightning balance and
+                receive limit
               </div>
             </div>
             <div className="ml-9 text-muted-foreground text-sm">
@@ -76,10 +76,10 @@ export function SubwalletIntro() {
               </div>
             </div>
             <div className="ml-9 text-muted-foreground text-sm">
-              Make sure you always maintain enough funds in your spending
+              Make sure you always maintain enough funds in your lightning
               balance to prevent sub-wallets becoming unspendable. Sub-wallet
-              payments might fail if the amount isn't available in your spending
-              balance.
+              payments might fail if the amount isn't available in your
+              lightning balance.
             </div>
           </div>
           <div>

--- a/frontend/src/screens/subwallets/SubwalletList.tsx
+++ b/frontend/src/screens/subwallets/SubwalletList.tsx
@@ -137,10 +137,10 @@ export function SubwalletList() {
             Sub-wallets you manage are insufficiently backed
           </AlertTitle>
           <AlertDescription className="flex flex-row gap-3">
-            There's not enough bitcoin in your spending balance to honor all
-            balances of sub-wallets under your management. Increase spending
-            capacity by opening a channel or review your channel statuses to
-            back them up again.
+            There's not enough bitcoin in your lightning balance to honor all
+            balances of sub-wallets under your management. Increase your
+            lightning balance by opening a channel or review your channel
+            statuses to back them up again.
             <LinkButton to="/wallet/receive" variant="secondary">
               Deposit Bitcoin
             </LinkButton>

--- a/frontend/src/screens/wallet/Lightning.tsx
+++ b/frontend/src/screens/wallet/Lightning.tsx
@@ -81,15 +81,15 @@ export default function Lightning() {
             <button
               type="button"
               onClick={() => navigate("/wallet/onchain")}
-              aria-label="Toggle balance mode, currently Spending Balance"
+              aria-label="Toggle balance mode, currently Lightning Balance"
               className="inline-flex items-center justify-center gap-1 text-xs font-medium leading-none uppercase text-muted-foreground transition-colors hover:text-foreground"
             >
-              Spending Balance
+              Lightning Balance
               <ArrowDownUpIcon aria-hidden className="size-3 shrink-0" />
             </button>
           ) : (
             <span className="text-xs font-medium leading-none uppercase text-muted-foreground">
-              Spending Balance
+              Lightning Balance
             </span>
           )}
           <div className="flex flex-col items-center gap-3">

--- a/frontend/src/screens/wallet/Receive.tsx
+++ b/frontend/src/screens/wallet/Receive.tsx
@@ -22,9 +22,9 @@ export default function Receive() {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const activeTab =
-    searchParams.get("type") === "onchain" ? "onchain" : "spending";
+    searchParams.get("type") === "onchain" ? "onchain" : "lightning";
 
-  const isSpendingTab = activeTab === "spending";
+  const isSpendingTab = activeTab === "lightning";
   const isLightningAddressLoading =
     isSpendingTab && info?.albyAccountConnected && !me && !meError;
 
@@ -62,7 +62,7 @@ export default function Receive() {
         >
           <TabsList className="w-full mb-2">
             <TabsTrigger
-              value="spending"
+              value="lightning"
               className="flex gap-2 items-center w-full"
             >
               <ZapIcon className="size-4" />
@@ -76,7 +76,7 @@ export default function Receive() {
               To On-chain Balance
             </TabsTrigger>
           </TabsList>
-          <TabsContent value="spending">
+          <TabsContent value="lightning">
             <ReceiveToLightning />
           </TabsContent>
           <TabsContent value="onchain">

--- a/frontend/src/screens/wallet/Receive.tsx
+++ b/frontend/src/screens/wallet/Receive.tsx
@@ -4,8 +4,8 @@ import { useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
 import Loading from "src/components/Loading";
+import { ReceiveToLightning } from "src/components/ReceiveToLightning";
 import { ReceiveToOnchain } from "src/components/ReceiveToOnchain";
-import { ReceiveToSpending } from "src/components/ReceiveToSpending";
 import {
   Tabs,
   TabsContent,
@@ -77,7 +77,7 @@ export default function Receive() {
             </TabsTrigger>
           </TabsList>
           <TabsContent value="spending">
-            <ReceiveToSpending />
+            <ReceiveToLightning />
           </TabsContent>
           <TabsContent value="onchain">
             <ReceiveToOnchain />

--- a/frontend/src/screens/wallet/Receive.tsx
+++ b/frontend/src/screens/wallet/Receive.tsx
@@ -66,7 +66,7 @@ export default function Receive() {
               className="flex gap-2 items-center w-full"
             >
               <ZapIcon className="size-4" />
-              To Spending Balance
+              To Lightning Balance
             </TabsTrigger>
             <TabsTrigger
               value="onchain"

--- a/frontend/src/screens/wallet/send/ConfirmPayment.tsx
+++ b/frontend/src/screens/wallet/send/ConfirmPayment.tsx
@@ -9,10 +9,10 @@ import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
 import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
+import { InsufficientLightningBalanceAlert } from "src/components/InsufficientLightningBalanceAlert";
 import Loading from "src/components/Loading";
 import { PaymentFailedAlert } from "src/components/PaymentFailedAlert";
 import { PendingPaymentAlert } from "src/components/PendingPaymentAlert";
-import { SpendingAlert } from "src/components/SpendingAlert";
 import {
   Card,
   CardContent,
@@ -126,7 +126,10 @@ export default function ConfirmPayment() {
           </CardContent>
           <CardFooter className="flex flex-col gap-2 pt-2">
             <PayFromSelect appId={appId} onChange={setAppId} />
-            <SpendingAlert className="mb-2" amountSat={invoice.satoshi} />
+            <InsufficientLightningBalanceAlert
+              className="mb-2"
+              amountSat={invoice.satoshi}
+            />
             <LoadingButton
               onClick={confirmPayment}
               loading={isLoading}

--- a/frontend/src/screens/wallet/send/ConfirmPayment.tsx
+++ b/frontend/src/screens/wallet/send/ConfirmPayment.tsx
@@ -137,7 +137,7 @@ export default function ConfirmPayment() {
               Confirm Payment
             </LoadingButton>
             <div className="flex items-center justify-between gap-2 text-muted-foreground text-xs sensitive slashed-zero">
-              Spending Balance:{" "}
+              Lightning Balance:{" "}
               <FormattedBitcoinAmount
                 amountMsat={balances.lightning.totalSpendableMsat}
               />

--- a/frontend/src/screens/wallet/send/LnurlPay.tsx
+++ b/frontend/src/screens/wallet/send/LnurlPay.tsx
@@ -160,7 +160,7 @@ export default function LnurlPay() {
           <div className="grid gap-2">
             <div className="flex justify-between text-xs text-muted-foreground sensitive slashed-zero">
               <div>
-                Spending Balance:{" "}
+                Lightning Balance:{" "}
                 <FormattedBitcoinAmount
                   amountMsat={balances.lightning.totalSpendableMsat}
                 />

--- a/frontend/src/screens/wallet/send/LnurlPay.tsx
+++ b/frontend/src/screens/wallet/send/LnurlPay.tsx
@@ -7,10 +7,10 @@ import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
 import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
+import { InsufficientLightningBalanceAlert } from "src/components/InsufficientLightningBalanceAlert";
 import Loading from "src/components/Loading";
 import { PaymentFailedAlert } from "src/components/PaymentFailedAlert";
 import { PendingPaymentAlert } from "src/components/PendingPaymentAlert";
-import { SpendingAlert } from "src/components/SpendingAlert";
 import { InputWithAdornment } from "src/components/ui/custom/input-with-adornment";
 import { LinkButton } from "src/components/ui/custom/link-button";
 import { LoadingButton } from "src/components/ui/custom/loading-button";
@@ -187,7 +187,7 @@ export default function LnurlPay() {
           </div>
         )}
         <PayFromSelect appId={appId} onChange={setAppId} />
-        <SpendingAlert amountSat={+amountSat} />
+        <InsufficientLightningBalanceAlert amountSat={+amountSat} />
         <div className="flex gap-2">
           <LinkButton to="/wallet/send" variant="outline">
             Back

--- a/frontend/src/screens/wallet/send/Onchain.tsx
+++ b/frontend/src/screens/wallet/send/Onchain.tsx
@@ -13,9 +13,9 @@ import AppHeader from "src/components/AppHeader";
 import ExternalLink from "src/components/ExternalLink";
 import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
+import { InsufficientLightningBalanceAlert } from "src/components/InsufficientLightningBalanceAlert";
 import Loading from "src/components/Loading";
 import { MempoolAlert } from "src/components/MempoolAlert";
-import { SpendingAlert } from "src/components/SpendingAlert";
 import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
 import { Button } from "src/components/ui/button";
 import { InputWithAdornment } from "src/components/ui/custom/input-with-adornment";
@@ -451,7 +451,7 @@ function SwapForm({
           <p>{swapInfo.albyServiceFee + swapInfo.boltzServiceFee}%</p>
         </div>
       </div>
-      <SpendingAlert amountSat={+amountSat} />
+      <InsufficientLightningBalanceAlert amountSat={+amountSat} />
       <div className="flex gap-2">
         <LinkButton to="/wallet/send" variant="outline">
           Back

--- a/frontend/src/screens/wallet/send/Onchain.tsx
+++ b/frontend/src/screens/wallet/send/Onchain.tsx
@@ -144,7 +144,7 @@ function OnchainForm({
       }
       if (balances.onchain.spendableSat <= ONCHAIN_DUST_SATS) {
         throw new Error(
-          "You currently don't have enough sats to pay for an on-chain transaction. Consider swapping from Spending Balance."
+          "You currently don't have enough sats to pay for an on-chain transaction. Consider swapping from Lightning Balance."
         );
       }
       setLoading(true);
@@ -225,7 +225,7 @@ function OnchainForm({
       </div>
       <div className="flex items-center justify-between">
         <Label htmlFor="swap" className="cursor-pointer">
-          Swap from Spending Balance
+          Swap from Lightning Balance
         </Label>
         <Switch id="swap" onCheckedChange={setSwap} />
       </div>
@@ -405,7 +405,7 @@ function SwapForm({
         <div className="grid gap-1">
           <div className="flex justify-between text-xs text-muted-foreground sensitive slashed-zero">
             <div>
-              Spending Balance:{" "}
+              Lightning Balance:{" "}
               <FormattedBitcoinAmount
                 amountMsat={balances.lightning.totalSpendableMsat}
               />
@@ -431,7 +431,7 @@ function SwapForm({
       </div>
       <div className="flex items-center justify-between">
         <Label htmlFor="swap" className="cursor-pointer">
-          Swap from Spending Balance
+          Swap from Lightning Balance
         </Label>
         <Switch id="swap" checked onCheckedChange={setSwap} />
       </div>

--- a/frontend/src/screens/wallet/send/PayFromSelect.tsx
+++ b/frontend/src/screens/wallet/send/PayFromSelect.tsx
@@ -19,8 +19,8 @@ import { useApps } from "src/hooks/useApps";
 import { getAppDisplayName } from "src/lib/utils";
 import { App } from "src/types";
 
-const SPENDING_BALANCE = "spending-balance";
-const SPENDING_BALANCE_LABEL = "Spending Balance";
+const LIGHTNING_BALANCE = "lightning-balance";
+const LIGHTNING_BALANCE_LABEL = "Lightning Balance";
 
 type PayFromOption = {
   value: string;
@@ -33,13 +33,13 @@ type Props = {
   onChange(appId: number | undefined): void;
 };
 
-function SpendingOption() {
+function LightningOption() {
   return (
     <div className="flex items-center gap-3">
       <div className="flex size-6 items-center justify-center rounded-lg bg-muted">
         <WalletIcon className="size-3 text-muted-foreground" />
       </div>
-      <div>{SPENDING_BALANCE_LABEL}</div>
+      <div>{LIGHTNING_BALANCE_LABEL}</div>
     </div>
   );
 }
@@ -74,7 +74,7 @@ export default function PayFromSelect({ appId, onChange }: Props) {
 
   const options = React.useMemo<PayFromOption[]>(
     () => [
-      { value: SPENDING_BALANCE, label: SPENDING_BALANCE_LABEL },
+      { value: LIGHTNING_BALANCE, label: LIGHTNING_BALANCE_LABEL },
       ...apps.map((app) => ({
         value: app.id.toString(),
         label: getAppDisplayName(app.name),
@@ -85,7 +85,7 @@ export default function PayFromSelect({ appId, onChange }: Props) {
   );
 
   const selectedOption = options.find(
-    (opt) => (appId ? opt.value === appId.toString() : undefined) // : opt.value === SPENDING_BALANCE
+    (opt) => (appId ? opt.value === appId.toString() : undefined) // : opt.value === LIGHTNING_BALANCE
   );
 
   return (
@@ -98,14 +98,14 @@ export default function PayFromSelect({ appId, onChange }: Props) {
         onInputValueChange={setSearch}
         onValueChange={(option) =>
           onChange(
-            option?.value === SPENDING_BALANCE
+            option?.value === LIGHTNING_BALANCE
               ? undefined
               : Number(option?.value)
           )
         }
       >
         <div ref={anchorRef} className="w-full">
-          <ComboboxInput placeholder={SPENDING_BALANCE_LABEL}>
+          <ComboboxInput placeholder={LIGHTNING_BALANCE_LABEL}>
             <InputGroupAddon>
               {selectedOption?.app ? (
                 <AppAvatar
@@ -128,7 +128,7 @@ export default function PayFromSelect({ appId, onChange }: Props) {
                 {option.app ? (
                   <AppOption app={option.app} />
                 ) : (
-                  <SpendingOption />
+                  <LightningOption />
                 )}
               </ComboboxItem>
             )}

--- a/frontend/src/screens/wallet/send/PayFromSelect.tsx
+++ b/frontend/src/screens/wallet/send/PayFromSelect.tsx
@@ -84,8 +84,8 @@ export default function PayFromSelect({ appId, onChange }: Props) {
     [apps]
   );
 
-  const selectedOption = options.find(
-    (opt) => (appId ? opt.value === appId.toString() : undefined) // : opt.value === LIGHTNING_BALANCE
+  const selectedOption = options.find((opt) =>
+    appId ? opt.value === appId.toString() : undefined
   );
 
   return (

--- a/frontend/src/screens/wallet/send/ZeroAmount.tsx
+++ b/frontend/src/screens/wallet/send/ZeroAmount.tsx
@@ -142,7 +142,7 @@ export default function ZeroAmount() {
           <div className="grid gap-2">
             <div className="flex justify-between text-xs text-muted-foreground sensitive slashed-zero">
               <div>
-                Spending Balance:{" "}
+                Lightning Balance:{" "}
                 <FormattedBitcoinAmount
                   amountMsat={balances.lightning.totalSpendableMsat}
                 />

--- a/frontend/src/screens/wallet/send/ZeroAmount.tsx
+++ b/frontend/src/screens/wallet/send/ZeroAmount.tsx
@@ -8,10 +8,10 @@ import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
 import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
+import { InsufficientLightningBalanceAlert } from "src/components/InsufficientLightningBalanceAlert";
 import Loading from "src/components/Loading";
 import { PaymentFailedAlert } from "src/components/PaymentFailedAlert";
 import { PendingPaymentAlert } from "src/components/PendingPaymentAlert";
-import { SpendingAlert } from "src/components/SpendingAlert";
 import { InputWithAdornment } from "src/components/ui/custom/input-with-adornment";
 import { LinkButton } from "src/components/ui/custom/link-button";
 import { LoadingButton } from "src/components/ui/custom/loading-button";
@@ -155,7 +155,7 @@ export default function ZeroAmount() {
           </div>
         </div>
         <PayFromSelect appId={appId} onChange={setAppId} />
-        <SpendingAlert amountSat={+amountSat} />
+        <InsufficientLightningBalanceAlert amountSat={+amountSat} />
         <div className="flex gap-2">
           <LinkButton to="/wallet/send" variant="outline">
             Back

--- a/frontend/src/screens/wallet/swap/AutoSwap.tsx
+++ b/frontend/src/screens/wallet/swap/AutoSwap.tsx
@@ -425,7 +425,7 @@ function ActiveSwapOutConfig({ swapConfig }: { swapConfig: AutoSwapConfig }) {
         </div>
         <div className="flex justify-between items-center gap-2">
           <span className="font-medium truncate">
-            Lightning Balance Threshold
+            Lightning balance threshold
           </span>
           <span className="shrink-0 text-muted-foreground text-right">
             <FormattedBitcoinAmount

--- a/frontend/src/screens/wallet/swap/AutoSwap.tsx
+++ b/frontend/src/screens/wallet/swap/AutoSwap.tsx
@@ -161,7 +161,7 @@ function AutoSwapOutForm() {
         </div>
 
         <div className="grid gap-1.5">
-          <Label>Spending balance threshold</Label>
+          <Label>Lightning balance threshold</Label>
           <Input
             type="number"
             placeholder="Amount in satoshis"
@@ -425,7 +425,7 @@ function ActiveSwapOutConfig({ swapConfig }: { swapConfig: AutoSwapConfig }) {
         </div>
         <div className="flex justify-between items-center gap-2">
           <span className="font-medium truncate">
-            Spending Balance Threshold
+            Lightning Balance Threshold
           </span>
           <span className="shrink-0 text-muted-foreground text-right">
             <FormattedBitcoinAmount

--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -183,7 +183,7 @@ function SwapInForm() {
               On-chain <MoveRightIcon /> Lightning
             </h2>
             <p className="mt-1 text-muted-foreground">
-              Swap on-chain funds into your lightning spending balance.
+              Swap on-chain funds into your lightning balance.
             </p>
           </div>
           <div className="grid gap-1.5">


### PR DESCRIPTION
Closes https://github.com/getAlby/hub/issues/2297

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated UI terminology throughout the application, replacing "Spending Balance" with "Lightning Balance" across balance displays, channel management, payment confirmations, transaction flows, swap settings, and account backup information. Enhanced UI consistency and clarity for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->