### PR TITLE
fix: replace payment flow intermediate screens in browser history

### DIFF
--- a/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
@@ -261,7 +261,7 @@ export default function ReceiveInvoice() {
                       className="w-full"
                     >
                       <LinkIcon className="h-4 w-4" />
-                      Receive from On-chain
+                      Receive from On-chain / Other Cryptocurrency
                     </LinkButton>
                   </div>
                 )}

--- a/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
@@ -90,7 +90,9 @@ export default function ReceiveOnchain() {
       if (!swapInResponse) {
         throw new Error("Error swapping in");
       }
-      navigate(`/wallet/swap/in/status/${swapInResponse.swapId}`);
+      navigate(`/wallet/swap/in/status/${swapInResponse.swapId}`, {
+        replace: true,
+      });
       toast("Initiated swap");
     } catch (error) {
       toast.error("Failed to initiate swap", {

--- a/frontend/src/screens/wallet/send/ConfirmPayment.tsx
+++ b/frontend/src/screens/wallet/send/ConfirmPayment.tsx
@@ -68,6 +68,7 @@ export default function ConfirmPayment() {
           pageTitle: "Pay Invoice",
           invoice,
         },
+        replace: true,
       });
       toast("Successfully paid invoice");
     } catch (e) {

--- a/frontend/src/screens/wallet/send/LnurlPay.tsx
+++ b/frontend/src/screens/wallet/send/LnurlPay.tsx
@@ -80,6 +80,7 @@ export default function LnurlPay() {
           to: lnAddress.address,
           pageTitle: "Send to Lightning Address",
         },
+        replace: true,
       });
       toast("Successfully paid invoice");
     } catch (e) {
@@ -109,7 +110,7 @@ export default function LnurlPay() {
         pageTitle="Send to Lightning Address"
         title="Send to Lightning Address"
       />
-      <div className="max-w-lg grid gap-4">
+      <div className="md:max-w-lg grid gap-4">
         <PendingPaymentAlert />
         {errorMessage && invoice && (
           <PaymentFailedAlert
@@ -117,86 +118,86 @@ export default function LnurlPay() {
             invoice={invoice.paymentRequest}
           />
         )}
-      </div>
-      <form onSubmit={onSubmit} className="grid gap-6 max-w-lg">
-        <div className="grid gap-2">
-          <div className="text-sm font-medium">Recipient</div>
-          <div className="flex items-center justify-between">
-            <p className="text-sm">{lnAddress.address}</p>
-            <Link to="/wallet/send">
-              <XIcon className="w-4 h-4 cursor-pointer text-muted-foreground" />
-            </Link>
-          </div>
-        </div>
-        {lnAddress.lnurlpData?.description && (
+        <form onSubmit={onSubmit} className="grid gap-6">
           <div className="grid gap-2">
-            <Label>Description</Label>
-            <p className="text-muted-foreground text-sm">
-              {lnAddress.lnurlpData.description}
-            </p>
-          </div>
-        )}
-        <div className="grid gap-2">
-          <Label htmlFor="amount">Amount</Label>
-          <InputWithAdornment
-            id="amount"
-            type="number"
-            value={amountSat}
-            placeholder="Amount in Satoshi..."
-            onChange={(e) => {
-              setAmountSat(e.target.value.trim());
-            }}
-            min={1}
-            max={balances.lightning.totalSpendableSat}
-            required
-            autoFocus
-            endAdornment={
-              <FormattedFiatAmount
-                amountSat={Number(amountSat)}
-                className="mr-2"
-              />
-            }
-          />
-          <div className="grid gap-2">
-            <div className="flex justify-between text-xs text-muted-foreground sensitive slashed-zero">
-              <div>
-                Spending Balance:{" "}
-                <FormattedBitcoinAmount
-                  amountMsat={balances.lightning.totalSpendableMsat}
-                />
-              </div>
-              <FormattedFiatAmount
-                className="text-xs"
-                amountSat={balances.lightning.totalSpendableSat}
-              />
+            <div className="text-sm font-medium">Recipient</div>
+            <div className="flex items-center justify-between">
+              <p className="text-sm">{lnAddress.address}</p>
+              <Link to="/wallet/send">
+                <XIcon className="w-4 h-4 cursor-pointer text-muted-foreground" />
+              </Link>
             </div>
           </div>
-        </div>
-        {!!lnAddress.lnurlpData?.commentAllowed && (
+          {lnAddress.lnurlpData?.description && (
+            <div className="grid gap-2">
+              <Label>Description</Label>
+              <p className="text-muted-foreground text-sm">
+                {lnAddress.lnurlpData.description}
+              </p>
+            </div>
+          )}
           <div className="grid gap-2">
-            <Label htmlFor="comment">Comment</Label>
-            <Input
-              id="comment"
-              type="text"
-              value={comment}
-              placeholder="Optional"
+            <Label htmlFor="amount">Amount</Label>
+            <InputWithAdornment
+              id="amount"
+              type="number"
+              value={amountSat}
+              placeholder="Amount in Satoshi..."
               onChange={(e) => {
-                setComment(e.target.value);
+                setAmountSat(e.target.value.trim());
               }}
+              min={1}
+              max={balances.lightning.totalSpendableSat}
+              required
+              autoFocus
+              endAdornment={
+                <FormattedFiatAmount
+                  amountSat={Number(amountSat)}
+                  className="mr-2"
+                />
+              }
             />
+            <div className="grid gap-2">
+              <div className="flex justify-between text-xs text-muted-foreground sensitive slashed-zero">
+                <div>
+                  Spending Balance:{" "}
+                  <FormattedBitcoinAmount
+                    amountMsat={balances.lightning.totalSpendableMsat}
+                  />
+                </div>
+                <FormattedFiatAmount
+                  className="text-xs"
+                  amountSat={balances.lightning.totalSpendableSat}
+                />
+              </div>
+            </div>
           </div>
-        )}
-        <PayFromSelect appId={appId} onChange={setAppId} />
-        <SpendingAlert amountSat={+amountSat} />
-        <div className="flex gap-2">
-          <LinkButton to="/wallet/send" variant="outline">
-            Back
-          </LinkButton>
-          <LoadingButton loading={isLoading} type="submit" className="flex-1">
-            Send
-          </LoadingButton>
-        </div>
-      </form>
+          {!!lnAddress.lnurlpData?.commentAllowed && (
+            <div className="grid gap-2">
+              <Label htmlFor="comment">Comment</Label>
+              <Input
+                id="comment"
+                type="text"
+                value={comment}
+                placeholder="Optional"
+                onChange={(e) => {
+                  setComment(e.target.value);
+                }}
+              />
+            </div>
+          )}
+          <PayFromSelect appId={appId} onChange={setAppId} />
+          <SpendingAlert amountSat={+amountSat} />
+          <div className="flex gap-2">
+            <LinkButton to="/wallet/send" variant="outline">
+              Back
+            </LinkButton>
+            <LoadingButton loading={isLoading} type="submit" className="flex-1">
+              Send
+            </LoadingButton>
+          </div>
+        </form>
+      </div>
     </div>
   );
 }

--- a/frontend/src/screens/wallet/send/LnurlPay.tsx
+++ b/frontend/src/screens/wallet/send/LnurlPay.tsx
@@ -121,8 +121,8 @@ export default function LnurlPay() {
         <form onSubmit={onSubmit} className="grid gap-6">
           <div className="grid gap-2">
             <div className="text-sm font-medium">Recipient</div>
-            <div className="flex items-center justify-between">
-              <p className="text-sm">{lnAddress.address}</p>
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-sm break-all">{lnAddress.address}</p>
               <Link to="/wallet/send">
                 <XIcon className="w-4 h-4 cursor-pointer text-muted-foreground" />
               </Link>

--- a/frontend/src/screens/wallet/send/Onchain.tsx
+++ b/frontend/src/screens/wallet/send/Onchain.tsx
@@ -171,6 +171,7 @@ function OnchainForm({
           amountSat: +amountSat,
           txId: response.txId,
         },
+        replace: true,
       });
       toast("Successfully broadcasted transaction");
     } catch (e) {

--- a/frontend/src/screens/wallet/send/ZeroAmount.tsx
+++ b/frontend/src/screens/wallet/send/ZeroAmount.tsx
@@ -63,6 +63,7 @@ export default function ZeroAmount() {
           invoice,
           amountSat,
         },
+        replace: true,
       });
       toast("Successfully paid invoice");
     } catch (e) {


### PR DESCRIPTION
Fixes #2296

Adds `replace: true` to intermediate screens while navigating to success/pending in send and receive.

Also fixes a minor gap issue in LnurlPay screen + Adds "/ Other Cryptocurrency" to the receive on-chain button when ln address is not present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded receive label to include other cryptocurrencies.

* **Style**
  * Refined layout and spacing in the Lightning address payment flow.

* **Bug Fixes**
  * Success redirects now replace history for send/on-chain/zero-amount/lnurl flows and swap-in status, improving back-button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->