### PR TITLE
fix: position and size sidebar hint x icon

### DIFF
--- a/frontend/src/components/SidebarHint.tsx
+++ b/frontend/src/components/SidebarHint.tsx
@@ -146,10 +146,10 @@ function SidebarHintCard({
         <CardTitle>{title}</CardTitle>
         {onClose && (
           <button
-            className="absolute top-4 right-4 text-muted-foreground hover:text-primary"
+            className="absolute top-6 right-6 text-muted-foreground hover:text-foreground"
             onClick={onClose}
           >
-            <XIcon name="X" />
+            <XIcon name="X" className="size-4" />
           </button>
         )}
       </CardHeader>

--- a/frontend/src/components/SidebarHint.tsx
+++ b/frontend/src/components/SidebarHint.tsx
@@ -149,7 +149,7 @@ function SidebarHintCard({
             className="absolute top-6 right-6 text-muted-foreground hover:text-foreground"
             onClick={onClose}
           >
-            <XIcon name="X" className="size-4" />
+            <XIcon className="size-4" />
           </button>
         )}
       </CardHeader>


### PR DESCRIPTION
## Screenshots (Before vs After)
<table>
<tr>
<td><img src="https://github.com/user-attachments/assets/4d38448a-1d3d-4448-a9e6-729e9466aa28"/></td>
<td><img src="https://github.com/user-attachments/assets/3870a147-21b9-49ea-9392-c79ce1751187"/></td>
</tr>
</table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted the sidebar hint card’s close button positioning for improved alignment and spacing.
  * Updated the close button hover styling to better match foreground contrast and improve visibility.
  * Standardized the close icon sizing to enhance visual consistency across the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->