### PR TITLE
feat: show last transaction amount on recently used apps

### DIFF
--- a/frontend/src/components/home/widgets/LatestUsedAppsWidget.tsx
+++ b/frontend/src/components/home/widgets/LatestUsedAppsWidget.tsx
@@ -61,7 +61,7 @@ function RecentlyUsedAppRow({ app }: { app: App }) {
   return (
     <Link to={`/apps/${app.id}`} className="group">
       <div className="flex items-center w-full gap-4">
-        <AppAvatar app={app} className="w-14 h-14 rounded-lg" />
+        <AppAvatar app={app} className="w-12 h-12 rounded-lg" />
         <p className="text-sm font-medium flex-1 truncate">
           {getAppDisplayName(app.name)}
         </p>

--- a/frontend/src/components/home/widgets/LatestUsedAppsWidget.tsx
+++ b/frontend/src/components/home/widgets/LatestUsedAppsWidget.tsx
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 import { ChevronRightIcon } from "lucide-react";
 import { Link } from "react-router";
 import AppAvatar from "src/components/AppAvatar";
+import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import {
   Card,
   CardContent,
@@ -10,7 +11,9 @@ import {
 } from "src/components/ui/card";
 import { LinkButton } from "src/components/ui/custom/link-button";
 import { useApps } from "src/hooks/useApps";
-import { getAppDisplayName } from "src/lib/utils";
+import { useTransactions } from "src/hooks/useTransactions";
+import { cn, getAppDisplayName } from "src/lib/utils";
+import { App } from "src/types";
 
 export function LatestUsedAppsWidget() {
   const { data: appsData } = useApps(
@@ -44,22 +47,47 @@ export function LatestUsedAppsWidget() {
               new Date(a.lastSettledTransactionAt ?? 0).getTime()
           )
           .map((app) => (
-            <Link key={app.id} to={`/apps/${app.id}`} className="group">
-              <div className="flex items-center w-full gap-4">
-                <AppAvatar app={app} className="w-14 h-14 rounded-lg" />
-                <p className="text-sm font-medium flex-1 truncate">
-                  {getAppDisplayName(app.name)}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {app.lastSettledTransactionAt
-                    ? dayjs(app.lastSettledTransactionAt).fromNow()
-                    : "never"}
-                </p>
-                <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
-              </div>
-            </Link>
+            <RecentlyUsedAppRow key={app.id} app={app} />
           ))}
       </CardContent>
     </Card>
+  );
+}
+
+function RecentlyUsedAppRow({ app }: { app: App }) {
+  const { data: transactionsData } = useTransactions(app.id, false, 1, 1);
+  const latestTransaction = transactionsData?.transactions[0];
+
+  return (
+    <Link to={`/apps/${app.id}`} className="group">
+      <div className="flex items-center w-full gap-4">
+        <AppAvatar app={app} className="w-14 h-14 rounded-lg" />
+        <p className="text-sm font-medium flex-1 truncate">
+          {getAppDisplayName(app.name)}
+        </p>
+        <div className="flex flex-col items-end">
+          {latestTransaction && (
+            <span
+              className={cn(
+                "text-sm font-medium",
+                latestTransaction.type === "incoming" &&
+                  "text-green-600 dark:text-emerald-500"
+              )}
+            >
+              {latestTransaction.type === "outgoing" ? "-" : "+"}
+              <FormattedBitcoinAmount
+                amountMsat={latestTransaction.amountMsat}
+              />
+            </span>
+          )}
+          <span className="text-xs text-muted-foreground">
+            {app.lastSettledTransactionAt
+              ? dayjs(app.lastSettledTransactionAt).fromNow()
+              : "never"}
+          </span>
+        </div>
+        <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+      </div>
+    </Link>
   );
 }


### PR DESCRIPTION
<img width="1241" height="757" alt="image" src="https://github.com/user-attachments/assets/914cd594-3cf3-4a48-ab63-f402f0aa1592" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recently used apps widget now displays the latest transaction amount with color-coded styling (green for incoming) and the most recent transaction timestamp for each app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->