### PR TITLE
feat: new currency input

### DIFF
--- a/frontend/src/components/AnchorReserveAlert.tsx
+++ b/frontend/src/components/AnchorReserveAlert.tsx
@@ -32,12 +32,14 @@ export function AnchorReserveAlert({
       <AlertTriangleIcon className="h-4 w-4" />
       <AlertTitle>Channel Anchor Reserves will be depleted</AlertTitle>
       <AlertDescription>
-        You have channels open and by spending your entire on-chain balance
-        including your anchor reserves may put your node at risk of unable to
-        reclaim funds in your channel after a force-closure. To prevent this,
-        set aside at least{" "}
-        <FormattedBitcoinAmount amountMsat={channels.length * 25000 * 1000} />{" "}
-        on-chain.
+        <p>
+          You have channels open and by spending your entire on-chain balance
+          including your anchor reserves may put your node at risk of unable to
+          reclaim funds in your channel after a force-closure. To prevent this,
+          set aside at least{" "}
+          <FormattedBitcoinAmount amountMsat={channels.length * 25000 * 1000} />{" "}
+          on-chain.
+        </p>
       </AlertDescription>
     </Alert>
   );

--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -397,6 +397,7 @@ export function CurrencyInputField({
           {...props}
           id={inputId}
           aria-invalid={invalid || undefined}
+          autoComplete="off"
           className={cn(
             "sensitive slashed-zero min-w-0 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           )}

--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -1,5 +1,5 @@
-import { ArrowRightLeftIcon } from "lucide-react";
 import * as React from "react";
+import { toast } from "sonner";
 import {
   Field,
   FieldDescription,
@@ -11,9 +11,7 @@ import {
   InputGroupAddon,
   InputGroupButton,
   InputGroupInput,
-  InputGroupText,
 } from "src/components/ui/input-group";
-import { Separator } from "src/components/ui/separator";
 import { Skeleton } from "src/components/ui/skeleton";
 import { BITCOIN_DISPLAY_FORMAT_BIP177 } from "src/constants";
 import { useBitcoinRate } from "src/hooks/useBitcoinRate";
@@ -21,6 +19,7 @@ import { useInfo } from "src/hooks/useInfo";
 import { cn } from "src/lib/utils";
 
 type CurrencyInputMode = "bitcoin" | "fiat";
+type BitcoinDenomination = "sats" | "btc";
 
 export type CurrencyInputContextRow = {
   label: string;
@@ -103,17 +102,87 @@ function formatFiatInput(amountSat: string, rate: number, currency: string) {
 
 function formatBitcoinValue(
   amountSat: string | number | null | undefined,
-  displayFormat: string | undefined
+  displayFormat: string | undefined,
+  denomination: BitcoinDenomination = "sats"
 ) {
+  const { amount, unit } = formatBitcoinValueParts(
+    amountSat,
+    displayFormat,
+    denomination
+  );
+
+  if (unit === "₿") {
+    return `${unit}${amount}`;
+  }
+
+  return `${amount} ${unit}`;
+}
+
+function formatBitcoinValueParts(
+  amountSat: string | number | null | undefined,
+  displayFormat: string | undefined,
+  denomination: BitcoinDenomination = "sats"
+) {
+  if (denomination === "btc") {
+    return {
+      amount: formatBtcDisplay(amountSat),
+      unit: "BTC",
+    };
+  }
+
   const formattedAmount = new Intl.NumberFormat().format(
     Math.floor(getNumericValue(amountSat))
   );
 
   if (displayFormat === BITCOIN_DISPLAY_FORMAT_BIP177) {
-    return `₿${formattedAmount}`;
+    return {
+      amount: formattedAmount,
+      unit: "₿",
+    };
   }
 
-  return `${formattedAmount} sats`;
+  return {
+    amount: formattedAmount,
+    unit: "sats",
+  };
+}
+
+function BitcoinValueText({
+  amountSat,
+  denomination,
+  displayFormat,
+}: {
+  amountSat: string | number | null | undefined;
+  denomination: BitcoinDenomination;
+  displayFormat: string | undefined;
+}) {
+  const { amount, unit } = formatBitcoinValueParts(
+    amountSat,
+    displayFormat,
+    denomination
+  );
+
+  return (
+    <span className="inline-flex min-w-0 items-center justify-end gap-1">
+      {unit === "₿" && <span>{unit}</span>}
+      <span className="min-w-0 truncate">{amount}</span>
+      {unit !== "₿" && <span>{unit}</span>}
+    </span>
+  );
+}
+
+function formatBtcDisplay(amountSat: string | number | null | undefined) {
+  return (getNumericValue(amountSat) / SATS_PER_BTC).toFixed(8);
+}
+
+function formatBtcInput(amountSat: string | number | null | undefined) {
+  const amount = getNumericValue(amountSat);
+
+  if (!amount) {
+    return "";
+  }
+
+  return (amount / SATS_PER_BTC).toFixed(8);
 }
 
 export function CurrencyInputField({
@@ -138,6 +207,9 @@ export function CurrencyInputField({
   );
   const [mode, setMode] = React.useState<CurrencyInputMode>("bitcoin");
   const [fiatValue, setFiatValue] = React.useState("");
+  const [bitcoinDenomination, setBitcoinDenomination] =
+    React.useState<BitcoinDenomination>("sats");
+  const [btcValue, setBtcValue] = React.useState("");
 
   const currency = info?.currency || "USD";
   const rate = bitcoinRate?.rate_float;
@@ -150,10 +222,23 @@ export function CurrencyInputField({
     !!error;
   const inputId = id || generatedId;
   const isFiatMode = mode === "fiat";
-  const inputValue = isFiatMode ? fiatValue : valueSat;
-  const showLeadingUnit = isFiatMode || bitcoinUnit !== "sats";
+  const isBtcDenominated = bitcoinDenomination === "btc";
+  const inputValue = isFiatMode
+    ? fiatValue
+    : isBtcDenominated
+      ? btcValue
+      : valueSat;
+  const alternateBitcoinValue = formatBitcoinValueParts(
+    valueSat,
+    info?.bitcoinDisplayFormat,
+    bitcoinDenomination
+  );
   const alternateValue = isFiatMode
-    ? formatBitcoinValue(valueSat, info?.bitcoinDisplayFormat)
+    ? formatBitcoinValue(
+        valueSat,
+        info?.bitcoinDisplayFormat,
+        bitcoinDenomination
+      )
     : formatFiatValue(valueSat, rate, currency);
 
   React.useEffect(() => {
@@ -162,24 +247,102 @@ export function CurrencyInputField({
     }
   }, [mode, valueSat]);
 
+  React.useEffect(() => {
+    if (mode === "bitcoin" && isBtcDenominated && !valueSat) {
+      setBtcValue("");
+    }
+  }, [isBtcDenominated, mode, valueSat]);
+
   function handleToggleMode() {
-    if (!canUseFiat || disabled) {
+    if (disabled) {
       return;
     }
 
     if (mode === "bitcoin") {
+      if (!canUseFiat) {
+        return;
+      }
+
       setFiatValue(formatFiatInput(valueSat, rate, currency));
       setMode("fiat");
       return;
     }
 
+    if (isBtcDenominated) {
+      setBtcValue(formatBtcInput(valueSat));
+    }
+
     setMode("bitcoin");
   }
 
-  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+  function handleAlternateValueClick() {
+    if (disabled || isFiatMode || !canUseFiat) {
+      return;
+    }
+
+    handleToggleMode();
+  }
+
+  function handleToggleBitcoinDenomination() {
+    if (disabled) {
+      return;
+    }
+
+    if (isBtcDenominated) {
+      setBitcoinDenomination("sats");
+      return;
+    }
+
+    setBtcValue(formatBtcInput(valueSat));
+    setBitcoinDenomination("btc");
+  }
+
+  function handleChangeMode(event: React.ChangeEvent<HTMLInputElement>) {
     const nextValue = event.target.value.trim();
 
     if (mode === "bitcoin") {
+      if (!isBtcDenominated && nextValue.includes(".")) {
+        setBitcoinDenomination("btc");
+        setBtcValue(nextValue);
+        toast("Switched to BTC for decimal amount");
+
+        if (!nextValue) {
+          onValueSatChange("");
+          return;
+        }
+
+        const amountBtc = Number(nextValue);
+        if (!Number.isFinite(amountBtc)) {
+          onValueSatChange("");
+          return;
+        }
+
+        onValueSatChange(
+          Math.max(0, Math.round(amountBtc * SATS_PER_BTC)).toString()
+        );
+        return;
+      }
+
+      if (isBtcDenominated) {
+        setBtcValue(nextValue);
+
+        if (!nextValue) {
+          onValueSatChange("");
+          return;
+        }
+
+        const amountBtc = Number(nextValue);
+        if (!Number.isFinite(amountBtc)) {
+          onValueSatChange("");
+          return;
+        }
+
+        onValueSatChange(
+          Math.max(0, Math.round(amountBtc * SATS_PER_BTC)).toString()
+        );
+        return;
+      }
+
       onValueSatChange(nextValue);
       return;
     }
@@ -207,7 +370,15 @@ export function CurrencyInputField({
       return undefined;
     }
 
-    if (!isFiatMode || !rate) {
+    if (!isFiatMode) {
+      if (isBtcDenominated) {
+        return amountSat / SATS_PER_BTC;
+      }
+
+      return amountSat;
+    }
+
+    if (!rate) {
       return amountSat;
     }
 
@@ -221,86 +392,128 @@ export function CurrencyInputField({
       data-invalid={invalid || undefined}
     >
       {label && <FieldLabel htmlFor={inputId}>{label}</FieldLabel>}
-      <div
-        className={cn(
-          "w-full min-w-0 overflow-hidden rounded-md border border-input bg-background shadow-xs transition-[color,box-shadow]",
-          "focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50",
-          invalid &&
-            "border-destructive ring-destructive/20 focus-within:border-destructive focus-within:ring-destructive/20"
-        )}
-      >
-        <InputGroup className="h-9 min-w-0 rounded-none border-0 shadow-none">
-          <InputGroupInput
-            {...props}
-            id={inputId}
-            aria-invalid={invalid || undefined}
-            className={cn(
-              "sensitive slashed-zero min-w-0 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-            )}
-            disabled={disabled}
-            inputMode="decimal"
-            max={getModeBound(maxSat)}
-            min={getModeBound(minSat)}
-            onChange={handleChange}
-            placeholder={isFiatMode ? "0.00" : "0"}
-            required={required}
-            step={isFiatMode ? "any" : 1}
-            type="number"
-            value={inputValue}
-          />
-          {showLeadingUnit && (
-            <InputGroupAddon align="inline-start">
-              <InputGroupText>
-                {isFiatMode ? getCurrencySymbol(currency) : bitcoinUnit}
-              </InputGroupText>
-            </InputGroupAddon>
+      <InputGroup className="h-9 min-w-0 overflow-hidden has-[>[data-align=inline-start]]:[&>input]:pl-1">
+        <InputGroupInput
+          {...props}
+          id={inputId}
+          aria-invalid={invalid || undefined}
+          className={cn(
+            "sensitive slashed-zero min-w-0 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           )}
-          <InputGroupAddon
-            align="inline-end"
-            className="!mr-0 min-w-0 self-stretch gap-0 py-0 pr-0"
-          >
-            <InputGroupText className="sensitive slashed-zero mr-2 min-w-0 max-w-28 truncate tabular-nums sm:max-w-none">
-              {alternateValue ?? <Skeleton className="h-4 w-16" />}
-            </InputGroupText>
+          disabled={disabled}
+          inputMode="decimal"
+          max={getModeBound(maxSat)}
+          min={getModeBound(minSat)}
+          onChange={handleChangeMode}
+          placeholder={
+            isFiatMode ? "0.00" : isBtcDenominated ? "0.00000000" : "0"
+          }
+          required={required}
+          step={isFiatMode ? "any" : isBtcDenominated ? 0.00000001 : 1}
+          type="number"
+          value={inputValue}
+        />
+        <InputGroupAddon align="inline-start">
+          {isFiatMode ? (
+            <InputGroupButton
+              aria-label="Enter amount in bitcoin"
+              disabled={disabled}
+              onClick={handleToggleMode}
+              size="xs"
+              className="h-full rounded-none bg-transparent pl-2 pr-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
+              title="Enter amount in bitcoin"
+            >
+              {getCurrencySymbol(currency)}
+            </InputGroupButton>
+          ) : (
             <InputGroupButton
               aria-label={
-                isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
+                isBtcDenominated
+                  ? "Display bitcoin amounts in satoshis"
+                  : "Display bitcoin amounts in BTC"
               }
-              disabled={!canUseFiat || disabled}
-              onClick={handleToggleMode}
-              size="icon-sm"
-              className="!size-9 rounded-none border-l border-input p-0"
+              aria-pressed={isBtcDenominated}
+              disabled={disabled}
+              onClick={handleToggleBitcoinDenomination}
+              size="xs"
+              className="h-full rounded-none bg-transparent pl-2 pr-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
               title={
-                isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
+                isBtcDenominated
+                  ? "Display bitcoin amounts in satoshis"
+                  : "Display bitcoin amounts in BTC"
               }
             >
-              <ArrowRightLeftIcon className="size-4" />
+              {isBtcDenominated ? "BTC" : bitcoinUnit}
             </InputGroupButton>
-          </InputGroupAddon>
-        </InputGroup>
-        {!!contextRows?.length && (
-          <>
-            <Separator />
-            <div className="flex min-w-0 flex-col gap-2 px-3 py-2 text-sm text-muted-foreground">
-              {contextRows.map((row) => (
-                <div
-                  className="flex min-w-0 items-center justify-between gap-3"
-                  key={row.label}
-                >
-                  <span className="truncate">{row.label}:</span>
-                  <span className="sensitive slashed-zero min-w-0 max-w-[55%] truncate text-right tabular-nums">
-                    {row.value ??
-                      formatBitcoinValue(
-                        row.amountSat,
-                        info?.bitcoinDisplayFormat
-                      )}
-                  </span>
-                </div>
-              ))}
+          )}
+        </InputGroupAddon>
+        <InputGroupAddon
+          align="inline-end"
+          className="!mr-0 min-w-0 self-stretch py-0 pr-1"
+        >
+          {isFiatMode ? (
+            <InputGroupButton
+              aria-label={
+                isBtcDenominated
+                  ? "Display bitcoin amounts in satoshis"
+                  : "Display bitcoin amounts in BTC"
+              }
+              aria-pressed={isBtcDenominated}
+              disabled={disabled}
+              onClick={handleToggleBitcoinDenomination}
+              size="xs"
+              className="sensitive slashed-zero h-full min-w-0 justify-end truncate rounded-none bg-transparent px-0.5 text-muted-foreground tabular-nums hover:bg-transparent hover:text-foreground"
+              title={
+                isBtcDenominated
+                  ? "Display bitcoin amounts in satoshis"
+                  : "Display bitcoin amounts in BTC"
+              }
+            >
+              {alternateBitcoinValue.unit === "₿" && (
+                <span>{alternateBitcoinValue.unit}</span>
+              )}
+              <span className="min-w-0 truncate">
+                {alternateBitcoinValue.amount}
+              </span>
+              {alternateBitcoinValue.unit !== "₿" && (
+                <span>{alternateBitcoinValue.unit}</span>
+              )}
+            </InputGroupButton>
+          ) : (
+            <InputGroupButton
+              aria-label="Enter amount in fiat"
+              disabled={disabled || !canUseFiat}
+              onClick={handleAlternateValueClick}
+              size="xs"
+              className="sensitive slashed-zero h-full min-w-0 max-w-28 justify-end truncate rounded-none bg-transparent px-1 text-muted-foreground tabular-nums hover:bg-transparent hover:text-foreground sm:max-w-none"
+              title="Enter amount in fiat"
+            >
+              {alternateValue ?? <Skeleton className="h-4 w-16" />}
+            </InputGroupButton>
+          )}
+        </InputGroupAddon>
+      </InputGroup>
+      {!!contextRows?.length && (
+        <div className="flex min-w-0 cursor-default flex-col gap-1 text-sm text-muted-foreground">
+          {contextRows.map((row) => (
+            <div
+              className="flex min-w-0 items-center justify-between gap-3"
+              key={row.label}
+            >
+              <span className="truncate">{row.label}:</span>
+              <span className="sensitive slashed-zero min-w-0 max-w-[55%] truncate text-right tabular-nums">
+                {row.value ?? (
+                  <BitcoinValueText
+                    amountSat={row.amountSat}
+                    displayFormat={info?.bitcoinDisplayFormat}
+                    denomination={bitcoinDenomination}
+                  />
+                )}
+              </span>
             </div>
-          </>
-        )}
-      </div>
+          ))}
+        </div>
+      )}
       {description && <FieldDescription>{description}</FieldDescription>}
       {error && <FieldError>{error}</FieldError>}
     </Field>

--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -420,7 +420,7 @@ export function CurrencyInputField({
               disabled={disabled}
               onClick={handleToggleMode}
               size="xs"
-              className="h-full rounded-none bg-transparent pl-2 pr-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
+              className="h-full rounded-none bg-transparent pl-2 pr-0 text-muted-foreground hover:bg-transparent hover:text-foreground focus-visible:text-foreground focus-visible:ring-0"
               title="Enter amount in bitcoin"
             >
               {getCurrencySymbol(currency)}
@@ -436,7 +436,7 @@ export function CurrencyInputField({
               disabled={disabled}
               onClick={handleToggleBitcoinDenomination}
               size="xs"
-              className="h-full rounded-none bg-transparent pl-2 pr-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
+              className="h-full rounded-none bg-transparent pl-2 pr-0 text-muted-foreground hover:bg-transparent hover:text-foreground focus-visible:text-foreground focus-visible:ring-0"
               title={
                 isBtcDenominated
                   ? "Display bitcoin amounts in satoshis"
@@ -462,7 +462,7 @@ export function CurrencyInputField({
               disabled={disabled}
               onClick={handleToggleBitcoinDenomination}
               size="xs"
-              className="sensitive slashed-zero h-full min-w-0 justify-end truncate rounded-none bg-transparent px-0.5 text-muted-foreground tabular-nums hover:bg-transparent hover:text-foreground"
+              className="sensitive slashed-zero h-full min-w-0 justify-end truncate rounded-none bg-transparent px-0.5 text-muted-foreground tabular-nums hover:bg-transparent hover:text-foreground focus-visible:text-foreground focus-visible:ring-0"
               title={
                 isBtcDenominated
                   ? "Display bitcoin amounts in satoshis"
@@ -485,7 +485,7 @@ export function CurrencyInputField({
               disabled={disabled || !canUseFiat}
               onClick={handleAlternateValueClick}
               size="xs"
-              className="sensitive slashed-zero h-full min-w-0 max-w-28 justify-end truncate rounded-none bg-transparent px-1 text-muted-foreground tabular-nums hover:bg-transparent hover:text-foreground sm:max-w-none"
+              className="sensitive slashed-zero h-full min-w-0 max-w-28 justify-end truncate rounded-none bg-transparent px-1 text-muted-foreground tabular-nums hover:bg-transparent hover:text-foreground focus-visible:text-foreground focus-visible:ring-0 sm:max-w-none"
               title="Enter amount in fiat"
             >
               {alternateValue ?? <Skeleton className="h-4 w-16" />}

--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -1,0 +1,308 @@
+import { ArrowRightLeftIcon } from "lucide-react";
+import * as React from "react";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+} from "src/components/ui/field";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+  InputGroupText,
+} from "src/components/ui/input-group";
+import { Separator } from "src/components/ui/separator";
+import { Skeleton } from "src/components/ui/skeleton";
+import { BITCOIN_DISPLAY_FORMAT_BIP177 } from "src/constants";
+import { useBitcoinRate } from "src/hooks/useBitcoinRate";
+import { useInfo } from "src/hooks/useInfo";
+import { cn } from "src/lib/utils";
+
+type CurrencyInputMode = "bitcoin" | "fiat";
+
+export type CurrencyInputContextRow = {
+  label: string;
+  amountSat?: number | null;
+  value?: React.ReactNode;
+};
+
+type CurrencyInputFieldProps = Omit<
+  React.ComponentProps<typeof InputGroupInput>,
+  "max" | "min" | "onChange" | "step" | "type" | "value"
+> & {
+  contextRows?: CurrencyInputContextRow[];
+  description?: React.ReactNode;
+  error?: React.ReactNode;
+  label?: React.ReactNode;
+  maxSat?: number;
+  minSat?: number;
+  onValueSatChange: (valueSat: string) => void;
+  valueSat: string;
+};
+
+const SATS_PER_BTC = 100_000_000;
+
+function getNumericValue(value: string | number | null | undefined) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function getCurrencyFractionDigits(currency: string) {
+  try {
+    return new Intl.NumberFormat("en-US", {
+      currency,
+      style: "currency",
+    }).resolvedOptions().maximumFractionDigits;
+  } catch {
+    return 2;
+  }
+}
+
+function getCurrencySymbol(currency: string) {
+  try {
+    return (
+      new Intl.NumberFormat("en-US", {
+        currency,
+        style: "currency",
+      })
+        .formatToParts(0)
+        .find((part) => part.type === "currency")?.value || currency
+    );
+  } catch {
+    return currency;
+  }
+}
+
+function formatFiatValue(
+  amountSat: string | number | undefined,
+  rate: number | undefined,
+  currency: string | undefined
+) {
+  if (!rate || !currency) {
+    return null;
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    currency,
+    style: "currency",
+  }).format((getNumericValue(amountSat) / SATS_PER_BTC) * rate);
+}
+
+function formatFiatInput(amountSat: string, rate: number, currency: string) {
+  const fractionDigits = getCurrencyFractionDigits(currency);
+  const amountFiat = (getNumericValue(amountSat) / SATS_PER_BTC) * rate;
+
+  if (!amountFiat) {
+    return "";
+  }
+
+  return amountFiat.toFixed(fractionDigits);
+}
+
+function formatBitcoinValue(
+  amountSat: string | number | null | undefined,
+  displayFormat: string | undefined
+) {
+  const formattedAmount = new Intl.NumberFormat().format(
+    Math.floor(getNumericValue(amountSat))
+  );
+
+  if (displayFormat === BITCOIN_DISPLAY_FORMAT_BIP177) {
+    return `₿${formattedAmount}`;
+  }
+
+  return `${formattedAmount} sats`;
+}
+
+export function CurrencyInputField({
+  className,
+  contextRows,
+  description,
+  disabled,
+  error,
+  id,
+  label = "Amount",
+  maxSat,
+  minSat,
+  onValueSatChange,
+  required,
+  valueSat,
+  ...props
+}: CurrencyInputFieldProps) {
+  const generatedId = React.useId();
+  const { data: info } = useInfo();
+  const { data: bitcoinRate, error: bitcoinRateError } = useBitcoinRate(
+    info?.currency
+  );
+  const [mode, setMode] = React.useState<CurrencyInputMode>("bitcoin");
+  const [fiatValue, setFiatValue] = React.useState("");
+
+  const currency = info?.currency || "USD";
+  const rate = bitcoinRate?.rate_float;
+  const canUseFiat = currency !== "SATS" && !!rate && !bitcoinRateError;
+  const bitcoinUnit =
+    info?.bitcoinDisplayFormat === BITCOIN_DISPLAY_FORMAT_BIP177 ? "₿" : "sats";
+  const invalid =
+    props["aria-invalid"] === true ||
+    props["aria-invalid"] === "true" ||
+    !!error;
+  const inputId = id || generatedId;
+  const isFiatMode = mode === "fiat";
+  const inputValue = isFiatMode ? fiatValue : valueSat;
+  const showLeadingUnit = isFiatMode || bitcoinUnit !== "sats";
+  const alternateValue = isFiatMode
+    ? formatBitcoinValue(valueSat, info?.bitcoinDisplayFormat)
+    : formatFiatValue(valueSat, rate, currency);
+
+  React.useEffect(() => {
+    if (mode === "fiat" && !valueSat) {
+      setFiatValue("");
+    }
+  }, [mode, valueSat]);
+
+  function handleToggleMode() {
+    if (!canUseFiat || disabled) {
+      return;
+    }
+
+    if (mode === "bitcoin") {
+      setFiatValue(formatFiatInput(valueSat, rate, currency));
+      setMode("fiat");
+      return;
+    }
+
+    setMode("bitcoin");
+  }
+
+  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const nextValue = event.target.value.trim();
+
+    if (mode === "bitcoin") {
+      onValueSatChange(nextValue);
+      return;
+    }
+
+    setFiatValue(nextValue);
+
+    if (!nextValue || !rate) {
+      onValueSatChange("");
+      return;
+    }
+
+    const amountFiat = Number(nextValue);
+    if (!Number.isFinite(amountFiat)) {
+      onValueSatChange("");
+      return;
+    }
+
+    onValueSatChange(
+      Math.max(0, Math.round((amountFiat / rate) * SATS_PER_BTC)).toString()
+    );
+  }
+
+  function getModeBound(amountSat: number | undefined) {
+    if (amountSat === undefined) {
+      return undefined;
+    }
+
+    if (!isFiatMode || !rate) {
+      return amountSat;
+    }
+
+    return (amountSat / SATS_PER_BTC) * rate;
+  }
+
+  return (
+    <Field
+      className={cn("w-full min-w-0", className)}
+      data-disabled={disabled || undefined}
+      data-invalid={invalid || undefined}
+    >
+      {label && <FieldLabel htmlFor={inputId}>{label}</FieldLabel>}
+      <div
+        className={cn(
+          "w-full min-w-0 overflow-hidden rounded-md border border-input bg-background shadow-xs transition-[color,box-shadow]",
+          "focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50",
+          invalid &&
+            "border-destructive ring-destructive/20 focus-within:border-destructive focus-within:ring-destructive/20"
+        )}
+      >
+        <InputGroup className="h-9 min-w-0 rounded-none border-0 shadow-none">
+          <InputGroupInput
+            {...props}
+            id={inputId}
+            aria-invalid={invalid || undefined}
+            className={cn(
+              "sensitive slashed-zero min-w-0 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            )}
+            disabled={disabled}
+            inputMode="decimal"
+            max={getModeBound(maxSat)}
+            min={getModeBound(minSat)}
+            onChange={handleChange}
+            placeholder={isFiatMode ? "0.00" : "0"}
+            required={required}
+            step={isFiatMode ? "any" : 1}
+            type="number"
+            value={inputValue}
+          />
+          {showLeadingUnit && (
+            <InputGroupAddon align="inline-start">
+              <InputGroupText>
+                {isFiatMode ? getCurrencySymbol(currency) : bitcoinUnit}
+              </InputGroupText>
+            </InputGroupAddon>
+          )}
+          <InputGroupAddon
+            align="inline-end"
+            className="!mr-0 min-w-0 self-stretch gap-0 py-0 pr-0"
+          >
+            <InputGroupText className="sensitive slashed-zero mr-2 min-w-0 max-w-28 truncate tabular-nums sm:max-w-none">
+              {alternateValue ?? <Skeleton className="h-4 w-16" />}
+            </InputGroupText>
+            <InputGroupButton
+              aria-label={
+                isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
+              }
+              disabled={!canUseFiat || disabled}
+              onClick={handleToggleMode}
+              size="icon-sm"
+              className="!size-9 rounded-none border-l border-input p-0"
+              title={
+                isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
+              }
+            >
+              <ArrowRightLeftIcon className="size-4" />
+            </InputGroupButton>
+          </InputGroupAddon>
+        </InputGroup>
+        {!!contextRows?.length && (
+          <>
+            <Separator />
+            <div className="flex min-w-0 flex-col gap-2 px-3 py-2 text-sm text-muted-foreground">
+              {contextRows.map((row) => (
+                <div
+                  className="flex min-w-0 items-center justify-between gap-3"
+                  key={row.label}
+                >
+                  <span className="truncate">{row.label}:</span>
+                  <span className="sensitive slashed-zero min-w-0 max-w-[55%] truncate text-right tabular-nums">
+                    {row.value ??
+                      formatBitcoinValue(
+                        row.amountSat,
+                        info?.bitcoinDisplayFormat
+                      )}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+      {description && <FieldDescription>{description}</FieldDescription>}
+      {error && <FieldError>{error}</FieldError>}
+    </Field>
+  );
+}

--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -452,7 +452,7 @@ export function CurrencyInputField({
         </InputGroupAddon>
         <InputGroupAddon
           align="inline-end"
-          className="!mr-0 min-w-0 self-stretch py-0 pr-1"
+          className="mr-0 min-w-0 self-stretch py-0 pr-4"
         >
           {isFiatMode ? (
             <InputGroupButton

--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -382,7 +382,7 @@ export function CurrencyInputField({
       return amountSat;
     }
 
-    return (amountSat / SATS_PER_BTC) * rate;
+    return ((amountSat / SATS_PER_BTC) * rate).toFixed(2);
   }
 
   return (

--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -382,7 +382,9 @@ export function CurrencyInputField({
       return amountSat;
     }
 
-    return ((amountSat / SATS_PER_BTC) * rate).toFixed(2);
+    return ((amountSat / SATS_PER_BTC) * rate).toFixed(
+      getCurrencyFractionDigits(currency)
+    );
   }
 
   return (

--- a/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
@@ -202,14 +202,22 @@ export default function ReceiveInvoice() {
                   valueSat={amountSat}
                   onValueSatChange={setAmountSat}
                   minSat={1}
-                  maxSat={balances.lightning.totalReceivableSat}
+                  maxSat={
+                    hasChannelManagement
+                      ? balances.lightning.totalReceivableSat
+                      : undefined
+                  }
                   autoFocus
-                  contextRows={[
-                    {
-                      label: "Receive limit",
-                      amountSat: balances.lightning.totalReceivableSat,
-                    },
-                  ]}
+                  contextRows={
+                    hasChannelManagement
+                      ? [
+                          {
+                            label: "Receive limit",
+                            amountSat: balances.lightning.totalReceivableSat,
+                          },
+                        ]
+                      : undefined
+                  }
                 />
                 <div className="grid gap-2">
                   <Label htmlFor="description">Description</Label>

--- a/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
@@ -255,7 +255,7 @@ export default function ReceiveInvoice() {
                       className="w-full"
                     >
                       <LinkIcon className="h-4 w-4" />
-                      Receive from On-chain
+                      Receive from On-chain / Other Cryptocurrency
                     </LinkButton>
                   </div>
                 )}

--- a/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
@@ -9,6 +9,7 @@ import TickSVG from "public/images/illustrations/tick.svg";
 import React from "react";
 import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
+import { CurrencyInputField } from "src/components/CurrencyInputField";
 import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import FormattedFiatAmount from "src/components/FormattedFiatAmount";
 import Loading from "src/components/Loading";
@@ -23,7 +24,6 @@ import {
   CardTitle,
 } from "src/components/ui/card";
 import { ExternalLinkButton } from "src/components/ui/custom/external-link-button";
-import { InputWithAdornment } from "src/components/ui/custom/input-with-adornment";
 import { LinkButton } from "src/components/ui/custom/link-button";
 import { LoadingButton } from "src/components/ui/custom/loading-button";
 import { Input } from "src/components/ui/input";
@@ -197,26 +197,20 @@ export default function ReceiveInvoice() {
               </Card>
             ) : (
               <form onSubmit={handleSubmit} className="grid gap-6">
-                <div className="grid gap-2">
-                  <Label htmlFor="amount">Amount</Label>
-                  <InputWithAdornment
-                    id="amount"
-                    type="number"
-                    value={amountSat?.toString()}
-                    placeholder="Amount in Satoshi..."
-                    onChange={(e) => {
-                      setAmountSat(e.target.value.trim());
-                    }}
-                    min={1}
-                    autoFocus
-                    endAdornment={
-                      <FormattedFiatAmount
-                        amountSat={+amountSat}
-                        className="mr-2"
-                      />
-                    }
-                  />
-                </div>
+                <CurrencyInputField
+                  id="amount"
+                  valueSat={amountSat}
+                  onValueSatChange={setAmountSat}
+                  minSat={1}
+                  maxSat={balances.lightning.totalReceivableSat}
+                  autoFocus
+                  contextRows={[
+                    {
+                      label: "Receive limit",
+                      amountSat: balances.lightning.totalReceivableSat,
+                    },
+                  ]}
+                />
                 <div className="grid gap-2">
                   <Label htmlFor="description">Description</Label>
                   <Input
@@ -261,7 +255,7 @@ export default function ReceiveInvoice() {
                       className="w-full"
                     >
                       <LinkIcon className="h-4 w-4" />
-                      Receive from On-chain / Other Cryptocurrency
+                      Receive from On-chain
                     </LinkButton>
                   </div>
                 )}

--- a/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
@@ -88,7 +88,9 @@ export default function ReceiveOnchain() {
       if (!swapInResponse) {
         throw new Error("Error swapping in");
       }
-      navigate(`/wallet/swap/in/status/${swapInResponse.swapId}`);
+      navigate(`/wallet/swap/in/status/${swapInResponse.swapId}`, {
+        replace: true,
+      });
       toast("Initiated swap");
     } catch (error) {
       toast.error("Failed to initiate swap", {

--- a/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
@@ -134,19 +134,27 @@ export default function ReceiveOnchain() {
                 }
                 maxSat={
                   swapFrom === "bitcoin"
-                    ? Math.min(
-                        swapInfo.maxAmountSat,
-                        balances.lightning.totalReceivableSat * 0.99
-                      )
-                    : balances.lightning.totalReceivableSat * 0.99
+                    ? hasChannelManagement
+                      ? Math.min(
+                          swapInfo.maxAmountSat,
+                          balances.lightning.totalReceivableSat * 0.99
+                        )
+                      : swapInfo.maxAmountSat
+                    : hasChannelManagement
+                      ? balances.lightning.totalReceivableSat * 0.99
+                      : undefined
                 }
                 required
-                contextRows={[
-                  {
-                    label: "Receive limit",
-                    amountSat: balances.lightning.totalReceivableSat,
-                  },
-                ]}
+                contextRows={
+                  hasChannelManagement
+                    ? [
+                        {
+                          label: "Receive limit",
+                          amountSat: balances.lightning.totalReceivableSat,
+                        },
+                      ]
+                    : undefined
+                }
               />
               <div className="flex flex-col gap-4">
                 <Label>Swap from</Label>

--- a/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
@@ -2,13 +2,11 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
+import { CurrencyInputField } from "src/components/CurrencyInputField";
 import { FixedFloatSwapInFlow } from "src/components/FixedFloatSwapInFlow";
-import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
-import FormattedFiatAmount from "src/components/FormattedFiatAmount";
 import Loading from "src/components/Loading";
 import LowReceivingCapacityAlert from "src/components/LowReceivingCapacityAlert";
 import { MempoolAlert } from "src/components/MempoolAlert";
-import { InputWithAdornment } from "src/components/ui/custom/input-with-adornment";
 import { LoadingButton } from "src/components/ui/custom/loading-button";
 import { Label } from "src/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "src/components/ui/radio-group";
@@ -90,9 +88,7 @@ export default function ReceiveOnchain() {
       if (!swapInResponse) {
         throw new Error("Error swapping in");
       }
-      navigate(`/wallet/swap/in/status/${swapInResponse.swapId}`, {
-        replace: true,
-      });
+      navigate(`/wallet/swap/in/status/${swapInResponse.swapId}`);
       toast("Initiated swap");
     } catch (error) {
       toast.error("Failed to initiate swap", {
@@ -126,48 +122,30 @@ export default function ReceiveOnchain() {
                   0.8 * balances.lightning.totalReceivableMsat && (
                   <LowReceivingCapacityAlert />
                 )}
-              <div className="grid gap-1.5">
-                <Label>Amount</Label>
-                <InputWithAdornment
-                  type="number"
-                  autoFocus
-                  placeholder="Amount in satoshis"
-                  value={swapAmountSat}
-                  min={
-                    swapFrom === "bitcoin" ? swapInfo.minAmountSat : undefined
-                  }
-                  max={
-                    swapFrom === "bitcoin"
-                      ? Math.min(
-                          swapInfo.maxAmountSat,
-                          balances.lightning.totalReceivableSat * 0.99
-                        )
-                      : balances.lightning.totalReceivableSat * 0.99
-                  }
-                  onChange={(e) => setSwapAmountSat(e.target.value)}
-                  required
-                  endAdornment={
-                    <FormattedFiatAmount
-                      amountSat={+swapAmountSat}
-                      className="mr-2"
-                    />
-                  }
-                />
-                <div className="grid">
-                  <div className="flex justify-between text-muted-foreground text-xs sensitive slashed-zero">
-                    <div>
-                      Receiving Capacity:{" "}
-                      <FormattedBitcoinAmount
-                        amountMsat={balances.lightning.totalReceivableMsat}
-                      />
-                    </div>
-                    <FormattedFiatAmount
-                      className="text-xs"
-                      amountSat={balances.lightning.totalReceivableSat}
-                    />
-                  </div>
-                </div>
-              </div>
+              <CurrencyInputField
+                label="Amount"
+                autoFocus
+                valueSat={swapAmountSat}
+                onValueSatChange={setSwapAmountSat}
+                minSat={
+                  swapFrom === "bitcoin" ? swapInfo.minAmountSat : undefined
+                }
+                maxSat={
+                  swapFrom === "bitcoin"
+                    ? Math.min(
+                        swapInfo.maxAmountSat,
+                        balances.lightning.totalReceivableSat * 0.99
+                      )
+                    : balances.lightning.totalReceivableSat * 0.99
+                }
+                required
+                contextRows={[
+                  {
+                    label: "Receive limit",
+                    amountSat: balances.lightning.totalReceivableSat,
+                  },
+                ]}
+              />
               <div className="flex flex-col gap-4">
                 <Label>Swap from</Label>
                 <RadioGroup

--- a/frontend/src/screens/wallet/send/LnurlPay.tsx
+++ b/frontend/src/screens/wallet/send/LnurlPay.tsx
@@ -5,13 +5,11 @@ import React from "react";
 import { Link, useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
-import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
-import FormattedFiatAmount from "src/components/FormattedFiatAmount";
+import { CurrencyInputField } from "src/components/CurrencyInputField";
 import { InsufficientLightningBalanceAlert } from "src/components/InsufficientLightningBalanceAlert";
 import Loading from "src/components/Loading";
 import { PaymentFailedAlert } from "src/components/PaymentFailedAlert";
 import { PendingPaymentAlert } from "src/components/PendingPaymentAlert";
-import { InputWithAdornment } from "src/components/ui/custom/input-with-adornment";
 import { LinkButton } from "src/components/ui/custom/link-button";
 import { LoadingButton } from "src/components/ui/custom/loading-button";
 import { Input } from "src/components/ui/input";
@@ -136,42 +134,21 @@ export default function LnurlPay() {
               </p>
             </div>
           )}
-          <div className="grid gap-2">
-            <Label htmlFor="amount">Amount</Label>
-            <InputWithAdornment
-              id="amount"
-              type="number"
-              value={amountSat}
-              placeholder="Amount in Satoshi..."
-              onChange={(e) => {
-                setAmountSat(e.target.value.trim());
-              }}
-              min={1}
-              max={balances.lightning.totalSpendableSat}
-              required
-              autoFocus
-              endAdornment={
-                <FormattedFiatAmount
-                  amountSat={Number(amountSat)}
-                  className="mr-2"
-                />
-              }
-            />
-            <div className="grid gap-2">
-              <div className="flex justify-between text-xs text-muted-foreground sensitive slashed-zero">
-                <div>
-                  Lightning Balance:{" "}
-                  <FormattedBitcoinAmount
-                    amountMsat={balances.lightning.totalSpendableMsat}
-                  />
-                </div>
-                <FormattedFiatAmount
-                  className="text-xs"
-                  amountSat={balances.lightning.totalSpendableSat}
-                />
-              </div>
-            </div>
-          </div>
+          <CurrencyInputField
+            id="amount"
+            valueSat={amountSat}
+            onValueSatChange={setAmountSat}
+            minSat={1}
+            maxSat={balances.lightning.totalSpendableSat}
+            required
+            autoFocus
+            contextRows={[
+              {
+                label: "Spending balance",
+                amountSat: balances.lightning.totalSpendableSat,
+              },
+            ]}
+          />
           {!!lnAddress.lnurlpData?.commentAllowed && (
             <div className="grid gap-2">
               <Label htmlFor="comment">Comment</Label>

--- a/frontend/src/screens/wallet/send/LnurlPay.tsx
+++ b/frontend/src/screens/wallet/send/LnurlPay.tsx
@@ -144,7 +144,7 @@ export default function LnurlPay() {
             autoFocus
             contextRows={[
               {
-                label: "Spending balance",
+                label: "Lightning balance",
                 amountSat: balances.lightning.totalSpendableSat,
               },
             ]}

--- a/frontend/src/screens/wallet/send/Onchain.tsx
+++ b/frontend/src/screens/wallet/send/Onchain.tsx
@@ -10,8 +10,8 @@ import { Link, useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { AnchorReserveAlert } from "src/components/AnchorReserveAlert";
 import AppHeader from "src/components/AppHeader";
-import ExternalLink from "src/components/ExternalLink";
 import { CurrencyInputField } from "src/components/CurrencyInputField";
+import ExternalLink from "src/components/ExternalLink";
 import { InsufficientLightningBalanceAlert } from "src/components/InsufficientLightningBalanceAlert";
 import Loading from "src/components/Loading";
 import { MempoolAlert } from "src/components/MempoolAlert";
@@ -371,7 +371,7 @@ function SwapForm({
         autoFocus
         contextRows={[
           {
-            label: "Spending balance",
+            label: "Lightning balance",
             amountSat: balances.lightning.totalSpendableSat,
           },
           {

--- a/frontend/src/screens/wallet/send/Onchain.tsx
+++ b/frontend/src/screens/wallet/send/Onchain.tsx
@@ -11,14 +11,12 @@ import { toast } from "sonner";
 import { AnchorReserveAlert } from "src/components/AnchorReserveAlert";
 import AppHeader from "src/components/AppHeader";
 import ExternalLink from "src/components/ExternalLink";
-import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
-import FormattedFiatAmount from "src/components/FormattedFiatAmount";
+import { CurrencyInputField } from "src/components/CurrencyInputField";
 import { InsufficientLightningBalanceAlert } from "src/components/InsufficientLightningBalanceAlert";
 import Loading from "src/components/Loading";
 import { MempoolAlert } from "src/components/MempoolAlert";
 import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
 import { Button } from "src/components/ui/button";
-import { InputWithAdornment } from "src/components/ui/custom/input-with-adornment";
 import { LinkButton } from "src/components/ui/custom/link-button";
 import { LoadingButton } from "src/components/ui/custom/loading-button";
 import { Input } from "src/components/ui/input";
@@ -190,40 +188,21 @@ function OnchainForm({
 
   return (
     <form onSubmit={onSubmit} className="grid gap-6">
-      <div className="grid gap-2">
-        <Label htmlFor="amount">Amount</Label>
-        <InputWithAdornment
-          id="amount"
-          type="number"
-          value={amountSat}
-          placeholder="Amount in Satoshi..."
-          onChange={(e) => {
-            setAmountSat(e.target.value.trim());
-          }}
-          min={ONCHAIN_DUST_SATS}
-          max={balances.onchain.spendableSat}
-          required
-          autoFocus
-          endAdornment={
-            <FormattedFiatAmount
-              amountSat={Number(amountSat)}
-              className="mr-2"
-            />
-          }
-        />
-        <div className="flex justify-between text-muted-foreground text-xs sensitive slashed-zero">
-          <div>
-            On-chain Balance:{" "}
-            <FormattedBitcoinAmount
-              amountMsat={balances.onchain.spendableSat * 1000}
-            />
-          </div>
-          <FormattedFiatAmount
-            className="text-xs"
-            amountSat={balances.onchain.spendableSat}
-          />
-        </div>
-      </div>
+      <CurrencyInputField
+        id="amount"
+        valueSat={amountSat}
+        onValueSatChange={setAmountSat}
+        minSat={ONCHAIN_DUST_SATS}
+        maxSat={balances.onchain.spendableSat}
+        required
+        autoFocus
+        contextRows={[
+          {
+            label: "On-chain available",
+            amountSat: balances.onchain.spendableSat,
+          },
+        ]}
+      />
       <div className="flex items-center justify-between">
         <Label htmlFor="swap" className="cursor-pointer">
           Swap from Lightning Balance
@@ -379,57 +358,28 @@ function SwapForm({
 
   return (
     <form onSubmit={onSubmit} className="grid gap-6">
-      <div className="grid gap-2">
-        <Label htmlFor="amount">Amount</Label>
-        <InputWithAdornment
-          id="amount"
-          type="number"
-          value={amountSat}
-          placeholder="Amount in Satoshi..."
-          onChange={(e) => {
-            setAmountSat(e.target.value.trim());
-          }}
-          min={swapInfo.minAmountSat}
-          max={Math.min(
-            swapInfo.maxAmountSat,
-            balances.lightning.totalSpendableSat
-          )}
-          required
-          autoFocus
-          endAdornment={
-            <FormattedFiatAmount
-              amountSat={Number(amountSat)}
-              className="mr-2"
-            />
-          }
-        />
-        <div className="grid gap-1">
-          <div className="flex justify-between text-xs text-muted-foreground sensitive slashed-zero">
-            <div>
-              Lightning Balance:{" "}
-              <FormattedBitcoinAmount
-                amountMsat={balances.lightning.totalSpendableMsat}
-              />
-            </div>
-            <FormattedFiatAmount
-              className="text-xs"
-              amountSat={balances.lightning.totalSpendableSat}
-            />
-          </div>
-          <div className="flex justify-between text-muted-foreground text-xs sensitive slashed-zero">
-            <div>
-              Minimum:{" "}
-              <FormattedBitcoinAmount
-                amountMsat={swapInfo.minAmountSat * 1000}
-              />
-            </div>
-            <FormattedFiatAmount
-              className="text-xs"
-              amountSat={swapInfo.minAmountSat}
-            />
-          </div>
-        </div>
-      </div>
+      <CurrencyInputField
+        id="amount"
+        valueSat={amountSat}
+        onValueSatChange={setAmountSat}
+        minSat={swapInfo.minAmountSat}
+        maxSat={Math.min(
+          swapInfo.maxAmountSat,
+          balances.lightning.totalSpendableSat
+        )}
+        required
+        autoFocus
+        contextRows={[
+          {
+            label: "Spending balance",
+            amountSat: balances.lightning.totalSpendableSat,
+          },
+          {
+            label: "Minimum",
+            amountSat: swapInfo.minAmountSat,
+          },
+        ]}
+      />
       <div className="flex items-center justify-between">
         <Label htmlFor="swap" className="cursor-pointer">
           Swap from Lightning Balance

--- a/frontend/src/screens/wallet/send/ZeroAmount.tsx
+++ b/frontend/src/screens/wallet/send/ZeroAmount.tsx
@@ -127,7 +127,7 @@ export default function ZeroAmount() {
           autoFocus
           contextRows={[
             {
-              label: "Spending balance",
+              label: "Lightning balance",
               amountSat: balances.lightning.totalSpendableSat,
             },
           ]}

--- a/frontend/src/screens/wallet/send/ZeroAmount.tsx
+++ b/frontend/src/screens/wallet/send/ZeroAmount.tsx
@@ -6,13 +6,11 @@ import { XIcon } from "lucide-react";
 import { Link, useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
-import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
-import FormattedFiatAmount from "src/components/FormattedFiatAmount";
+import { CurrencyInputField } from "src/components/CurrencyInputField";
 import { InsufficientLightningBalanceAlert } from "src/components/InsufficientLightningBalanceAlert";
 import Loading from "src/components/Loading";
 import { PaymentFailedAlert } from "src/components/PaymentFailedAlert";
 import { PendingPaymentAlert } from "src/components/PendingPaymentAlert";
-import { InputWithAdornment } from "src/components/ui/custom/input-with-adornment";
 import { LinkButton } from "src/components/ui/custom/link-button";
 import { LoadingButton } from "src/components/ui/custom/loading-button";
 import { useBalances } from "src/hooks/useBalances";
@@ -119,42 +117,21 @@ export default function ZeroAmount() {
             </p>
           </div>
         )}
-        <div className="grid gap-2">
-          <Label htmlFor="amount">Amount</Label>
-          <InputWithAdornment
-            id="amount"
-            type="number"
-            value={amountSat}
-            placeholder="Amount in Satoshi..."
-            onChange={(e) => {
-              setAmountSat(e.target.value.trim());
-            }}
-            min={1}
-            max={balances.lightning.totalSpendableSat}
-            required
-            autoFocus
-            endAdornment={
-              <FormattedFiatAmount
-                amountSat={Number(amountSat)}
-                className="mr-2"
-              />
-            }
-          />
-          <div className="grid gap-2">
-            <div className="flex justify-between text-xs text-muted-foreground sensitive slashed-zero">
-              <div>
-                Lightning Balance:{" "}
-                <FormattedBitcoinAmount
-                  amountMsat={balances.lightning.totalSpendableMsat}
-                />
-              </div>
-              <FormattedFiatAmount
-                className="text-xs"
-                amountSat={balances.lightning.totalSpendableSat}
-              />
-            </div>
-          </div>
-        </div>
+        <CurrencyInputField
+          id="amount"
+          valueSat={amountSat}
+          onValueSatChange={setAmountSat}
+          minSat={1}
+          maxSat={balances.lightning.totalSpendableSat}
+          required
+          autoFocus
+          contextRows={[
+            {
+              label: "Spending balance",
+              amountSat: balances.lightning.totalSpendableSat,
+            },
+          ]}
+        />
         <PayFromSelect appId={appId} onChange={setAppId} />
         <InsufficientLightningBalanceAlert amountSat={+amountSat} />
         <div className="flex gap-2">

--- a/frontend/src/screens/wallet/swap/AutoSwap.tsx
+++ b/frontend/src/screens/wallet/swap/AutoSwap.tsx
@@ -9,6 +9,7 @@ import {
 import { useState } from "react";
 import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
+import { CurrencyInputField } from "src/components/CurrencyInputField";
 import ExternalLink from "src/components/ExternalLink";
 import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import Loading from "src/components/Loading";
@@ -160,37 +161,29 @@ function AutoSwapOutForm() {
           </p>
         </div>
 
-        <div className="grid gap-1.5">
-          <Label>Lightning balance threshold</Label>
-          <Input
-            type="number"
-            placeholder="Amount in satoshis"
-            value={balanceThresholdSat}
-            min={swapAmountSat}
-            onChange={(e) => setBalanceThresholdSat(e.target.value)}
-            required
-          />
-          <p className="text-xs text-muted-foreground">
-            Swap out as soon as this amount is reached
-          </p>
-        </div>
+        <CurrencyInputField
+          label="Spending balance threshold"
+          valueSat={balanceThresholdSat}
+          onValueSatChange={setBalanceThresholdSat}
+          minSat={Number(swapAmountSat) || undefined}
+          required
+          description="Swap out as soon as this amount is reached"
+        />
 
-        <div className="grid gap-1.5">
-          <Label>Swap amount</Label>
-          <Input
-            type="number"
-            placeholder="Amount in satoshis"
-            value={swapAmountSat}
-            min={swapInfo.minAmountSat}
-            max={swapInfo.maxAmountSat}
-            onChange={(e) => setSwapAmountSat(e.target.value)}
-            required
-          />
-          <p className="text-xs text-muted-foreground">
-            Minimum{" "}
-            <FormattedBitcoinAmount amountMsat={swapInfo.minAmountSat * 1000} />
-          </p>
-        </div>
+        <CurrencyInputField
+          label="Swap amount"
+          valueSat={swapAmountSat}
+          onValueSatChange={setSwapAmountSat}
+          minSat={swapInfo.minAmountSat}
+          maxSat={swapInfo.maxAmountSat}
+          required
+          contextRows={[
+            {
+              label: "Minimum",
+              amountSat: swapInfo.minAmountSat,
+            },
+          ]}
+        />
         <div className="flex flex-col gap-4">
           <Label>Swap to</Label>
           <RadioGroup
@@ -425,7 +418,7 @@ function ActiveSwapOutConfig({ swapConfig }: { swapConfig: AutoSwapConfig }) {
         </div>
         <div className="flex justify-between items-center gap-2">
           <span className="font-medium truncate">
-            Lightning balance threshold
+            Spending balance threshold
           </span>
           <span className="shrink-0 text-muted-foreground text-right">
             <FormattedBitcoinAmount

--- a/frontend/src/screens/wallet/swap/AutoSwap.tsx
+++ b/frontend/src/screens/wallet/swap/AutoSwap.tsx
@@ -162,7 +162,7 @@ function AutoSwapOutForm() {
         </div>
 
         <CurrencyInputField
-          label="Spending balance threshold"
+          label="Lightning balance threshold"
           valueSat={balanceThresholdSat}
           onValueSatChange={setBalanceThresholdSat}
           minSat={Number(swapAmountSat) || undefined}
@@ -418,7 +418,7 @@ function ActiveSwapOutConfig({ swapConfig }: { swapConfig: AutoSwapConfig }) {
         </div>
         <div className="flex justify-between items-center gap-2">
           <span className="font-medium truncate">
-            Spending balance threshold
+            Lightning balance threshold
           </span>
           <span className="shrink-0 text-muted-foreground text-right">
             <FormattedBitcoinAmount

--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -7,6 +7,7 @@ import {
 import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
+import { AnchorReserveAlert } from "src/components/AnchorReserveAlert";
 import AppHeader from "src/components/AppHeader";
 import { CurrencyInputField } from "src/components/CurrencyInputField";
 import { FixedFloatButton } from "src/components/FixedFloatButton";
@@ -27,7 +28,6 @@ import {
   TabsTrigger,
 } from "src/components/ui/tabs";
 import { useBalances } from "src/hooks/useBalances";
-import { useChannels } from "src/hooks/useChannels";
 import { useInfo } from "src/hooks/useInfo";
 import { useSwapInfo } from "src/hooks/useSwaps";
 import {
@@ -94,7 +94,6 @@ function SwapInForm() {
   const { data: info, hasChannelManagement } = useInfo();
   const { data: balances } = useBalances();
   const { data: swapInfo } = useSwapInfo("in");
-  const { data: channels } = useChannels();
   const navigate = useNavigate();
 
   const [swapAmountSat, setSwapAmountSat] = useState("");
@@ -159,10 +158,7 @@ function SwapInForm() {
     return <Loading />;
   }
 
-  const spendableOnchainBalanceSatWithAnchorReserves = Math.max(
-    balances.onchain.spendableSat - (channels?.length || 0) * 25000,
-    0
-  );
+  const spendableOnchainBalance = balances.onchain.spendableSat;
   const isInternalSwap = swapFrom === "internal";
   const isCryptoSwappingState =
     swapFrom === "crypto" && cryptoTransaction !== null;
@@ -188,6 +184,9 @@ function SwapInForm() {
                 </div>
               )}
 
+            {isInternalSwap && (
+              <AnchorReserveAlert amountSat={+swapAmountSat} />
+            )}
             <CurrencyInputField
               label="Swap amount"
               autoFocus
@@ -201,9 +200,7 @@ function SwapInForm() {
                     : undefined
                   : Math.min(
                       swapInfo.maxAmountSat,
-                      ...(isInternalSwap
-                        ? [spendableOnchainBalanceSatWithAnchorReserves]
-                        : []),
+                      ...(isInternalSwap ? [spendableOnchainBalance] : []),
                       ...(hasChannelManagement
                         ? [balances.lightning.totalReceivableSat * 0.99]
                         : [])
@@ -215,7 +212,7 @@ function SwapInForm() {
                   ? [
                       {
                         label: "Available on-chain",
-                        amountSat: spendableOnchainBalanceSatWithAnchorReserves,
+                        amountSat: spendableOnchainBalance,
                       },
                     ]
                   : []),

--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -1,7 +1,6 @@
 import {
   ClipboardPasteIcon,
   ExternalLinkIcon,
-  InfoIcon,
   MoveRightIcon,
   RefreshCwIcon,
 } from "lucide-react";
@@ -9,9 +8,9 @@ import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
+import { CurrencyInputField } from "src/components/CurrencyInputField";
 import { FixedFloatButton } from "src/components/FixedFloatButton";
 import { FixedFloatSwapInFlow } from "src/components/FixedFloatSwapInFlow";
-import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import Loading from "src/components/Loading";
 import LowReceivingCapacityAlert from "src/components/LowReceivingCapacityAlert";
 import ResponsiveLinkButton from "src/components/ResponsiveLinkButton";
@@ -27,12 +26,6 @@ import {
   TabsList,
   TabsTrigger,
 } from "src/components/ui/tabs";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "src/components/ui/tooltip";
 import { useBalances } from "src/hooks/useBalances";
 import { useChannels } from "src/hooks/useChannels";
 import { useInfo } from "src/hooks/useInfo";
@@ -195,14 +188,13 @@ function SwapInForm() {
                 </div>
               )}
 
-            <Label>Swap amount</Label>
-            <Input
-              type="number"
+            <CurrencyInputField
+              label="Swap amount"
               autoFocus
-              placeholder="Amount in satoshis"
-              value={swapAmountSat}
-              min={swapFrom !== "crypto" ? swapInfo.minAmountSat : undefined}
-              max={
+              valueSat={swapAmountSat}
+              onValueSatChange={setSwapAmountSat}
+              minSat={swapFrom !== "crypto" ? swapInfo.minAmountSat : undefined}
+              maxSat={
                 swapFrom === "crypto"
                   ? balances.lightning.totalReceivableSat * 0.99
                   : Math.min(
@@ -213,56 +205,22 @@ function SwapInForm() {
                       balances.lightning.totalReceivableSat * 0.99
                     )
               }
-              onChange={(e) => setSwapAmountSat(e.target.value)}
               required
+              contextRows={[
+                ...(isInternalSwap
+                  ? [
+                      {
+                        label: "Available on-chain",
+                        amountSat: spendableOnchainBalanceSatWithAnchorReserves,
+                      },
+                    ]
+                  : []),
+                {
+                  label: "Receive limit",
+                  amountSat: balances.lightning.totalReceivableSat,
+                },
+              ]}
             />
-
-            <div className="flex justify-between">
-              {balances && (
-                <div>
-                  <p className="text-xs text-muted-foreground">
-                    Receiving Capacity:{" "}
-                    <FormattedBitcoinAmount
-                      amountMsat={balances.lightning.totalReceivableMsat}
-                    />
-                  </p>
-                  {isInternalSwap && (
-                    <p className="text-xs text-muted-foreground flex items-center justify-center gap-1">
-                      Spendable On-Chain Balance:{" "}
-                      <FormattedBitcoinAmount
-                        amountMsat={
-                          spendableOnchainBalanceSatWithAnchorReserves * 1000
-                        }
-                      />
-                      {!!channels?.length && (
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger>
-                              <div className="flex flex-row gap-1 items-center text-muted-foreground">
-                                <InfoIcon className="h-3 w-3 shrink-0" />
-                              </div>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              To ensure you can close channels, you need to set
-                              aside at least{" "}
-                              <FormattedBitcoinAmount
-                                amountMsat={channels.length * 25000 * 1000}
-                              />{" "}
-                              on-chain. Your total on-chain balance is{" "}
-                              <FormattedBitcoinAmount
-                                amountMsat={
-                                  balances.onchain.spendableSat * 1000
-                                }
-                              />
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                      )}
-                    </p>
-                  )}
-                </div>
-              )}
-            </div>
           </div>
           <div className="flex flex-col gap-4">
             <Label>Swap from</Label>
@@ -405,35 +363,28 @@ function SwapOutForm() {
         </p>
       </div>
       <div className="grid gap-1.5">
-        <Label>Swap amount</Label>
-        <Input
-          type="number"
+        <CurrencyInputField
+          label="Swap amount"
           autoFocus
-          placeholder="Amount in satoshis"
-          value={swapAmountSat}
-          min={swapInfo.minAmountSat}
-          max={Math.min(
+          valueSat={swapAmountSat}
+          onValueSatChange={setSwapAmountSat}
+          minSat={swapInfo.minAmountSat}
+          maxSat={Math.min(
             swapInfo.maxAmountSat,
             balances.lightning.totalSpendableSat
           )}
-          onChange={(e) => setSwapAmountSat(e.target.value)}
           required
+          contextRows={[
+            {
+              label: "Spending balance",
+              amountSat: balances.lightning.totalSpendableSat,
+            },
+            {
+              label: "Minimum",
+              amountSat: swapInfo.minAmountSat,
+            },
+          ]}
         />
-
-        <div className="flex justify-between">
-          {balances && (
-            <p className="text-xs text-muted-foreground">
-              Balance:{" "}
-              <FormattedBitcoinAmount
-                amountMsat={balances.lightning.totalSpendableMsat}
-              />
-            </p>
-          )}
-          <p className="text-xs text-muted-foreground">
-            Minimum:{" "}
-            <FormattedBitcoinAmount amountMsat={swapInfo.minAmountSat * 1000} />
-          </p>
-        </div>
       </div>
       <div className="flex flex-col gap-4">
         <Label>Swap to</Label>

--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -384,7 +384,7 @@ function SwapOutForm() {
           required
           contextRows={[
             {
-              label: "Spending balance",
+              label: "Lightning balance",
               amountSat: balances.lightning.totalSpendableSat,
             },
             {

--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -196,13 +196,17 @@ function SwapInForm() {
               minSat={swapFrom !== "crypto" ? swapInfo.minAmountSat : undefined}
               maxSat={
                 swapFrom === "crypto"
-                  ? balances.lightning.totalReceivableSat * 0.99
+                  ? hasChannelManagement
+                    ? balances.lightning.totalReceivableSat * 0.99
+                    : undefined
                   : Math.min(
                       swapInfo.maxAmountSat,
                       ...(isInternalSwap
                         ? [spendableOnchainBalanceSatWithAnchorReserves]
                         : []),
-                      balances.lightning.totalReceivableSat * 0.99
+                      ...(hasChannelManagement
+                        ? [balances.lightning.totalReceivableSat * 0.99]
+                        : [])
                     )
               }
               required
@@ -215,10 +219,14 @@ function SwapInForm() {
                       },
                     ]
                   : []),
-                {
-                  label: "Receive limit",
-                  amountSat: balances.lightning.totalReceivableSat,
-                },
+                ...(hasChannelManagement
+                  ? [
+                      {
+                        label: "Receive limit",
+                        amountSat: balances.lightning.totalReceivableSat,
+                      },
+                    ]
+                  : []),
               ]}
             />
           </div>


### PR DESCRIPTION
## Summary

Part of #2319.

Fixes https://github.com/getAlby/hub/issues/2379

Adds a reusable `CurrencyInputField` composed from the existing shadcn `Field` and `InputGroup` primitives, then adopts it in receive flows. The field supports bitcoin/sats display, fiat entry through the configured currency, opposite-currency preview, and context rows.

## Scope

- Add `CurrencyInputField`
- Replace amount input in Lightning invoice creation
- Replace amount input in receive-from-on-chain flow
- Show `Receive limit` context from existing balance data

## Validation

- `yarn tsc:compile`
- `yarn lint` before splitting the PR stack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added currency input field with bitcoin/fiat conversion support, enabling seamless amount entry in BTC, sats, or fiat with mode toggling across receive, send, and swap flows.

* **Improvements**
  * Refined UI consistency across invoice, on-chain, Lightning, and auto-swap screens with enhanced currency input fields and real-time balance context display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getAlby/hub/pull/2320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->