### PR TITLE
feat: use currency input in send flows

### DIFF
--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -1,5 +1,5 @@
-import { ArrowRightLeftIcon } from "lucide-react";
 import * as React from "react";
+import { toast } from "sonner";
 import {
   Field,
   FieldDescription,
@@ -11,9 +11,7 @@ import {
   InputGroupAddon,
   InputGroupButton,
   InputGroupInput,
-  InputGroupText,
 } from "src/components/ui/input-group";
-import { Separator } from "src/components/ui/separator";
 import { Skeleton } from "src/components/ui/skeleton";
 import { BITCOIN_DISPLAY_FORMAT_BIP177 } from "src/constants";
 import { useBitcoinRate } from "src/hooks/useBitcoinRate";
@@ -21,6 +19,7 @@ import { useInfo } from "src/hooks/useInfo";
 import { cn } from "src/lib/utils";
 
 type CurrencyInputMode = "bitcoin" | "fiat";
+type BitcoinDenomination = "sats" | "btc";
 
 export type CurrencyInputContextRow = {
   label: string;
@@ -103,17 +102,87 @@ function formatFiatInput(amountSat: string, rate: number, currency: string) {
 
 function formatBitcoinValue(
   amountSat: string | number | null | undefined,
-  displayFormat: string | undefined
+  displayFormat: string | undefined,
+  denomination: BitcoinDenomination = "sats"
 ) {
+  const { amount, unit } = formatBitcoinValueParts(
+    amountSat,
+    displayFormat,
+    denomination
+  );
+
+  if (unit === "₿") {
+    return `${unit}${amount}`;
+  }
+
+  return `${amount} ${unit}`;
+}
+
+function formatBitcoinValueParts(
+  amountSat: string | number | null | undefined,
+  displayFormat: string | undefined,
+  denomination: BitcoinDenomination = "sats"
+) {
+  if (denomination === "btc") {
+    return {
+      amount: formatBtcDisplay(amountSat),
+      unit: "BTC",
+    };
+  }
+
   const formattedAmount = new Intl.NumberFormat().format(
     Math.floor(getNumericValue(amountSat))
   );
 
   if (displayFormat === BITCOIN_DISPLAY_FORMAT_BIP177) {
-    return `₿${formattedAmount}`;
+    return {
+      amount: formattedAmount,
+      unit: "₿",
+    };
   }
 
-  return `${formattedAmount} sats`;
+  return {
+    amount: formattedAmount,
+    unit: "sats",
+  };
+}
+
+function BitcoinValueText({
+  amountSat,
+  denomination,
+  displayFormat,
+}: {
+  amountSat: string | number | null | undefined;
+  denomination: BitcoinDenomination;
+  displayFormat: string | undefined;
+}) {
+  const { amount, unit } = formatBitcoinValueParts(
+    amountSat,
+    displayFormat,
+    denomination
+  );
+
+  return (
+    <span className="inline-flex min-w-0 items-center justify-end gap-1">
+      {unit === "₿" && <span>{unit}</span>}
+      <span className="min-w-0 truncate">{amount}</span>
+      {unit !== "₿" && <span>{unit}</span>}
+    </span>
+  );
+}
+
+function formatBtcDisplay(amountSat: string | number | null | undefined) {
+  return (getNumericValue(amountSat) / SATS_PER_BTC).toFixed(8);
+}
+
+function formatBtcInput(amountSat: string | number | null | undefined) {
+  const amount = getNumericValue(amountSat);
+
+  if (!amount) {
+    return "";
+  }
+
+  return (amount / SATS_PER_BTC).toFixed(8);
 }
 
 export function CurrencyInputField({
@@ -138,6 +207,9 @@ export function CurrencyInputField({
   );
   const [mode, setMode] = React.useState<CurrencyInputMode>("bitcoin");
   const [fiatValue, setFiatValue] = React.useState("");
+  const [bitcoinDenomination, setBitcoinDenomination] =
+    React.useState<BitcoinDenomination>("sats");
+  const [btcValue, setBtcValue] = React.useState("");
 
   const currency = info?.currency || "USD";
   const rate = bitcoinRate?.rate_float;
@@ -150,10 +222,23 @@ export function CurrencyInputField({
     !!error;
   const inputId = id || generatedId;
   const isFiatMode = mode === "fiat";
-  const inputValue = isFiatMode ? fiatValue : valueSat;
-  const showLeadingUnit = isFiatMode || bitcoinUnit !== "sats";
+  const isBtcDenominated = bitcoinDenomination === "btc";
+  const inputValue = isFiatMode
+    ? fiatValue
+    : isBtcDenominated
+      ? btcValue
+      : valueSat;
+  const alternateBitcoinValue = formatBitcoinValueParts(
+    valueSat,
+    info?.bitcoinDisplayFormat,
+    bitcoinDenomination
+  );
   const alternateValue = isFiatMode
-    ? formatBitcoinValue(valueSat, info?.bitcoinDisplayFormat)
+    ? formatBitcoinValue(
+        valueSat,
+        info?.bitcoinDisplayFormat,
+        bitcoinDenomination
+      )
     : formatFiatValue(valueSat, rate, currency);
 
   React.useEffect(() => {
@@ -162,24 +247,102 @@ export function CurrencyInputField({
     }
   }, [mode, valueSat]);
 
+  React.useEffect(() => {
+    if (mode === "bitcoin" && isBtcDenominated && !valueSat) {
+      setBtcValue("");
+    }
+  }, [isBtcDenominated, mode, valueSat]);
+
   function handleToggleMode() {
-    if (!canUseFiat || disabled) {
+    if (disabled) {
       return;
     }
 
     if (mode === "bitcoin") {
+      if (!canUseFiat) {
+        return;
+      }
+
       setFiatValue(formatFiatInput(valueSat, rate, currency));
       setMode("fiat");
       return;
     }
 
+    if (isBtcDenominated) {
+      setBtcValue(formatBtcInput(valueSat));
+    }
+
     setMode("bitcoin");
   }
 
-  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+  function handleAlternateValueClick() {
+    if (disabled || isFiatMode || !canUseFiat) {
+      return;
+    }
+
+    handleToggleMode();
+  }
+
+  function handleToggleBitcoinDenomination() {
+    if (disabled) {
+      return;
+    }
+
+    if (isBtcDenominated) {
+      setBitcoinDenomination("sats");
+      return;
+    }
+
+    setBtcValue(formatBtcInput(valueSat));
+    setBitcoinDenomination("btc");
+  }
+
+  function handleChangeMode(event: React.ChangeEvent<HTMLInputElement>) {
     const nextValue = event.target.value.trim();
 
     if (mode === "bitcoin") {
+      if (!isBtcDenominated && nextValue.includes(".")) {
+        setBitcoinDenomination("btc");
+        setBtcValue(nextValue);
+        toast("Switched to BTC for decimal amount");
+
+        if (!nextValue) {
+          onValueSatChange("");
+          return;
+        }
+
+        const amountBtc = Number(nextValue);
+        if (!Number.isFinite(amountBtc)) {
+          onValueSatChange("");
+          return;
+        }
+
+        onValueSatChange(
+          Math.max(0, Math.round(amountBtc * SATS_PER_BTC)).toString()
+        );
+        return;
+      }
+
+      if (isBtcDenominated) {
+        setBtcValue(nextValue);
+
+        if (!nextValue) {
+          onValueSatChange("");
+          return;
+        }
+
+        const amountBtc = Number(nextValue);
+        if (!Number.isFinite(amountBtc)) {
+          onValueSatChange("");
+          return;
+        }
+
+        onValueSatChange(
+          Math.max(0, Math.round(amountBtc * SATS_PER_BTC)).toString()
+        );
+        return;
+      }
+
       onValueSatChange(nextValue);
       return;
     }
@@ -207,7 +370,15 @@ export function CurrencyInputField({
       return undefined;
     }
 
-    if (!isFiatMode || !rate) {
+    if (!isFiatMode) {
+      if (isBtcDenominated) {
+        return amountSat / SATS_PER_BTC;
+      }
+
+      return amountSat;
+    }
+
+    if (!rate) {
       return amountSat;
     }
 
@@ -221,86 +392,128 @@ export function CurrencyInputField({
       data-invalid={invalid || undefined}
     >
       {label && <FieldLabel htmlFor={inputId}>{label}</FieldLabel>}
-      <div
-        className={cn(
-          "w-full min-w-0 overflow-hidden rounded-md border border-input bg-background shadow-xs transition-[color,box-shadow]",
-          "focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50",
-          invalid &&
-            "border-destructive ring-destructive/20 focus-within:border-destructive focus-within:ring-destructive/20"
-        )}
-      >
-        <InputGroup className="h-9 min-w-0 rounded-none border-0 shadow-none">
-          <InputGroupInput
-            {...props}
-            id={inputId}
-            aria-invalid={invalid || undefined}
-            className={cn(
-              "sensitive slashed-zero min-w-0 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-            )}
-            disabled={disabled}
-            inputMode="decimal"
-            max={getModeBound(maxSat)}
-            min={getModeBound(minSat)}
-            onChange={handleChange}
-            placeholder={isFiatMode ? "0.00" : "0"}
-            required={required}
-            step={isFiatMode ? "any" : 1}
-            type="number"
-            value={inputValue}
-          />
-          {showLeadingUnit && (
-            <InputGroupAddon align="inline-start">
-              <InputGroupText>
-                {isFiatMode ? getCurrencySymbol(currency) : bitcoinUnit}
-              </InputGroupText>
-            </InputGroupAddon>
+      <InputGroup className="h-9 min-w-0 overflow-hidden has-[>[data-align=inline-start]]:[&>input]:pl-1">
+        <InputGroupInput
+          {...props}
+          id={inputId}
+          aria-invalid={invalid || undefined}
+          className={cn(
+            "sensitive slashed-zero min-w-0 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           )}
-          <InputGroupAddon
-            align="inline-end"
-            className="!mr-0 min-w-0 self-stretch gap-0 py-0 pr-0"
-          >
-            <InputGroupText className="sensitive slashed-zero mr-2 min-w-0 max-w-28 truncate tabular-nums sm:max-w-none">
-              {alternateValue ?? <Skeleton className="h-4 w-16" />}
-            </InputGroupText>
+          disabled={disabled}
+          inputMode="decimal"
+          max={getModeBound(maxSat)}
+          min={getModeBound(minSat)}
+          onChange={handleChangeMode}
+          placeholder={
+            isFiatMode ? "0.00" : isBtcDenominated ? "0.00000000" : "0"
+          }
+          required={required}
+          step={isFiatMode ? "any" : isBtcDenominated ? 0.00000001 : 1}
+          type="number"
+          value={inputValue}
+        />
+        <InputGroupAddon align="inline-start">
+          {isFiatMode ? (
+            <InputGroupButton
+              aria-label="Enter amount in bitcoin"
+              disabled={disabled}
+              onClick={handleToggleMode}
+              size="xs"
+              className="h-full rounded-none bg-transparent pl-2 pr-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
+              title="Enter amount in bitcoin"
+            >
+              {getCurrencySymbol(currency)}
+            </InputGroupButton>
+          ) : (
             <InputGroupButton
               aria-label={
-                isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
+                isBtcDenominated
+                  ? "Display bitcoin amounts in satoshis"
+                  : "Display bitcoin amounts in BTC"
               }
-              disabled={!canUseFiat || disabled}
-              onClick={handleToggleMode}
-              size="icon-sm"
-              className="!size-9 rounded-none border-l border-input p-0"
+              aria-pressed={isBtcDenominated}
+              disabled={disabled}
+              onClick={handleToggleBitcoinDenomination}
+              size="xs"
+              className="h-full rounded-none bg-transparent pl-2 pr-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
               title={
-                isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
+                isBtcDenominated
+                  ? "Display bitcoin amounts in satoshis"
+                  : "Display bitcoin amounts in BTC"
               }
             >
-              <ArrowRightLeftIcon className="size-4" />
+              {isBtcDenominated ? "BTC" : bitcoinUnit}
             </InputGroupButton>
-          </InputGroupAddon>
-        </InputGroup>
-        {!!contextRows?.length && (
-          <>
-            <Separator />
-            <div className="flex min-w-0 flex-col gap-2 px-3 py-2 text-sm text-muted-foreground">
-              {contextRows.map((row) => (
-                <div
-                  className="flex min-w-0 items-center justify-between gap-3"
-                  key={row.label}
-                >
-                  <span className="truncate">{row.label}:</span>
-                  <span className="sensitive slashed-zero min-w-0 max-w-[55%] truncate text-right tabular-nums">
-                    {row.value ??
-                      formatBitcoinValue(
-                        row.amountSat,
-                        info?.bitcoinDisplayFormat
-                      )}
-                  </span>
-                </div>
-              ))}
+          )}
+        </InputGroupAddon>
+        <InputGroupAddon
+          align="inline-end"
+          className="!mr-0 min-w-0 self-stretch py-0 pr-1"
+        >
+          {isFiatMode ? (
+            <InputGroupButton
+              aria-label={
+                isBtcDenominated
+                  ? "Display bitcoin amounts in satoshis"
+                  : "Display bitcoin amounts in BTC"
+              }
+              aria-pressed={isBtcDenominated}
+              disabled={disabled}
+              onClick={handleToggleBitcoinDenomination}
+              size="xs"
+              className="sensitive slashed-zero h-full min-w-0 justify-end truncate rounded-none bg-transparent px-0.5 text-muted-foreground tabular-nums hover:bg-transparent hover:text-foreground"
+              title={
+                isBtcDenominated
+                  ? "Display bitcoin amounts in satoshis"
+                  : "Display bitcoin amounts in BTC"
+              }
+            >
+              {alternateBitcoinValue.unit === "₿" && (
+                <span>{alternateBitcoinValue.unit}</span>
+              )}
+              <span className="min-w-0 truncate">
+                {alternateBitcoinValue.amount}
+              </span>
+              {alternateBitcoinValue.unit !== "₿" && (
+                <span>{alternateBitcoinValue.unit}</span>
+              )}
+            </InputGroupButton>
+          ) : (
+            <InputGroupButton
+              aria-label="Enter amount in fiat"
+              disabled={disabled || !canUseFiat}
+              onClick={handleAlternateValueClick}
+              size="xs"
+              className="sensitive slashed-zero h-full min-w-0 max-w-28 justify-end truncate rounded-none bg-transparent px-1 text-muted-foreground tabular-nums hover:bg-transparent hover:text-foreground sm:max-w-none"
+              title="Enter amount in fiat"
+            >
+              {alternateValue ?? <Skeleton className="h-4 w-16" />}
+            </InputGroupButton>
+          )}
+        </InputGroupAddon>
+      </InputGroup>
+      {!!contextRows?.length && (
+        <div className="flex min-w-0 cursor-default flex-col gap-1 text-sm text-muted-foreground">
+          {contextRows.map((row) => (
+            <div
+              className="flex min-w-0 items-center justify-between gap-3"
+              key={row.label}
+            >
+              <span className="truncate">{row.label}:</span>
+              <span className="sensitive slashed-zero min-w-0 max-w-[55%] truncate text-right tabular-nums">
+                {row.value ?? (
+                  <BitcoinValueText
+                    amountSat={row.amountSat}
+                    displayFormat={info?.bitcoinDisplayFormat}
+                    denomination={bitcoinDenomination}
+                  />
+                )}
+              </span>
             </div>
-          </>
-        )}
-      </div>
+          ))}
+        </div>
+      )}
       {description && <FieldDescription>{description}</FieldDescription>}
       {error && <FieldError>{error}</FieldError>}
     </Field>

--- a/frontend/src/screens/wallet/send/LnurlPay.tsx
+++ b/frontend/src/screens/wallet/send/LnurlPay.tsx
@@ -5,13 +5,11 @@ import React from "react";
 import { Link, useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
-import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
-import FormattedFiatAmount from "src/components/FormattedFiatAmount";
+import { CurrencyInputField } from "src/components/CurrencyInputField";
 import { InsufficientLightningBalanceAlert } from "src/components/InsufficientLightningBalanceAlert";
 import Loading from "src/components/Loading";
 import { PaymentFailedAlert } from "src/components/PaymentFailedAlert";
 import { PendingPaymentAlert } from "src/components/PendingPaymentAlert";
-import { InputWithAdornment } from "src/components/ui/custom/input-with-adornment";
 import { LinkButton } from "src/components/ui/custom/link-button";
 import { LoadingButton } from "src/components/ui/custom/loading-button";
 import { Input } from "src/components/ui/input";
@@ -136,42 +134,21 @@ export default function LnurlPay() {
               </p>
             </div>
           )}
-          <div className="grid gap-2">
-            <Label htmlFor="amount">Amount</Label>
-            <InputWithAdornment
-              id="amount"
-              type="number"
-              value={amountSat}
-              placeholder="Amount in Satoshi..."
-              onChange={(e) => {
-                setAmountSat(e.target.value.trim());
-              }}
-              min={1}
-              max={balances.lightning.totalSpendableSat}
-              required
-              autoFocus
-              endAdornment={
-                <FormattedFiatAmount
-                  amountSat={Number(amountSat)}
-                  className="mr-2"
-                />
-              }
-            />
-            <div className="grid gap-2">
-              <div className="flex justify-between text-xs text-muted-foreground sensitive slashed-zero">
-                <div>
-                  Lightning Balance:{" "}
-                  <FormattedBitcoinAmount
-                    amountMsat={balances.lightning.totalSpendableMsat}
-                  />
-                </div>
-                <FormattedFiatAmount
-                  className="text-xs"
-                  amountSat={balances.lightning.totalSpendableSat}
-                />
-              </div>
-            </div>
-          </div>
+          <CurrencyInputField
+            id="amount"
+            valueSat={amountSat}
+            onValueSatChange={setAmountSat}
+            minSat={1}
+            maxSat={balances.lightning.totalSpendableSat}
+            required
+            autoFocus
+            contextRows={[
+              {
+                label: "Spending balance",
+                amountSat: balances.lightning.totalSpendableSat,
+              },
+            ]}
+          />
           {!!lnAddress.lnurlpData?.commentAllowed && (
             <div className="grid gap-2">
               <Label htmlFor="comment">Comment</Label>

--- a/frontend/src/screens/wallet/send/Onchain.tsx
+++ b/frontend/src/screens/wallet/send/Onchain.tsx
@@ -11,14 +11,12 @@ import { toast } from "sonner";
 import { AnchorReserveAlert } from "src/components/AnchorReserveAlert";
 import AppHeader from "src/components/AppHeader";
 import ExternalLink from "src/components/ExternalLink";
-import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
-import FormattedFiatAmount from "src/components/FormattedFiatAmount";
+import { CurrencyInputField } from "src/components/CurrencyInputField";
 import { InsufficientLightningBalanceAlert } from "src/components/InsufficientLightningBalanceAlert";
 import Loading from "src/components/Loading";
 import { MempoolAlert } from "src/components/MempoolAlert";
 import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
 import { Button } from "src/components/ui/button";
-import { InputWithAdornment } from "src/components/ui/custom/input-with-adornment";
 import { LinkButton } from "src/components/ui/custom/link-button";
 import { LoadingButton } from "src/components/ui/custom/loading-button";
 import { Input } from "src/components/ui/input";
@@ -190,40 +188,21 @@ function OnchainForm({
 
   return (
     <form onSubmit={onSubmit} className="grid gap-6">
-      <div className="grid gap-2">
-        <Label htmlFor="amount">Amount</Label>
-        <InputWithAdornment
-          id="amount"
-          type="number"
-          value={amountSat}
-          placeholder="Amount in Satoshi..."
-          onChange={(e) => {
-            setAmountSat(e.target.value.trim());
-          }}
-          min={ONCHAIN_DUST_SATS}
-          max={balances.onchain.spendableSat}
-          required
-          autoFocus
-          endAdornment={
-            <FormattedFiatAmount
-              amountSat={Number(amountSat)}
-              className="mr-2"
-            />
-          }
-        />
-        <div className="flex justify-between text-muted-foreground text-xs sensitive slashed-zero">
-          <div>
-            On-chain Balance:{" "}
-            <FormattedBitcoinAmount
-              amountMsat={balances.onchain.spendableSat * 1000}
-            />
-          </div>
-          <FormattedFiatAmount
-            className="text-xs"
-            amountSat={balances.onchain.spendableSat}
-          />
-        </div>
-      </div>
+      <CurrencyInputField
+        id="amount"
+        valueSat={amountSat}
+        onValueSatChange={setAmountSat}
+        minSat={ONCHAIN_DUST_SATS}
+        maxSat={balances.onchain.spendableSat}
+        required
+        autoFocus
+        contextRows={[
+          {
+            label: "On-chain available",
+            amountSat: balances.onchain.spendableSat,
+          },
+        ]}
+      />
       <div className="flex items-center justify-between">
         <Label htmlFor="swap" className="cursor-pointer">
           Swap from Lightning Balance
@@ -379,57 +358,28 @@ function SwapForm({
 
   return (
     <form onSubmit={onSubmit} className="grid gap-6">
-      <div className="grid gap-2">
-        <Label htmlFor="amount">Amount</Label>
-        <InputWithAdornment
-          id="amount"
-          type="number"
-          value={amountSat}
-          placeholder="Amount in Satoshi..."
-          onChange={(e) => {
-            setAmountSat(e.target.value.trim());
-          }}
-          min={swapInfo.minAmountSat}
-          max={Math.min(
-            swapInfo.maxAmountSat,
-            balances.lightning.totalSpendableSat
-          )}
-          required
-          autoFocus
-          endAdornment={
-            <FormattedFiatAmount
-              amountSat={Number(amountSat)}
-              className="mr-2"
-            />
-          }
-        />
-        <div className="grid gap-1">
-          <div className="flex justify-between text-xs text-muted-foreground sensitive slashed-zero">
-            <div>
-              Lightning Balance:{" "}
-              <FormattedBitcoinAmount
-                amountMsat={balances.lightning.totalSpendableMsat}
-              />
-            </div>
-            <FormattedFiatAmount
-              className="text-xs"
-              amountSat={balances.lightning.totalSpendableSat}
-            />
-          </div>
-          <div className="flex justify-between text-muted-foreground text-xs sensitive slashed-zero">
-            <div>
-              Minimum:{" "}
-              <FormattedBitcoinAmount
-                amountMsat={swapInfo.minAmountSat * 1000}
-              />
-            </div>
-            <FormattedFiatAmount
-              className="text-xs"
-              amountSat={swapInfo.minAmountSat}
-            />
-          </div>
-        </div>
-      </div>
+      <CurrencyInputField
+        id="amount"
+        valueSat={amountSat}
+        onValueSatChange={setAmountSat}
+        minSat={swapInfo.minAmountSat}
+        maxSat={Math.min(
+          swapInfo.maxAmountSat,
+          balances.lightning.totalSpendableSat
+        )}
+        required
+        autoFocus
+        contextRows={[
+          {
+            label: "Spending balance",
+            amountSat: balances.lightning.totalSpendableSat,
+          },
+          {
+            label: "Minimum",
+            amountSat: swapInfo.minAmountSat,
+          },
+        ]}
+      />
       <div className="flex items-center justify-between">
         <Label htmlFor="swap" className="cursor-pointer">
           Swap from Lightning Balance

--- a/frontend/src/screens/wallet/send/ZeroAmount.tsx
+++ b/frontend/src/screens/wallet/send/ZeroAmount.tsx
@@ -6,13 +6,11 @@ import { XIcon } from "lucide-react";
 import { Link, useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
-import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
-import FormattedFiatAmount from "src/components/FormattedFiatAmount";
+import { CurrencyInputField } from "src/components/CurrencyInputField";
 import { InsufficientLightningBalanceAlert } from "src/components/InsufficientLightningBalanceAlert";
 import Loading from "src/components/Loading";
 import { PaymentFailedAlert } from "src/components/PaymentFailedAlert";
 import { PendingPaymentAlert } from "src/components/PendingPaymentAlert";
-import { InputWithAdornment } from "src/components/ui/custom/input-with-adornment";
 import { LinkButton } from "src/components/ui/custom/link-button";
 import { LoadingButton } from "src/components/ui/custom/loading-button";
 import { useBalances } from "src/hooks/useBalances";
@@ -119,42 +117,21 @@ export default function ZeroAmount() {
             </p>
           </div>
         )}
-        <div className="grid gap-2">
-          <Label htmlFor="amount">Amount</Label>
-          <InputWithAdornment
-            id="amount"
-            type="number"
-            value={amountSat}
-            placeholder="Amount in Satoshi..."
-            onChange={(e) => {
-              setAmountSat(e.target.value.trim());
-            }}
-            min={1}
-            max={balances.lightning.totalSpendableSat}
-            required
-            autoFocus
-            endAdornment={
-              <FormattedFiatAmount
-                amountSat={Number(amountSat)}
-                className="mr-2"
-              />
-            }
-          />
-          <div className="grid gap-2">
-            <div className="flex justify-between text-xs text-muted-foreground sensitive slashed-zero">
-              <div>
-                Lightning Balance:{" "}
-                <FormattedBitcoinAmount
-                  amountMsat={balances.lightning.totalSpendableMsat}
-                />
-              </div>
-              <FormattedFiatAmount
-                className="text-xs"
-                amountSat={balances.lightning.totalSpendableSat}
-              />
-            </div>
-          </div>
-        </div>
+        <CurrencyInputField
+          id="amount"
+          valueSat={amountSat}
+          onValueSatChange={setAmountSat}
+          minSat={1}
+          maxSat={balances.lightning.totalSpendableSat}
+          required
+          autoFocus
+          contextRows={[
+            {
+              label: "Spending balance",
+              amountSat: balances.lightning.totalSpendableSat,
+            },
+          ]}
+        />
         <PayFromSelect appId={appId} onChange={setAppId} />
         <InsufficientLightningBalanceAlert amountSat={+amountSat} />
         <div className="flex gap-2">

--- a/frontend/src/screens/wallet/swap/AutoSwap.tsx
+++ b/frontend/src/screens/wallet/swap/AutoSwap.tsx
@@ -9,6 +9,7 @@ import {
 import { useState } from "react";
 import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
+import { CurrencyInputField } from "src/components/CurrencyInputField";
 import ExternalLink from "src/components/ExternalLink";
 import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import Loading from "src/components/Loading";
@@ -160,37 +161,29 @@ function AutoSwapOutForm() {
           </p>
         </div>
 
-        <div className="grid gap-1.5">
-          <Label>Lightning balance threshold</Label>
-          <Input
-            type="number"
-            placeholder="Amount in satoshis"
-            value={balanceThresholdSat}
-            min={swapAmountSat}
-            onChange={(e) => setBalanceThresholdSat(e.target.value)}
-            required
-          />
-          <p className="text-xs text-muted-foreground">
-            Swap out as soon as this amount is reached
-          </p>
-        </div>
+        <CurrencyInputField
+          label="Spending balance threshold"
+          valueSat={balanceThresholdSat}
+          onValueSatChange={setBalanceThresholdSat}
+          minSat={Number(swapAmountSat) || undefined}
+          required
+          description="Swap out as soon as this amount is reached"
+        />
 
-        <div className="grid gap-1.5">
-          <Label>Swap amount</Label>
-          <Input
-            type="number"
-            placeholder="Amount in satoshis"
-            value={swapAmountSat}
-            min={swapInfo.minAmountSat}
-            max={swapInfo.maxAmountSat}
-            onChange={(e) => setSwapAmountSat(e.target.value)}
-            required
-          />
-          <p className="text-xs text-muted-foreground">
-            Minimum{" "}
-            <FormattedBitcoinAmount amountMsat={swapInfo.minAmountSat * 1000} />
-          </p>
-        </div>
+        <CurrencyInputField
+          label="Swap amount"
+          valueSat={swapAmountSat}
+          onValueSatChange={setSwapAmountSat}
+          minSat={swapInfo.minAmountSat}
+          maxSat={swapInfo.maxAmountSat}
+          required
+          contextRows={[
+            {
+              label: "Minimum",
+              amountSat: swapInfo.minAmountSat,
+            },
+          ]}
+        />
         <div className="flex flex-col gap-4">
           <Label>Swap to</Label>
           <RadioGroup
@@ -425,7 +418,7 @@ function ActiveSwapOutConfig({ swapConfig }: { swapConfig: AutoSwapConfig }) {
         </div>
         <div className="flex justify-between items-center gap-2">
           <span className="font-medium truncate">
-            Lightning balance threshold
+            Spending balance threshold
           </span>
           <span className="shrink-0 text-muted-foreground text-right">
             <FormattedBitcoinAmount

--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -1,7 +1,6 @@
 import {
   ClipboardPasteIcon,
   ExternalLinkIcon,
-  InfoIcon,
   MoveRightIcon,
   RefreshCwIcon,
 } from "lucide-react";
@@ -9,9 +8,9 @@ import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
+import { CurrencyInputField } from "src/components/CurrencyInputField";
 import { FixedFloatButton } from "src/components/FixedFloatButton";
 import { FixedFloatSwapInFlow } from "src/components/FixedFloatSwapInFlow";
-import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import Loading from "src/components/Loading";
 import LowReceivingCapacityAlert from "src/components/LowReceivingCapacityAlert";
 import ResponsiveLinkButton from "src/components/ResponsiveLinkButton";
@@ -27,12 +26,6 @@ import {
   TabsList,
   TabsTrigger,
 } from "src/components/ui/tabs";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "src/components/ui/tooltip";
 import { useBalances } from "src/hooks/useBalances";
 import { useChannels } from "src/hooks/useChannels";
 import { useInfo } from "src/hooks/useInfo";
@@ -195,14 +188,13 @@ function SwapInForm() {
                 </div>
               )}
 
-            <Label>Swap amount</Label>
-            <Input
-              type="number"
+            <CurrencyInputField
+              label="Swap amount"
               autoFocus
-              placeholder="Amount in satoshis"
-              value={swapAmountSat}
-              min={swapFrom !== "crypto" ? swapInfo.minAmountSat : undefined}
-              max={
+              valueSat={swapAmountSat}
+              onValueSatChange={setSwapAmountSat}
+              minSat={swapFrom !== "crypto" ? swapInfo.minAmountSat : undefined}
+              maxSat={
                 swapFrom === "crypto"
                   ? balances.lightning.totalReceivableSat * 0.99
                   : Math.min(
@@ -213,56 +205,22 @@ function SwapInForm() {
                       balances.lightning.totalReceivableSat * 0.99
                     )
               }
-              onChange={(e) => setSwapAmountSat(e.target.value)}
               required
+              contextRows={[
+                ...(isInternalSwap
+                  ? [
+                      {
+                        label: "Available on-chain",
+                        amountSat: spendableOnchainBalanceSatWithAnchorReserves,
+                      },
+                    ]
+                  : []),
+                {
+                  label: "Receive limit",
+                  amountSat: balances.lightning.totalReceivableSat,
+                },
+              ]}
             />
-
-            <div className="flex justify-between">
-              {balances && (
-                <div>
-                  <p className="text-xs text-muted-foreground">
-                    Receiving Capacity:{" "}
-                    <FormattedBitcoinAmount
-                      amountMsat={balances.lightning.totalReceivableMsat}
-                    />
-                  </p>
-                  {isInternalSwap && (
-                    <p className="text-xs text-muted-foreground flex items-center justify-center gap-1">
-                      Spendable On-Chain Balance:{" "}
-                      <FormattedBitcoinAmount
-                        amountMsat={
-                          spendableOnchainBalanceSatWithAnchorReserves * 1000
-                        }
-                      />
-                      {!!channels?.length && (
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger>
-                              <div className="flex flex-row gap-1 items-center text-muted-foreground">
-                                <InfoIcon className="h-3 w-3 shrink-0" />
-                              </div>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              To ensure you can close channels, you need to set
-                              aside at least{" "}
-                              <FormattedBitcoinAmount
-                                amountMsat={channels.length * 25000 * 1000}
-                              />{" "}
-                              on-chain. Your total on-chain balance is{" "}
-                              <FormattedBitcoinAmount
-                                amountMsat={
-                                  balances.onchain.spendableSat * 1000
-                                }
-                              />
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                      )}
-                    </p>
-                  )}
-                </div>
-              )}
-            </div>
           </div>
           <div className="flex flex-col gap-4">
             <Label>Swap from</Label>
@@ -405,35 +363,28 @@ function SwapOutForm() {
         </p>
       </div>
       <div className="grid gap-1.5">
-        <Label>Swap amount</Label>
-        <Input
-          type="number"
+        <CurrencyInputField
+          label="Swap amount"
           autoFocus
-          placeholder="Amount in satoshis"
-          value={swapAmountSat}
-          min={swapInfo.minAmountSat}
-          max={Math.min(
+          valueSat={swapAmountSat}
+          onValueSatChange={setSwapAmountSat}
+          minSat={swapInfo.minAmountSat}
+          maxSat={Math.min(
             swapInfo.maxAmountSat,
             balances.lightning.totalSpendableSat
           )}
-          onChange={(e) => setSwapAmountSat(e.target.value)}
           required
+          contextRows={[
+            {
+              label: "Spending balance",
+              amountSat: balances.lightning.totalSpendableSat,
+            },
+            {
+              label: "Minimum",
+              amountSat: swapInfo.minAmountSat,
+            },
+          ]}
         />
-
-        <div className="flex justify-between">
-          {balances && (
-            <p className="text-xs text-muted-foreground">
-              Balance:{" "}
-              <FormattedBitcoinAmount
-                amountMsat={balances.lightning.totalSpendableMsat}
-              />
-            </p>
-          )}
-          <p className="text-xs text-muted-foreground">
-            Minimum:{" "}
-            <FormattedBitcoinAmount amountMsat={swapInfo.minAmountSat * 1000} />
-          </p>
-        </div>
       </div>
       <div className="flex flex-col gap-4">
         <Label>Swap to</Label>


### PR DESCRIPTION
Part of #2319.

## Summary
- Replaces Lightning amount inputs in LNURL-pay and zero-amount invoice send flows with `CurrencyInputField`.
- Replaces on-chain send and send-time swap amount inputs with `CurrencyInputField`.
- Wires spending balance, on-chain available balance, and swap minimum rows into the shared field without changing current navigation or alert behavior.

## Stack
- Depends on #2320.

## Validation
- `cd frontend && yarn tsc:compile`
- `cd frontend && yarn lint`