### PR TITLE
fix: update to alby go-nostr fork which reconnects after receiving CLOSED message

### DIFF
--- a/apps/apps_service.go
+++ b/apps/apps_service.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/config"
 	"github.com/getAlby/hub/constants"
 	"github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/events"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/service/keys"
-	"github.com/nbd-wtf/go-nostr"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/btcsuite/btcd v0.24.3-0.20250318170759-4f4ea81776d6
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/elnosh/gonuts v0.4.2
+	github.com/getAlby/go-nostr v0.0.0-20260509070347-31e205cac904
 	github.com/getAlby/ldk-node-go v0.0.0-20260424111754-3690cdb3031c
 	github.com/go-gormigrate/gormigrate/v2 v2.1.5
 	github.com/google/uuid v1.6.0
 	github.com/labstack/echo/v4 v4.15.1
 	github.com/mattn/go-sqlite3 v1.14.44
-	github.com/nbd-wtf/go-nostr v0.52.3
 	github.com/nbd-wtf/ln-decodepay v1.13.0
 	github.com/orandin/lumberjackrus v1.0.1
 	github.com/peterldowns/pgtestdb v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
+github.com/getAlby/go-nostr v0.0.0-20260509070347-31e205cac904 h1:UvdEf2rj3EXGR/HkMz3eZI9x1hBdSSlTLutyIHLYy8o=
+github.com/getAlby/go-nostr v0.0.0-20260509070347-31e205cac904/go.mod h1:BtlkV9evCTjpY0YeFhoNgycp7XNFbnfVXJPoykp+NtM=
 github.com/getAlby/ldk-node-go v0.0.0-20260424111754-3690cdb3031c h1:ikai5+taiPSgbaocdVMdxPkmOhnXs5V/gCX+J/P8iRw=
 github.com/getAlby/ldk-node-go v0.0.0-20260424111754-3690cdb3031c/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -510,8 +512,6 @@ github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nbd-wtf/go-nostr v0.52.3 h1:Xd87pXfJEJRXHpM+fLjQQln8dBNNaoPA10V7BbyP4KI=
-github.com/nbd-wtf/go-nostr v0.52.3/go.mod h1:4avYoc9mDGZ9wHsvCOhHH9vPzKucCfuYBtJUSpHTfNk=
 github.com/nbd-wtf/ln-decodepay v1.13.0 h1:ic32UwT6cBVbLw72fQ7vr0nTMziYTj67baQ2COwlxZk=
 github.com/nbd-wtf/ln-decodepay v1.13.0/go.mod h1:SNcdOd7Mv7+PY6Q5E/flUAOfnFdr/W/PK2O6wyzpra8=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=

--- a/nip47/cipher/cipher.go
+++ b/nip47/cipher/cipher.go
@@ -3,9 +3,9 @@ package cipher
 import (
 	"fmt"
 
+	"github.com/getAlby/go-nostr/nip04"
+	"github.com/getAlby/go-nostr/nip44"
 	"github.com/getAlby/hub/constants"
-	"github.com/nbd-wtf/go-nostr/nip04"
-	"github.com/nbd-wtf/go-nostr/nip44"
 )
 
 const (

--- a/nip47/cipher/cipher_test.go
+++ b/nip47/cipher/cipher_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/constants"
-	"github.com/nbd-wtf/go-nostr"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/nip47/controllers/cancel_hold_invoice_controller.go
+++ b/nip47/controllers/cancel_hold_invoice_controller.go
@@ -3,9 +3,9 @@ package controllers
 import (
 	"context"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/nip47/models"
-	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
 )
 

--- a/nip47/controllers/cancel_hold_invoice_controller_test.go
+++ b/nip47/controllers/cancel_hold_invoice_controller_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/nip47/controllers/create_connection_controller.go
+++ b/nip47/controllers/create_connection_controller.go
@@ -5,12 +5,12 @@ import (
 	"slices"
 	"time"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/alby"
 	"github.com/getAlby/hub/constants"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/nip47/models"
 	"github.com/getAlby/hub/nip47/permissions"
-	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
 )
 

--- a/nip47/controllers/create_connection_controller_test.go
+++ b/nip47/controllers/create_connection_controller_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/nip47/controllers/get_balance_controller.go
+++ b/nip47/controllers/get_balance_controller.go
@@ -3,11 +3,11 @@ package controllers
 import (
 	"context"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/db/queries"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/nip47/models"
-	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
 )
 

--- a/nip47/controllers/get_balance_controller_test.go
+++ b/nip47/controllers/get_balance_controller_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/nip47/controllers/get_budget_controller.go
+++ b/nip47/controllers/get_budget_controller.go
@@ -3,8 +3,8 @@ package controllers
 import (
 	"context"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/db/queries"
-	"github.com/nbd-wtf/go-nostr"
 
 	"github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/logger"

--- a/nip47/controllers/get_budget_controller_test.go
+++ b/nip47/controllers/get_budget_controller_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/nip47/controllers/get_info_controller.go
+++ b/nip47/controllers/get_info_controller.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/constants"
 	"github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/nip47/models"
-	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
 )
 

--- a/nip47/controllers/get_info_controller_test.go
+++ b/nip47/controllers/get_info_controller_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/nip47/controllers/list_transactions_controller.go
+++ b/nip47/controllers/list_transactions_controller.go
@@ -3,9 +3,9 @@ package controllers
 import (
 	"context"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/nip47/models"
-	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
 )
 

--- a/nip47/controllers/list_transactions_controller_test.go
+++ b/nip47/controllers/list_transactions_controller_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/nip47/controllers/lookup_invoice_controller.go
+++ b/nip47/controllers/lookup_invoice_controller.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/constants"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/nip47/models"
-	"github.com/nbd-wtf/go-nostr"
 	decodepay "github.com/nbd-wtf/ln-decodepay"
 	"github.com/sirupsen/logrus"
 )

--- a/nip47/controllers/lookup_invoice_controller_test.go
+++ b/nip47/controllers/lookup_invoice_controller_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/nip47/controllers/make_hold_invoice_controller.go
+++ b/nip47/controllers/make_hold_invoice_controller.go
@@ -3,10 +3,10 @@ package controllers
 import (
 	"context"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/constants"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/nip47/models"
-	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
 )
 

--- a/nip47/controllers/make_hold_invoice_controller_test.go
+++ b/nip47/controllers/make_hold_invoice_controller_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/nip47/controllers/make_invoice_controller.go
+++ b/nip47/controllers/make_invoice_controller.go
@@ -3,9 +3,9 @@ package controllers
 import (
 	"context"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/nip47/models"
-	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
 )
 

--- a/nip47/controllers/make_invoice_controller_test.go
+++ b/nip47/controllers/make_invoice_controller_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/nip47/controllers/models.go
+++ b/nip47/controllers/models.go
@@ -1,8 +1,8 @@
 package controllers
 
 import (
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/nip47/models"
-	"github.com/nbd-wtf/go-nostr"
 )
 
 type publishFunc = func(*models.Response, nostr.Tags)

--- a/nip47/controllers/multi_pay_invoice_controller.go
+++ b/nip47/controllers/multi_pay_invoice_controller.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/constants"
 	"github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/nip47/models"
-	"github.com/nbd-wtf/go-nostr"
 	decodepay "github.com/nbd-wtf/ln-decodepay"
 	"github.com/sirupsen/logrus"
 )

--- a/nip47/controllers/multi_pay_invoice_controller_test.go
+++ b/nip47/controllers/multi_pay_invoice_controller_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/nip47/controllers/multi_pay_keysend_controller.go
+++ b/nip47/controllers/multi_pay_keysend_controller.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"sync"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/nip47/models"
-	"github.com/nbd-wtf/go-nostr"
 )
 
 type multiPayKeysendParams struct {

--- a/nip47/controllers/multi_pay_keysend_controller_test.go
+++ b/nip47/controllers/multi_pay_keysend_controller_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/nip47/controllers/pay_invoice_controller.go
+++ b/nip47/controllers/pay_invoice_controller.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/constants"
 	"github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/nip47/models"
-	"github.com/nbd-wtf/go-nostr"
 	decodepay "github.com/nbd-wtf/ln-decodepay"
 	"github.com/sirupsen/logrus"
 )

--- a/nip47/controllers/pay_invoice_controller_test.go
+++ b/nip47/controllers/pay_invoice_controller_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/nip47/controllers/pay_keysend_controller.go
+++ b/nip47/controllers/pay_keysend_controller.go
@@ -3,11 +3,11 @@ package controllers
 import (
 	"context"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/lnclient"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/nip47/models"
-	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
 )
 

--- a/nip47/controllers/pay_keysend_controller_test.go
+++ b/nip47/controllers/pay_keysend_controller_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/nip47/controllers/settle_hold_invoice_controller.go
+++ b/nip47/controllers/settle_hold_invoice_controller.go
@@ -3,9 +3,9 @@ package controllers
 import (
 	"context"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/nip47/models"
-	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
 )
 

--- a/nip47/controllers/settle_hold_invoice_controller_test.go
+++ b/nip47/controllers/settle_hold_invoice_controller_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/nip47/controllers/sign_message_controller.go
+++ b/nip47/controllers/sign_message_controller.go
@@ -3,9 +3,9 @@ package controllers
 import (
 	"context"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/nip47/models"
-	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
 )
 

--- a/nip47/event_handler.go
+++ b/nip47/event_handler.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/constants"
 	"github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/events"
@@ -18,7 +19,6 @@ import (
 	"github.com/getAlby/hub/nip47/models"
 	"github.com/getAlby/hub/nip47/permissions"
 	nostrmodels "github.com/getAlby/hub/nostr/models"
-	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )

--- a/nip47/event_handler_test.go
+++ b/nip47/event_handler_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/nip47/nip47_service.go
+++ b/nip47/nip47_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/alby"
 	"github.com/getAlby/hub/apps"
 	"github.com/getAlby/hub/config"
@@ -16,7 +17,6 @@ import (
 	nostrmodels "github.com/getAlby/hub/nostr/models"
 	"github.com/getAlby/hub/service/keys"
 	"github.com/getAlby/hub/transactions"
-	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )

--- a/nip47/notifications/nip47_notifier.go
+++ b/nip47/notifications/nip47_notifier.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/config"
 	"github.com/getAlby/hub/constants"
 	"github.com/getAlby/hub/db"
@@ -15,7 +16,6 @@ import (
 	"github.com/getAlby/hub/nip47/permissions"
 	nostrmodels "github.com/getAlby/hub/nostr/models"
 	"github.com/getAlby/hub/service/keys"
-	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )

--- a/nip47/notifications/nip47_notifier_test.go
+++ b/nip47/notifications/nip47_notifier_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/nip47/publish_nip47_info.go
+++ b/nip47/publish_nip47_info.go
@@ -6,13 +6,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/lnclient"
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/nip47/cipher"
 	"github.com/getAlby/hub/nip47/models"
 	nostrmodels "github.com/getAlby/hub/nostr/models"
-	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
 )
 

--- a/nostr/models/models.go
+++ b/nostr/models/models.go
@@ -3,7 +3,7 @@ package models
 import (
 	"context"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 )
 
 type SimplePool interface {

--- a/service/create_app_consumer.go
+++ b/service/create_app_consumer.go
@@ -3,7 +3,7 @@ package service
 import (
 	"context"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/sirupsen/logrus"
 
 	"github.com/getAlby/hub/db"

--- a/service/delete_app_consumer.go
+++ b/service/delete_app_consumer.go
@@ -3,9 +3,9 @@ package service
 import (
 	"context"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/events"
 	"github.com/getAlby/hub/logger"
-	"github.com/nbd-wtf/go-nostr"
 )
 
 type deleteAppConsumer struct {

--- a/service/keys/keys.go
+++ b/service/keys/keys.go
@@ -10,9 +10,9 @@ import (
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/config"
 	"github.com/getAlby/hub/logger"
-	"github.com/nbd-wtf/go-nostr"
 	"github.com/tyler-smith/go-bip32"
 	"github.com/tyler-smith/go-bip39"
 )

--- a/service/keys/keys_test.go
+++ b/service/keys/keys_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/getAlby/hub/logger"
 	"github.com/getAlby/hub/tests/db"
 
-	"github.com/nbd-wtf/go-nostr"
+	"github.com/getAlby/go-nostr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tyler-smith/go-bip32"

--- a/service/start.go
+++ b/service/start.go
@@ -14,8 +14,8 @@ import (
 	"github.com/getAlby/hub/swaps"
 	"github.com/getAlby/hub/version"
 
-	"github.com/nbd-wtf/go-nostr"
-	"github.com/nbd-wtf/go-nostr/nip19"
+	"github.com/getAlby/go-nostr"
+	"github.com/getAlby/go-nostr/nip19"
 	"github.com/sirupsen/logrus"
 
 	"github.com/getAlby/hub/config"

--- a/service/update_app_consumer.go
+++ b/service/update_app_consumer.go
@@ -3,9 +3,9 @@ package service
 import (
 	"context"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/events"
 	"github.com/getAlby/hub/logger"
-	"github.com/nbd-wtf/go-nostr"
 )
 
 type updateAppConsumer struct {

--- a/tests/create_app.go
+++ b/tests/create_app.go
@@ -3,11 +3,11 @@ package tests
 import (
 	"time"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/constants"
 	db "github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/events"
 	"github.com/getAlby/hub/nip47/cipher"
-	"github.com/nbd-wtf/go-nostr"
 	"gorm.io/gorm"
 )
 

--- a/tests/create_mock_relay.go
+++ b/tests/create_mock_relay.go
@@ -3,8 +3,8 @@ package tests
 import (
 	"context"
 
+	"github.com/getAlby/go-nostr"
 	"github.com/getAlby/hub/logger"
-	"github.com/nbd-wtf/go-nostr"
 )
 
 type mockSimplePool struct {


### PR DESCRIPTION
Tested running two local relays, switching between real relays and relays that always return CLOSED. Alby Hub reconnects as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Nostr library dependency to an alternative implementation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getAlby/hub/pull/2331)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->