### PR TITLE
fix: show BOLT-12 offer button for CLN backend

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1391,6 +1391,7 @@ func (api *api) GetInfo(ctx context.Context) (*InfoResponse, error) {
 	info.HideUpdateBanner = api.cfg.GetEnv().HideUpdateBanner
 	info.LdkVssEnabled = ldkVssEnabled == "true"
 	info.VssSupported = backendType == config.LDKBackendType && api.cfg.GetEnv().LDKVssUrl != ""
+	info.SupportsBolt12 = backendType == config.LDKBackendType || backendType == config.CLNBackendType
 	info.AutoUnlockPasswordEnabled = autoUnlockPassword != ""
 	info.AutoUnlockPasswordSupported = api.cfg.GetEnv().IsDefaultClientId()
 	info.Relays = []InfoResponseRelay{}

--- a/api/models.go
+++ b/api/models.go
@@ -333,6 +333,7 @@ type InfoResponse struct {
 	ChainDataSourceType         string              `json:"chainDataSourceType,omitempty"`
 	ChainDataSourceAddress      string              `json:"chainDataSourceAddress,omitempty"`
 	HideUpdateBanner            bool                `json:"hideUpdateBanner"`
+	SupportsBolt12              bool                `json:"supportsBolt12"`
 }
 
 type UpdateSettingsRequest struct {

--- a/frontend/src/components/ReceiveToLightning.tsx
+++ b/frontend/src/components/ReceiveToLightning.tsx
@@ -40,7 +40,7 @@ export function ReceiveToLightning() {
           <ZapIcon className="w-4 h-4 mr-2" />
           Create Invoice
         </LinkButton>
-        {info.backendType === "LDK" && (
+        {(info.backendType === "LDK" || info.backendType === "CLN") && (
           <LinkButton
             to="/wallet/receive/offer"
             variant="outline"

--- a/frontend/src/components/ReceiveToLightning.tsx
+++ b/frontend/src/components/ReceiveToLightning.tsx
@@ -40,7 +40,7 @@ export function ReceiveToLightning() {
           <ZapIcon className="w-4 h-4 mr-2" />
           Create Invoice
         </LinkButton>
-        {(info.backendType === "LDK" || info.backendType === "CLN") && (
+        {info.supportsBolt12 && (
           <LinkButton
             to="/wallet/receive/offer"
             variant="outline"

--- a/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
@@ -245,7 +245,8 @@ export default function ReceiveInvoice() {
                 {(!info?.albyAccountConnected || !me?.lightning_address) && (
                   <div className="grid gap-2 border-t pt-6">
                     {!info?.albyAccountConnected &&
-                      info.backendType === "LDK" && (
+                      (info.backendType === "LDK" ||
+                        info.backendType === "CLN") && (
                         <LinkButton
                           to="/wallet/receive/offer"
                           variant="outline"

--- a/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
@@ -244,18 +244,16 @@ export default function ReceiveInvoice() {
                 </LoadingButton>
                 {(!info?.albyAccountConnected || !me?.lightning_address) && (
                   <div className="grid gap-2 border-t pt-6">
-                    {!info?.albyAccountConnected &&
-                      (info.backendType === "LDK" ||
-                        info.backendType === "CLN") && (
-                        <LinkButton
-                          to="/wallet/receive/offer"
-                          variant="outline"
-                          className="w-full"
-                        >
-                          <ReceiptTextIcon className="h-4 w-4" />
-                          Lightning Offer
-                        </LinkButton>
-                      )}
+                    {!info?.albyAccountConnected && info.supportsBolt12 && (
+                      <LinkButton
+                        to="/wallet/receive/offer"
+                        variant="outline"
+                        className="w-full"
+                      >
+                        <ReceiptTextIcon className="h-4 w-4" />
+                        Lightning Offer
+                      </LinkButton>
+                    )}
                     <LinkButton
                       to="/wallet/receive/onchain"
                       variant="outline"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -169,6 +169,7 @@ export interface InfoResponse {
   chainDataSourceType?: string;
   chainDataSourceAddress?: string;
   hideUpdateBanner: boolean;
+  supportsBolt12: boolean;
 }
 
 export type BitcoinDisplayFormat = "sats" | "bip177";


### PR DESCRIPTION
## Summary
- The CLN backend implements `MakeOffer` (calling CLN's `Offer` gRPC) and `/api/offers` is backend-agnostic, but the UI gated the "Lightning Offer" button on `backendType === "LDK"`, so CLN users had no way to reach the flow.
- Widens the gate in [ReceiveToLightning.tsx](frontend/src/components/ReceiveToLightning.tsx) and [ReceiveInvoice.tsx](frontend/src/screens/wallet/receive/ReceiveInvoice.tsx) to include `CLN`.

## Test plan
- [ ] With LDK backend: "Lightning Offer" button still appears on the Receive screen and the existing flow works.
- [ ] With CLN backend: "Lightning Offer" button appears, clicking through creates a BOLT-12 offer via `/api/offers`, QR renders, copy works.
- [ ] With LND / Phoenixd / Cashu backends: button remains hidden.
- [ ] No-Alby-account fallback path in `ReceiveInvoice` shows the offer button only for LDK/CLN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lightning Offer invoices are now available for additional wallet backends based on native Bolt12 support detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getAlby/hub/pull/2360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->