### PR TITLE
feat: add BTC denomination toggle to currency input

### DIFF
--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -21,6 +21,7 @@ import { useInfo } from "src/hooks/useInfo";
 import { cn } from "src/lib/utils";
 
 type CurrencyInputMode = "bitcoin" | "fiat";
+type BitcoinDenomination = "sats" | "btc";
 
 export type CurrencyInputContextRow = {
   label: string;
@@ -103,8 +104,13 @@ function formatFiatInput(amountSat: string, rate: number, currency: string) {
 
 function formatBitcoinValue(
   amountSat: string | number | null | undefined,
-  displayFormat: string | undefined
+  displayFormat: string | undefined,
+  denomination: BitcoinDenomination = "sats"
 ) {
+  if (denomination === "btc") {
+    return `${formatBtcDisplay(amountSat)} BTC`;
+  }
+
   const formattedAmount = new Intl.NumberFormat().format(
     Math.floor(getNumericValue(amountSat))
   );
@@ -114,6 +120,20 @@ function formatBitcoinValue(
   }
 
   return `${formattedAmount} sats`;
+}
+
+function formatBtcDisplay(amountSat: string | number | null | undefined) {
+  return (getNumericValue(amountSat) / SATS_PER_BTC).toFixed(8);
+}
+
+function formatBtcInput(amountSat: string | number | null | undefined) {
+  const amount = getNumericValue(amountSat);
+
+  if (!amount) {
+    return "";
+  }
+
+  return (amount / SATS_PER_BTC).toFixed(8);
 }
 
 export function CurrencyInputField({
@@ -138,6 +158,9 @@ export function CurrencyInputField({
   );
   const [mode, setMode] = React.useState<CurrencyInputMode>("bitcoin");
   const [fiatValue, setFiatValue] = React.useState("");
+  const [bitcoinDenomination, setBitcoinDenomination] =
+    React.useState<BitcoinDenomination>("sats");
+  const [btcValue, setBtcValue] = React.useState("");
 
   const currency = info?.currency || "USD";
   const rate = bitcoinRate?.rate_float;
@@ -150,10 +173,20 @@ export function CurrencyInputField({
     !!error;
   const inputId = id || generatedId;
   const isFiatMode = mode === "fiat";
-  const inputValue = isFiatMode ? fiatValue : valueSat;
-  const showLeadingUnit = isFiatMode || bitcoinUnit !== "sats";
+  const isBtcDenominated = bitcoinDenomination === "btc";
+  const inputValue = isFiatMode
+    ? fiatValue
+    : isBtcDenominated
+      ? btcValue
+      : valueSat;
+  const showLeadingUnit =
+    isFiatMode || isBtcDenominated || bitcoinUnit !== "sats";
   const alternateValue = isFiatMode
-    ? formatBitcoinValue(valueSat, info?.bitcoinDisplayFormat)
+    ? formatBitcoinValue(
+        valueSat,
+        info?.bitcoinDisplayFormat,
+        bitcoinDenomination
+      )
     : formatFiatValue(valueSat, rate, currency);
 
   React.useEffect(() => {
@@ -161,6 +194,12 @@ export function CurrencyInputField({
       setFiatValue("");
     }
   }, [mode, valueSat]);
+
+  React.useEffect(() => {
+    if (mode === "bitcoin" && isBtcDenominated && !valueSat) {
+      setBtcValue("");
+    }
+  }, [isBtcDenominated, mode, valueSat]);
 
   function handleToggleMode() {
     if (!canUseFiat || disabled) {
@@ -173,13 +212,51 @@ export function CurrencyInputField({
       return;
     }
 
+    if (isBtcDenominated) {
+      setBtcValue(formatBtcInput(valueSat));
+    }
+
     setMode("bitcoin");
+  }
+
+  function handleToggleBitcoinDenomination() {
+    if (disabled) {
+      return;
+    }
+
+    if (isBtcDenominated) {
+      setBitcoinDenomination("sats");
+      return;
+    }
+
+    setBtcValue(formatBtcInput(valueSat));
+    setBitcoinDenomination("btc");
   }
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     const nextValue = event.target.value.trim();
 
     if (mode === "bitcoin") {
+      if (isBtcDenominated) {
+        setBtcValue(nextValue);
+
+        if (!nextValue) {
+          onValueSatChange("");
+          return;
+        }
+
+        const amountBtc = Number(nextValue);
+        if (!Number.isFinite(amountBtc)) {
+          onValueSatChange("");
+          return;
+        }
+
+        onValueSatChange(
+          Math.max(0, Math.round(amountBtc * SATS_PER_BTC)).toString()
+        );
+        return;
+      }
+
       onValueSatChange(nextValue);
       return;
     }
@@ -207,7 +284,15 @@ export function CurrencyInputField({
       return undefined;
     }
 
-    if (!isFiatMode || !rate) {
+    if (!isFiatMode) {
+      if (isBtcDenominated) {
+        return amountSat / SATS_PER_BTC;
+      }
+
+      return amountSat;
+    }
+
+    if (!rate) {
       return amountSat;
     }
 
@@ -242,16 +327,22 @@ export function CurrencyInputField({
             max={getModeBound(maxSat)}
             min={getModeBound(minSat)}
             onChange={handleChange}
-            placeholder={isFiatMode ? "0.00" : "0"}
+            placeholder={
+              isFiatMode ? "0.00" : isBtcDenominated ? "0.00000000" : "0"
+            }
             required={required}
-            step={isFiatMode ? "any" : 1}
+            step={isFiatMode ? "any" : isBtcDenominated ? 0.00000001 : 1}
             type="number"
             value={inputValue}
           />
           {showLeadingUnit && (
             <InputGroupAddon align="inline-start">
               <InputGroupText>
-                {isFiatMode ? getCurrencySymbol(currency) : bitcoinUnit}
+                {isFiatMode
+                  ? getCurrencySymbol(currency)
+                  : isBtcDenominated
+                    ? "BTC"
+                    : bitcoinUnit}
               </InputGroupText>
             </InputGroupAddon>
           )}
@@ -276,6 +367,25 @@ export function CurrencyInputField({
             >
               <ArrowRightLeftIcon className="size-4" />
             </InputGroupButton>
+            <InputGroupButton
+              aria-label={
+                isBtcDenominated
+                  ? "Display bitcoin amounts in satoshis"
+                  : "Display bitcoin amounts in BTC"
+              }
+              aria-pressed={isBtcDenominated}
+              disabled={disabled}
+              onClick={handleToggleBitcoinDenomination}
+              size="icon-sm"
+              className="!size-9 rounded-none border-l border-input p-0 aria-pressed:bg-accent aria-pressed:text-accent-foreground"
+              title={
+                isBtcDenominated
+                  ? "Display bitcoin amounts in satoshis"
+                  : "Display bitcoin amounts in BTC"
+              }
+            >
+              <span className="text-sm leading-none">₿</span>
+            </InputGroupButton>
           </InputGroupAddon>
         </InputGroup>
         {!!contextRows?.length && (
@@ -292,7 +402,8 @@ export function CurrencyInputField({
                     {row.value ??
                       formatBitcoinValue(
                         row.amountSat,
-                        info?.bitcoinDisplayFormat
+                        info?.bitcoinDisplayFormat,
+                        bitcoinDenomination
                       )}
                   </span>
                 </div>

--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -1,5 +1,5 @@
-import { ArrowRightLeftIcon } from "lucide-react";
 import * as React from "react";
+import { toast } from "sonner";
 import {
   Field,
   FieldDescription,
@@ -11,9 +11,7 @@ import {
   InputGroupAddon,
   InputGroupButton,
   InputGroupInput,
-  InputGroupText,
 } from "src/components/ui/input-group";
-import { Separator } from "src/components/ui/separator";
 import { Skeleton } from "src/components/ui/skeleton";
 import { BITCOIN_DISPLAY_FORMAT_BIP177 } from "src/constants";
 import { useBitcoinRate } from "src/hooks/useBitcoinRate";
@@ -107,8 +105,29 @@ function formatBitcoinValue(
   displayFormat: string | undefined,
   denomination: BitcoinDenomination = "sats"
 ) {
+  const { amount, unit } = formatBitcoinValueParts(
+    amountSat,
+    displayFormat,
+    denomination
+  );
+
+  if (unit === "₿") {
+    return `${unit}${amount}`;
+  }
+
+  return `${amount} ${unit}`;
+}
+
+function formatBitcoinValueParts(
+  amountSat: string | number | null | undefined,
+  displayFormat: string | undefined,
+  denomination: BitcoinDenomination = "sats"
+) {
   if (denomination === "btc") {
-    return `${formatBtcDisplay(amountSat)} BTC`;
+    return {
+      amount: formatBtcDisplay(amountSat),
+      unit: "BTC",
+    };
   }
 
   const formattedAmount = new Intl.NumberFormat().format(
@@ -116,10 +135,40 @@ function formatBitcoinValue(
   );
 
   if (displayFormat === BITCOIN_DISPLAY_FORMAT_BIP177) {
-    return `₿${formattedAmount}`;
+    return {
+      amount: formattedAmount,
+      unit: "₿",
+    };
   }
 
-  return `${formattedAmount} sats`;
+  return {
+    amount: formattedAmount,
+    unit: "sats",
+  };
+}
+
+function BitcoinValueText({
+  amountSat,
+  denomination,
+  displayFormat,
+}: {
+  amountSat: string | number | null | undefined;
+  denomination: BitcoinDenomination;
+  displayFormat: string | undefined;
+}) {
+  const { amount, unit } = formatBitcoinValueParts(
+    amountSat,
+    displayFormat,
+    denomination
+  );
+
+  return (
+    <span className="inline-flex min-w-0 items-center justify-end gap-1">
+      {unit === "₿" && <span>{unit}</span>}
+      <span className="min-w-0 truncate">{amount}</span>
+      {unit !== "₿" && <span>{unit}</span>}
+    </span>
+  );
 }
 
 function formatBtcDisplay(amountSat: string | number | null | undefined) {
@@ -179,8 +228,11 @@ export function CurrencyInputField({
     : isBtcDenominated
       ? btcValue
       : valueSat;
-  const showLeadingUnit =
-    isFiatMode || isBtcDenominated || bitcoinUnit !== "sats";
+  const alternateBitcoinValue = formatBitcoinValueParts(
+    valueSat,
+    info?.bitcoinDisplayFormat,
+    bitcoinDenomination
+  );
   const alternateValue = isFiatMode
     ? formatBitcoinValue(
         valueSat,
@@ -202,11 +254,15 @@ export function CurrencyInputField({
   }, [isBtcDenominated, mode, valueSat]);
 
   function handleToggleMode() {
-    if (!canUseFiat || disabled) {
+    if (disabled) {
       return;
     }
 
     if (mode === "bitcoin") {
+      if (!canUseFiat) {
+        return;
+      }
+
       setFiatValue(formatFiatInput(valueSat, rate, currency));
       setMode("fiat");
       return;
@@ -217,6 +273,14 @@ export function CurrencyInputField({
     }
 
     setMode("bitcoin");
+  }
+
+  function handleAlternateValueClick() {
+    if (disabled || isFiatMode || !canUseFiat) {
+      return;
+    }
+
+    handleToggleMode();
   }
 
   function handleToggleBitcoinDenomination() {
@@ -233,13 +297,14 @@ export function CurrencyInputField({
     setBitcoinDenomination("btc");
   }
 
-  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+  function handleChangeMode(event: React.ChangeEvent<HTMLInputElement>) {
     const nextValue = event.target.value.trim();
 
     if (mode === "bitcoin") {
       if (!isBtcDenominated && nextValue.includes(".")) {
         setBitcoinDenomination("btc");
         setBtcValue(nextValue);
+        toast("Switched to BTC for decimal amount");
 
         if (!nextValue) {
           onValueSatChange("");
@@ -327,67 +392,40 @@ export function CurrencyInputField({
       data-invalid={invalid || undefined}
     >
       {label && <FieldLabel htmlFor={inputId}>{label}</FieldLabel>}
-      <div
-        className={cn(
-          "w-full min-w-0 overflow-hidden rounded-md border border-input bg-background shadow-xs transition-[color,box-shadow]",
-          "focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50",
-          invalid &&
-            "border-destructive ring-destructive/20 focus-within:border-destructive focus-within:ring-destructive/20"
-        )}
-      >
-        <InputGroup className="h-9 min-w-0 rounded-none border-0 shadow-none">
-          <InputGroupInput
-            {...props}
-            id={inputId}
-            aria-invalid={invalid || undefined}
-            className={cn(
-              "sensitive slashed-zero min-w-0 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-            )}
-            disabled={disabled}
-            inputMode="decimal"
-            max={getModeBound(maxSat)}
-            min={getModeBound(minSat)}
-            onChange={handleChange}
-            placeholder={
-              isFiatMode ? "0.00" : isBtcDenominated ? "0.00000000" : "0"
-            }
-            required={required}
-            step={isFiatMode ? "any" : isBtcDenominated ? 0.00000001 : 1}
-            type="number"
-            value={inputValue}
-          />
-          {showLeadingUnit && (
-            <InputGroupAddon align="inline-start">
-              <InputGroupText>
-                {isFiatMode
-                  ? getCurrencySymbol(currency)
-                  : isBtcDenominated
-                    ? "BTC"
-                    : bitcoinUnit}
-              </InputGroupText>
-            </InputGroupAddon>
+      <InputGroup className="h-9 min-w-0 overflow-hidden has-[>[data-align=inline-start]]:[&>input]:pl-1">
+        <InputGroupInput
+          {...props}
+          id={inputId}
+          aria-invalid={invalid || undefined}
+          className={cn(
+            "sensitive slashed-zero min-w-0 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           )}
-          <InputGroupAddon
-            align="inline-end"
-            className="!mr-0 min-w-0 self-stretch gap-0 py-0 pr-0"
-          >
-            <InputGroupText className="sensitive slashed-zero mr-2 min-w-0 max-w-28 truncate tabular-nums sm:max-w-none">
-              {alternateValue ?? <Skeleton className="h-4 w-16" />}
-            </InputGroupText>
+          disabled={disabled}
+          inputMode="decimal"
+          max={getModeBound(maxSat)}
+          min={getModeBound(minSat)}
+          onChange={handleChangeMode}
+          placeholder={
+            isFiatMode ? "0.00" : isBtcDenominated ? "0.00000000" : "0"
+          }
+          required={required}
+          step={isFiatMode ? "any" : isBtcDenominated ? 0.00000001 : 1}
+          type="number"
+          value={inputValue}
+        />
+        <InputGroupAddon align="inline-start">
+          {isFiatMode ? (
             <InputGroupButton
-              aria-label={
-                isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
-              }
-              disabled={!canUseFiat || disabled}
+              aria-label="Enter amount in bitcoin"
+              disabled={disabled}
               onClick={handleToggleMode}
-              size="icon-sm"
-              className="!size-9 rounded-none border-l border-input p-0"
-              title={
-                isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
-              }
+              size="xs"
+              className="h-full rounded-none bg-transparent pl-2 pr-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
+              title="Enter amount in bitcoin"
             >
-              <ArrowRightLeftIcon className="size-4" />
+              {getCurrencySymbol(currency)}
             </InputGroupButton>
+          ) : (
             <InputGroupButton
               aria-label={
                 isBtcDenominated
@@ -397,42 +435,85 @@ export function CurrencyInputField({
               aria-pressed={isBtcDenominated}
               disabled={disabled}
               onClick={handleToggleBitcoinDenomination}
-              size="icon-sm"
-              className="!size-9 rounded-none border-l border-input p-0 aria-pressed:bg-accent aria-pressed:text-accent-foreground"
+              size="xs"
+              className="h-full rounded-none bg-transparent pl-2 pr-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
               title={
                 isBtcDenominated
                   ? "Display bitcoin amounts in satoshis"
                   : "Display bitcoin amounts in BTC"
               }
             >
-              <span className="text-sm leading-none">₿</span>
+              {isBtcDenominated ? "BTC" : bitcoinUnit}
             </InputGroupButton>
-          </InputGroupAddon>
-        </InputGroup>
-        {!!contextRows?.length && (
-          <>
-            <Separator />
-            <div className="flex min-w-0 flex-col gap-2 px-3 py-2 text-sm text-muted-foreground">
-              {contextRows.map((row) => (
-                <div
-                  className="flex min-w-0 items-center justify-between gap-3"
-                  key={row.label}
-                >
-                  <span className="truncate">{row.label}:</span>
-                  <span className="sensitive slashed-zero min-w-0 max-w-[55%] truncate text-right tabular-nums">
-                    {row.value ??
-                      formatBitcoinValue(
-                        row.amountSat,
-                        info?.bitcoinDisplayFormat,
-                        bitcoinDenomination
-                      )}
-                  </span>
-                </div>
-              ))}
+          )}
+        </InputGroupAddon>
+        <InputGroupAddon
+          align="inline-end"
+          className="!mr-0 min-w-0 self-stretch py-0 pr-1"
+        >
+          {isFiatMode ? (
+            <InputGroupButton
+              aria-label={
+                isBtcDenominated
+                  ? "Display bitcoin amounts in satoshis"
+                  : "Display bitcoin amounts in BTC"
+              }
+              aria-pressed={isBtcDenominated}
+              disabled={disabled}
+              onClick={handleToggleBitcoinDenomination}
+              size="xs"
+              className="sensitive slashed-zero h-full min-w-0 justify-end truncate rounded-none bg-transparent px-0.5 text-muted-foreground tabular-nums hover:bg-transparent hover:text-foreground"
+              title={
+                isBtcDenominated
+                  ? "Display bitcoin amounts in satoshis"
+                  : "Display bitcoin amounts in BTC"
+              }
+            >
+              {alternateBitcoinValue.unit === "₿" && (
+                <span>{alternateBitcoinValue.unit}</span>
+              )}
+              <span className="min-w-0 truncate">
+                {alternateBitcoinValue.amount}
+              </span>
+              {alternateBitcoinValue.unit !== "₿" && (
+                <span>{alternateBitcoinValue.unit}</span>
+              )}
+            </InputGroupButton>
+          ) : (
+            <InputGroupButton
+              aria-label="Enter amount in fiat"
+              disabled={disabled || !canUseFiat}
+              onClick={handleAlternateValueClick}
+              size="xs"
+              className="sensitive slashed-zero h-full min-w-0 max-w-28 justify-end truncate rounded-none bg-transparent px-1 text-muted-foreground tabular-nums hover:bg-transparent hover:text-foreground sm:max-w-none"
+              title="Enter amount in fiat"
+            >
+              {alternateValue ?? <Skeleton className="h-4 w-16" />}
+            </InputGroupButton>
+          )}
+        </InputGroupAddon>
+      </InputGroup>
+      {!!contextRows?.length && (
+        <div className="flex min-w-0 cursor-default flex-col gap-1 text-sm text-muted-foreground">
+          {contextRows.map((row) => (
+            <div
+              className="flex min-w-0 items-center justify-between gap-3"
+              key={row.label}
+            >
+              <span className="truncate">{row.label}:</span>
+              <span className="sensitive slashed-zero min-w-0 max-w-[55%] truncate text-right tabular-nums">
+                {row.value ?? (
+                  <BitcoinValueText
+                    amountSat={row.amountSat}
+                    displayFormat={info?.bitcoinDisplayFormat}
+                    denomination={bitcoinDenomination}
+                  />
+                )}
+              </span>
             </div>
-          </>
-        )}
-      </div>
+          ))}
+        </div>
+      )}
       {description && <FieldDescription>{description}</FieldDescription>}
       {error && <FieldError>{error}</FieldError>}
     </Field>

--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -237,6 +237,27 @@ export function CurrencyInputField({
     const nextValue = event.target.value.trim();
 
     if (mode === "bitcoin") {
+      if (!isBtcDenominated && nextValue.includes(".")) {
+        setBitcoinDenomination("btc");
+        setBtcValue(nextValue);
+
+        if (!nextValue) {
+          onValueSatChange("");
+          return;
+        }
+
+        const amountBtc = Number(nextValue);
+        if (!Number.isFinite(amountBtc)) {
+          onValueSatChange("");
+          return;
+        }
+
+        onValueSatChange(
+          Math.max(0, Math.round(amountBtc * SATS_PER_BTC)).toString()
+        );
+        return;
+      }
+
       if (isBtcDenominated) {
         setBtcValue(nextValue);
 


### PR DESCRIPTION
Part of #2319.

## Summary
- Adds a BTC denomination toggle to the shared `CurrencyInputField`.
- Keeps the field value stored as sats while displaying/editing bitcoin amounts as full BTC with 8 decimals when enabled.
- Applies BTC formatting consistently to bitcoin input mode, fiat alternate value, and context rows.

## Stack
- Depends on #2320, #2321, and #2322.

## Validation
- `cd frontend && yarn tsc:compile`
- `cd frontend && yarn lint`
- Manual test in local mutinynet Hub workdir.