### PR TITLE
fix: stop prompting for bitcoin: protocol handler on every load

### DIFF
--- a/frontend/src/hooks/useRegisterProtocolHandler.ts
+++ b/frontend/src/hooks/useRegisterProtocolHandler.ts
@@ -2,16 +2,28 @@ import React from "react";
 
 import { isHttpMode } from "src/utils/isHttpMode";
 
+const STORAGE_KEY = "bitcoin-protocol-handler-registered";
+
 export function useRegisterProtocolHandler(basePath: string) {
   React.useEffect(() => {
     if (!isHttpMode() || !("registerProtocolHandler" in navigator)) {
       return;
     }
 
+    const normalizedBasePath = basePath.replace(/\/$/, "");
+    const handlerUrl = `${window.location.origin}${normalizedBasePath}/wallet/send?bip21=%s`;
+
+    // Browsers re-prompt every time registerProtocolHandler is called if the
+    // user previously dismissed the prompt without accepting or denying it.
+    // Limit to once per browser session so we don't ask on every page load,
+    // but users still get re-asked occasionally if they didn't opt in.
+    if (sessionStorage.getItem(STORAGE_KEY) === handlerUrl) {
+      return;
+    }
+
     try {
-      const normalizedBasePath = basePath.replace(/\/$/, "");
-      const handlerUrl = `${window.location.origin}${normalizedBasePath}/wallet/send?bip21=%s`;
       navigator.registerProtocolHandler("bitcoin", handlerUrl);
+      sessionStorage.setItem(STORAGE_KEY, handlerUrl);
     } catch (e) {
       console.error("Failed to register bitcoin protocol handler", e);
     }

--- a/frontend/src/hooks/useRegisterProtocolHandler.ts
+++ b/frontend/src/hooks/useRegisterProtocolHandler.ts
@@ -13,15 +13,17 @@ export function useRegisterProtocolHandler(basePath: string) {
     const normalizedBasePath = basePath.replace(/\/$/, "");
     const handlerUrl = `${window.location.origin}${normalizedBasePath}/wallet/send?bip21=%s`;
 
-    // Browsers re-prompt every time registerProtocolHandler is called if the
-    // user previously dismissed the prompt without accepting or denying it.
-    // Limit to once per browser session so we don't ask on every page load,
-    // but users still get re-asked occasionally if they didn't opt in.
-    if (sessionStorage.getItem(STORAGE_KEY) === handlerUrl) {
-      return;
-    }
-
     try {
+      // Browsers re-prompt every time registerProtocolHandler is called if the
+      // user previously dismissed the prompt without accepting or denying it.
+      // Limit to once per browser session so we don't ask on every page load,
+      // but users still get re-asked occasionally if they didn't opt in.
+      // sessionStorage access can throw in restricted/private modes, so it's
+      // inside the same try/catch as registerProtocolHandler.
+      if (sessionStorage.getItem(STORAGE_KEY) === handlerUrl) {
+        return;
+      }
+
       navigator.registerProtocolHandler("bitcoin", handlerUrl);
       sessionStorage.setItem(STORAGE_KEY, handlerUrl);
     } catch (e) {

--- a/frontend/src/hooks/useRegisterProtocolHandler.ts
+++ b/frontend/src/hooks/useRegisterProtocolHandler.ts
@@ -10,22 +10,21 @@ export function useRegisterProtocolHandler(basePath: string) {
       return;
     }
 
-    const normalizedBasePath = basePath.replace(/\/$/, "");
-    const handlerUrl = `${window.location.origin}${normalizedBasePath}/wallet/send?bip21=%s`;
-
     try {
       // Browsers re-prompt every time registerProtocolHandler is called if the
       // user previously dismissed the prompt without accepting or denying it.
       // Limit to once per browser session so we don't ask on every page load,
-      // but users still get re-asked occasionally if they didn't opt in.
+      // but users still get re-asked in a new session if they didn't opt in.
       // sessionStorage access can throw in restricted/private modes, so it's
       // inside the same try/catch as registerProtocolHandler.
-      if (sessionStorage.getItem(STORAGE_KEY) === handlerUrl) {
+      if (sessionStorage.getItem(STORAGE_KEY)) {
         return;
       }
 
+      const normalizedBasePath = basePath.replace(/\/$/, "");
+      const handlerUrl = `${window.location.origin}${normalizedBasePath}/wallet/send?bip21=%s`;
       navigator.registerProtocolHandler("bitcoin", handlerUrl);
-      sessionStorage.setItem(STORAGE_KEY, handlerUrl);
+      sessionStorage.setItem(STORAGE_KEY, "true");
     } catch (e) {
       console.error("Failed to register bitcoin protocol handler", e);
     }


### PR DESCRIPTION
## Summary
- The browser-native \`registerProtocolHandler\` prompt was reappearing on every page load, because browsers re-prompt every time \`navigator.registerProtocolHandler\` is called if the user dismissed (X'd) the previous prompt without explicitly accepting or denying.
- Gate the call with \`sessionStorage\` so we ask at most once per browser session. Users who dismiss still get re-asked next session, and an explicit accept persists permanently in the browser as before.

## Test plan
- [ ] Load Hub in a fresh tab → see the bitcoin protocol handler bar once.
- [ ] Dismiss it with X, reload the same tab → bar does NOT reappear.
- [ ] Open Hub in a new tab → bar appears again.
- [ ] Accept the prompt → bar never reappears (browser remembers permanently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated browser protocol-registration prompts by ensuring the handler is registered only once per session, avoiding redundant dialogs on subsequent page loads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getAlby/hub/pull/2369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->