### PR TITLE
chore: address feedback on currency input field

### DIFF
--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -1,5 +1,6 @@
 import { ArrowRightLeftIcon } from "lucide-react";
 import * as React from "react";
+import { toast } from "sonner";
 import {
   Field,
   FieldDescription,
@@ -13,7 +14,6 @@ import {
   InputGroupInput,
   InputGroupText,
 } from "src/components/ui/input-group";
-import { Separator } from "src/components/ui/separator";
 import { Skeleton } from "src/components/ui/skeleton";
 import { BITCOIN_DISPLAY_FORMAT_BIP177 } from "src/constants";
 import { useBitcoinRate } from "src/hooks/useBitcoinRate";
@@ -179,8 +179,6 @@ export function CurrencyInputField({
     : isBtcDenominated
       ? btcValue
       : valueSat;
-  const showLeadingUnit =
-    isFiatMode || isBtcDenominated || bitcoinUnit !== "sats";
   const alternateValue = isFiatMode
     ? formatBitcoinValue(
         valueSat,
@@ -233,13 +231,14 @@ export function CurrencyInputField({
     setBitcoinDenomination("btc");
   }
 
-  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+  function handleChangeMode(event: React.ChangeEvent<HTMLInputElement>) {
     const nextValue = event.target.value.trim();
 
     if (mode === "bitcoin") {
       if (!isBtcDenominated && nextValue.includes(".")) {
         setBitcoinDenomination("btc");
         setBtcValue(nextValue);
+        toast("Switched to BTC for decimal amount");
 
         if (!nextValue) {
           onValueSatChange("");
@@ -327,112 +326,100 @@ export function CurrencyInputField({
       data-invalid={invalid || undefined}
     >
       {label && <FieldLabel htmlFor={inputId}>{label}</FieldLabel>}
-      <div
-        className={cn(
-          "w-full min-w-0 overflow-hidden rounded-md border border-input bg-background shadow-xs transition-[color,box-shadow]",
-          "focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50",
-          invalid &&
-            "border-destructive ring-destructive/20 focus-within:border-destructive focus-within:ring-destructive/20"
-        )}
-      >
-        <InputGroup className="h-9 min-w-0 rounded-none border-0 shadow-none">
-          <InputGroupInput
-            {...props}
-            id={inputId}
-            aria-invalid={invalid || undefined}
-            className={cn(
-              "sensitive slashed-zero min-w-0 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-            )}
-            disabled={disabled}
-            inputMode="decimal"
-            max={getModeBound(maxSat)}
-            min={getModeBound(minSat)}
-            onChange={handleChange}
-            placeholder={
-              isFiatMode ? "0.00" : isBtcDenominated ? "0.00000000" : "0"
-            }
-            required={required}
-            step={isFiatMode ? "any" : isBtcDenominated ? 0.00000001 : 1}
-            type="number"
-            value={inputValue}
-          />
-          {showLeadingUnit && (
-            <InputGroupAddon align="inline-start">
-              <InputGroupText>
-                {isFiatMode
-                  ? getCurrencySymbol(currency)
-                  : isBtcDenominated
-                    ? "BTC"
-                    : bitcoinUnit}
-              </InputGroupText>
-            </InputGroupAddon>
+      <InputGroup className="h-9 min-w-0 overflow-hidden">
+        <InputGroupInput
+          {...props}
+          id={inputId}
+          aria-invalid={invalid || undefined}
+          className={cn(
+            "sensitive slashed-zero min-w-0 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           )}
-          <InputGroupAddon
-            align="inline-end"
-            className="!mr-0 min-w-0 self-stretch gap-0 py-0 pr-0"
+          disabled={disabled}
+          inputMode="decimal"
+          max={getModeBound(maxSat)}
+          min={getModeBound(minSat)}
+          onChange={handleChangeMode}
+          placeholder={
+            isFiatMode ? "0.00" : isBtcDenominated ? "0.00000000" : "0"
+          }
+          required={required}
+          step={isFiatMode ? "any" : isBtcDenominated ? 0.00000001 : 1}
+          type="number"
+          value={inputValue}
+        />
+        <InputGroupAddon align="inline-start">
+          <InputGroupText>
+            {isFiatMode
+              ? getCurrencySymbol(currency)
+              : isBtcDenominated
+                ? "BTC"
+                : bitcoinUnit}
+          </InputGroupText>
+        </InputGroupAddon>
+        <InputGroupAddon
+          align="inline-end"
+          className="!mr-0 min-w-0 self-stretch gap-0 py-0 pr-0"
+        >
+          <InputGroupText className="sensitive slashed-zero mr-2 min-w-0 max-w-28 truncate tabular-nums sm:max-w-none">
+            {alternateValue ?? <Skeleton className="h-4 w-16" />}
+          </InputGroupText>
+          <InputGroupButton
+            aria-label={
+              isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
+            }
+            disabled={!canUseFiat || disabled}
+            onClick={handleToggleMode}
+            size="icon-sm"
+            className="peer/swap !size-9 rounded-none border-l border-input p-0 focus-visible:border-l-transparent focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+            title={
+              isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
+            }
           >
-            <InputGroupText className="sensitive slashed-zero mr-2 min-w-0 max-w-28 truncate tabular-nums sm:max-w-none">
-              {alternateValue ?? <Skeleton className="h-4 w-16" />}
-            </InputGroupText>
-            <InputGroupButton
-              aria-label={
-                isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
-              }
-              disabled={!canUseFiat || disabled}
-              onClick={handleToggleMode}
-              size="icon-sm"
-              className="!size-9 rounded-none border-l border-input p-0"
-              title={
-                isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
-              }
+            <ArrowRightLeftIcon className="size-4" />
+          </InputGroupButton>
+          <InputGroupButton
+            aria-label={
+              isBtcDenominated
+                ? "Display bitcoin amounts in satoshis"
+                : "Display bitcoin amounts in BTC"
+            }
+            aria-pressed={isBtcDenominated}
+            disabled={disabled}
+            onClick={handleToggleBitcoinDenomination}
+            size="icon-sm"
+            className="!size-9 rounded-none rounded-r-md border-l border-input p-0 focus-visible:border-l-transparent focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring peer-focus-visible/swap:border-l-transparent aria-pressed:bg-accent aria-pressed:text-accent-foreground"
+            title={
+              isBtcDenominated
+                ? "Display bitcoin amounts in satoshis"
+                : "Display bitcoin amounts in BTC"
+            }
+          >
+            <span className="text-xs leading-none">
+              {isBtcDenominated ? "BTC" : bitcoinUnit}
+            </span>
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+      {!!contextRows?.length && (
+        <div className="flex min-w-0 cursor-default flex-col gap-1 text-sm text-muted-foreground">
+          {contextRows.map((row) => (
+            <div
+              className="flex min-w-0 items-center justify-between gap-3"
+              key={row.label}
             >
-              <ArrowRightLeftIcon className="size-4" />
-            </InputGroupButton>
-            <InputGroupButton
-              aria-label={
-                isBtcDenominated
-                  ? "Display bitcoin amounts in satoshis"
-                  : "Display bitcoin amounts in BTC"
-              }
-              aria-pressed={isBtcDenominated}
-              disabled={disabled}
-              onClick={handleToggleBitcoinDenomination}
-              size="icon-sm"
-              className="!size-9 rounded-none border-l border-input p-0 aria-pressed:bg-accent aria-pressed:text-accent-foreground"
-              title={
-                isBtcDenominated
-                  ? "Display bitcoin amounts in satoshis"
-                  : "Display bitcoin amounts in BTC"
-              }
-            >
-              <span className="text-sm leading-none">₿</span>
-            </InputGroupButton>
-          </InputGroupAddon>
-        </InputGroup>
-        {!!contextRows?.length && (
-          <>
-            <Separator />
-            <div className="flex min-w-0 flex-col gap-2 px-3 py-2 text-sm text-muted-foreground">
-              {contextRows.map((row) => (
-                <div
-                  className="flex min-w-0 items-center justify-between gap-3"
-                  key={row.label}
-                >
-                  <span className="truncate">{row.label}:</span>
-                  <span className="sensitive slashed-zero min-w-0 max-w-[55%] truncate text-right tabular-nums">
-                    {row.value ??
-                      formatBitcoinValue(
-                        row.amountSat,
-                        info?.bitcoinDisplayFormat,
-                        bitcoinDenomination
-                      )}
-                  </span>
-                </div>
-              ))}
+              <span className="truncate">{row.label}:</span>
+              <span className="sensitive slashed-zero min-w-0 max-w-[55%] truncate text-right tabular-nums">
+                {row.value ??
+                  formatBitcoinValue(
+                    row.amountSat,
+                    info?.bitcoinDisplayFormat,
+                    bitcoinDenomination
+                  )}
+              </span>
             </div>
-          </>
-        )}
-      </div>
+          ))}
+        </div>
+      )}
       {description && <FieldDescription>{description}</FieldDescription>}
       {error && <FieldError>{error}</FieldError>}
     </Field>

--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -106,8 +106,29 @@ function formatBitcoinValue(
   displayFormat: string | undefined,
   denomination: BitcoinDenomination = "sats"
 ) {
+  const { amount, unit } = formatBitcoinValueParts(
+    amountSat,
+    displayFormat,
+    denomination
+  );
+
+  if (unit === "₿") {
+    return `${unit}${amount}`;
+  }
+
+  return `${amount} ${unit}`;
+}
+
+function formatBitcoinValueParts(
+  amountSat: string | number | null | undefined,
+  displayFormat: string | undefined,
+  denomination: BitcoinDenomination = "sats"
+) {
   if (denomination === "btc") {
-    return `${formatBtcDisplay(amountSat)} BTC`;
+    return {
+      amount: formatBtcDisplay(amountSat),
+      unit: "BTC",
+    };
   }
 
   const formattedAmount = new Intl.NumberFormat().format(
@@ -115,10 +136,16 @@ function formatBitcoinValue(
   );
 
   if (displayFormat === BITCOIN_DISPLAY_FORMAT_BIP177) {
-    return `₿${formattedAmount}`;
+    return {
+      amount: formattedAmount,
+      unit: "₿",
+    };
   }
 
-  return `${formattedAmount} sats`;
+  return {
+    amount: formattedAmount,
+    unit: "sats",
+  };
 }
 
 function formatBtcDisplay(amountSat: string | number | null | undefined) {
@@ -178,6 +205,11 @@ export function CurrencyInputField({
     : isBtcDenominated
       ? btcValue
       : valueSat;
+  const alternateBitcoinValue = formatBitcoinValueParts(
+    valueSat,
+    info?.bitcoinDisplayFormat,
+    bitcoinDenomination
+  );
   const alternateValue = isFiatMode
     ? formatBitcoinValue(
         valueSat,
@@ -221,7 +253,7 @@ export function CurrencyInputField({
   }
 
   function handleAlternateValueClick() {
-    if (disabled || (!isFiatMode && !canUseFiat)) {
+    if (disabled || isFiatMode || !canUseFiat) {
       return;
     }
 
@@ -360,7 +392,16 @@ export function CurrencyInputField({
         />
         <InputGroupAddon align="inline-start">
           {isFiatMode ? (
-            <InputGroupText>{getCurrencySymbol(currency)}</InputGroupText>
+            <InputGroupButton
+              aria-label="Enter amount in bitcoin"
+              disabled={disabled}
+              onClick={handleToggleMode}
+              size="xs"
+              className="h-full rounded-none px-2 text-muted-foreground hover:text-foreground"
+              title="Enter amount in bitcoin"
+            >
+              {getCurrencySymbol(currency)}
+            </InputGroupButton>
           ) : (
             <InputGroupButton
               aria-label={
@@ -387,20 +428,66 @@ export function CurrencyInputField({
           align="inline-end"
           className="!mr-0 min-w-0 self-stretch py-0 pr-1"
         >
-          <InputGroupButton
-            aria-label={
-              isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
-            }
-            disabled={disabled || (!isFiatMode && !canUseFiat)}
-            onClick={handleAlternateValueClick}
-            size="xs"
-            className="sensitive slashed-zero h-full min-w-0 max-w-28 justify-end truncate rounded-none px-2 text-muted-foreground tabular-nums hover:text-foreground sm:max-w-none"
-            title={
-              isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
-            }
-          >
-            {alternateValue ?? <Skeleton className="h-4 w-16" />}
-          </InputGroupButton>
+          {isFiatMode ? (
+            <div className="flex h-full min-w-0 items-center">
+              {alternateBitcoinValue.unit === "₿" && (
+                <InputGroupButton
+                  aria-label={
+                    isBtcDenominated
+                      ? "Display bitcoin amounts in satoshis"
+                      : "Display bitcoin amounts in BTC"
+                  }
+                  aria-pressed={isBtcDenominated}
+                  disabled={disabled}
+                  onClick={handleToggleBitcoinDenomination}
+                  size="xs"
+                  className="h-full rounded-none px-1 text-muted-foreground hover:text-foreground aria-pressed:bg-accent aria-pressed:text-accent-foreground"
+                  title={
+                    isBtcDenominated
+                      ? "Display bitcoin amounts in satoshis"
+                      : "Display bitcoin amounts in BTC"
+                  }
+                >
+                  {alternateBitcoinValue.unit}
+                </InputGroupButton>
+              )}
+              <InputGroupText className="sensitive slashed-zero min-w-0 truncate px-1 tabular-nums">
+                {alternateBitcoinValue.amount}
+              </InputGroupText>
+              {alternateBitcoinValue.unit !== "₿" && (
+                <InputGroupButton
+                  aria-label={
+                    isBtcDenominated
+                      ? "Display bitcoin amounts in satoshis"
+                      : "Display bitcoin amounts in BTC"
+                  }
+                  aria-pressed={isBtcDenominated}
+                  disabled={disabled}
+                  onClick={handleToggleBitcoinDenomination}
+                  size="xs"
+                  className="h-full rounded-none px-1 text-muted-foreground hover:text-foreground aria-pressed:bg-accent aria-pressed:text-accent-foreground"
+                  title={
+                    isBtcDenominated
+                      ? "Display bitcoin amounts in satoshis"
+                      : "Display bitcoin amounts in BTC"
+                  }
+                >
+                  {alternateBitcoinValue.unit}
+                </InputGroupButton>
+              )}
+            </div>
+          ) : (
+            <InputGroupButton
+              aria-label="Enter amount in fiat"
+              disabled={disabled || !canUseFiat}
+              onClick={handleAlternateValueClick}
+              size="xs"
+              className="sensitive slashed-zero h-full min-w-0 max-w-28 justify-end truncate rounded-none px-2 text-muted-foreground tabular-nums hover:text-foreground sm:max-w-none"
+              title="Enter amount in fiat"
+            >
+              {alternateValue ?? <Skeleton className="h-4 w-16" />}
+            </InputGroupButton>
+          )}
         </InputGroupAddon>
       </InputGroup>
       {!!contextRows?.length && (

--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -413,7 +413,7 @@ export function CurrencyInputField({
               disabled={disabled}
               onClick={handleToggleBitcoinDenomination}
               size="xs"
-              className="h-full rounded-none px-2 text-muted-foreground hover:text-foreground aria-pressed:bg-accent aria-pressed:text-accent-foreground"
+              className="h-full rounded-none px-2 text-muted-foreground hover:text-foreground"
               title={
                 isBtcDenominated
                   ? "Display bitcoin amounts in satoshis"
@@ -441,7 +441,7 @@ export function CurrencyInputField({
                   disabled={disabled}
                   onClick={handleToggleBitcoinDenomination}
                   size="xs"
-                  className="h-full rounded-none px-1 text-muted-foreground hover:text-foreground aria-pressed:bg-accent aria-pressed:text-accent-foreground"
+                  className="h-full rounded-none px-1 text-muted-foreground hover:text-foreground"
                   title={
                     isBtcDenominated
                       ? "Display bitcoin amounts in satoshis"
@@ -465,7 +465,7 @@ export function CurrencyInputField({
                   disabled={disabled}
                   onClick={handleToggleBitcoinDenomination}
                   size="xs"
-                  className="h-full rounded-none px-1 text-muted-foreground hover:text-foreground aria-pressed:bg-accent aria-pressed:text-accent-foreground"
+                  className="h-full rounded-none px-1 text-muted-foreground hover:text-foreground"
                   title={
                     isBtcDenominated
                       ? "Display bitcoin amounts in satoshis"

--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -11,7 +11,6 @@ import {
   InputGroupAddon,
   InputGroupButton,
   InputGroupInput,
-  InputGroupText,
 } from "src/components/ui/input-group";
 import { Skeleton } from "src/components/ui/skeleton";
 import { BITCOIN_DISPLAY_FORMAT_BIP177 } from "src/constants";
@@ -429,53 +428,33 @@ export function CurrencyInputField({
           className="!mr-0 min-w-0 self-stretch py-0 pr-1"
         >
           {isFiatMode ? (
-            <div className="flex h-full min-w-0 items-center">
+            <InputGroupButton
+              aria-label={
+                isBtcDenominated
+                  ? "Display bitcoin amounts in satoshis"
+                  : "Display bitcoin amounts in BTC"
+              }
+              aria-pressed={isBtcDenominated}
+              disabled={disabled}
+              onClick={handleToggleBitcoinDenomination}
+              size="xs"
+              className="sensitive slashed-zero h-full min-w-0 justify-end truncate rounded-none bg-transparent px-0.5 text-muted-foreground tabular-nums hover:bg-transparent hover:text-foreground"
+              title={
+                isBtcDenominated
+                  ? "Display bitcoin amounts in satoshis"
+                  : "Display bitcoin amounts in BTC"
+              }
+            >
               {alternateBitcoinValue.unit === "₿" && (
-                <InputGroupButton
-                  aria-label={
-                    isBtcDenominated
-                      ? "Display bitcoin amounts in satoshis"
-                      : "Display bitcoin amounts in BTC"
-                  }
-                  aria-pressed={isBtcDenominated}
-                  disabled={disabled}
-                  onClick={handleToggleBitcoinDenomination}
-                  size="xs"
-                  className="h-full rounded-none bg-transparent px-0.5 text-muted-foreground hover:bg-transparent hover:text-foreground"
-                  title={
-                    isBtcDenominated
-                      ? "Display bitcoin amounts in satoshis"
-                      : "Display bitcoin amounts in BTC"
-                  }
-                >
-                  {alternateBitcoinValue.unit}
-                </InputGroupButton>
+                <span>{alternateBitcoinValue.unit}</span>
               )}
-              <InputGroupText className="sensitive slashed-zero min-w-0 truncate px-0.5 tabular-nums">
+              <span className="min-w-0 truncate">
                 {alternateBitcoinValue.amount}
-              </InputGroupText>
+              </span>
               {alternateBitcoinValue.unit !== "₿" && (
-                <InputGroupButton
-                  aria-label={
-                    isBtcDenominated
-                      ? "Display bitcoin amounts in satoshis"
-                      : "Display bitcoin amounts in BTC"
-                  }
-                  aria-pressed={isBtcDenominated}
-                  disabled={disabled}
-                  onClick={handleToggleBitcoinDenomination}
-                  size="xs"
-                  className="h-full rounded-none bg-transparent px-0.5 text-muted-foreground hover:bg-transparent hover:text-foreground"
-                  title={
-                    isBtcDenominated
-                      ? "Display bitcoin amounts in satoshis"
-                      : "Display bitcoin amounts in BTC"
-                  }
-                >
-                  {alternateBitcoinValue.unit}
-                </InputGroupButton>
+                <span>{alternateBitcoinValue.unit}</span>
               )}
-            </div>
+            </InputGroupButton>
           ) : (
             <InputGroupButton
               aria-label="Enter amount in fiat"

--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -369,7 +369,7 @@ export function CurrencyInputField({
       data-invalid={invalid || undefined}
     >
       {label && <FieldLabel htmlFor={inputId}>{label}</FieldLabel>}
-      <InputGroup className="h-9 min-w-0 overflow-hidden">
+      <InputGroup className="h-9 min-w-0 overflow-hidden has-[>[data-align=inline-start]]:[&>input]:pl-1">
         <InputGroupInput
           {...props}
           id={inputId}
@@ -397,7 +397,7 @@ export function CurrencyInputField({
               disabled={disabled}
               onClick={handleToggleMode}
               size="xs"
-              className="h-full rounded-none px-2 text-muted-foreground hover:text-foreground"
+              className="h-full rounded-none bg-transparent pl-2 pr-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
               title="Enter amount in bitcoin"
             >
               {getCurrencySymbol(currency)}
@@ -413,7 +413,7 @@ export function CurrencyInputField({
               disabled={disabled}
               onClick={handleToggleBitcoinDenomination}
               size="xs"
-              className="h-full rounded-none px-2 text-muted-foreground hover:text-foreground"
+              className="h-full rounded-none bg-transparent pl-2 pr-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
               title={
                 isBtcDenominated
                   ? "Display bitcoin amounts in satoshis"
@@ -441,7 +441,7 @@ export function CurrencyInputField({
                   disabled={disabled}
                   onClick={handleToggleBitcoinDenomination}
                   size="xs"
-                  className="h-full rounded-none px-1 text-muted-foreground hover:text-foreground"
+                  className="h-full rounded-none bg-transparent px-0.5 text-muted-foreground hover:bg-transparent hover:text-foreground"
                   title={
                     isBtcDenominated
                       ? "Display bitcoin amounts in satoshis"
@@ -451,7 +451,7 @@ export function CurrencyInputField({
                   {alternateBitcoinValue.unit}
                 </InputGroupButton>
               )}
-              <InputGroupText className="sensitive slashed-zero min-w-0 truncate px-1 tabular-nums">
+              <InputGroupText className="sensitive slashed-zero min-w-0 truncate px-0.5 tabular-nums">
                 {alternateBitcoinValue.amount}
               </InputGroupText>
               {alternateBitcoinValue.unit !== "₿" && (
@@ -465,7 +465,7 @@ export function CurrencyInputField({
                   disabled={disabled}
                   onClick={handleToggleBitcoinDenomination}
                   size="xs"
-                  className="h-full rounded-none px-1 text-muted-foreground hover:text-foreground"
+                  className="h-full rounded-none bg-transparent px-0.5 text-muted-foreground hover:bg-transparent hover:text-foreground"
                   title={
                     isBtcDenominated
                       ? "Display bitcoin amounts in satoshis"
@@ -482,7 +482,7 @@ export function CurrencyInputField({
               disabled={disabled || !canUseFiat}
               onClick={handleAlternateValueClick}
               size="xs"
-              className="sensitive slashed-zero h-full min-w-0 max-w-28 justify-end truncate rounded-none px-2 text-muted-foreground tabular-nums hover:text-foreground sm:max-w-none"
+              className="sensitive slashed-zero h-full min-w-0 max-w-28 justify-end truncate rounded-none bg-transparent px-1 text-muted-foreground tabular-nums hover:bg-transparent hover:text-foreground sm:max-w-none"
               title="Enter amount in fiat"
             >
               {alternateValue ?? <Skeleton className="h-4 w-16" />}

--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -147,6 +147,30 @@ function formatBitcoinValueParts(
   };
 }
 
+function BitcoinValueText({
+  amountSat,
+  denomination,
+  displayFormat,
+}: {
+  amountSat: string | number | null | undefined;
+  denomination: BitcoinDenomination;
+  displayFormat: string | undefined;
+}) {
+  const { amount, unit } = formatBitcoinValueParts(
+    amountSat,
+    displayFormat,
+    denomination
+  );
+
+  return (
+    <span className="inline-flex min-w-0 items-center justify-end gap-1">
+      {unit === "₿" && <span>{unit}</span>}
+      <span className="min-w-0 truncate">{amount}</span>
+      {unit !== "₿" && <span>{unit}</span>}
+    </span>
+  );
+}
+
 function formatBtcDisplay(amountSat: string | number | null | undefined) {
   return (getNumericValue(amountSat) / SATS_PER_BTC).toFixed(8);
 }
@@ -478,12 +502,13 @@ export function CurrencyInputField({
             >
               <span className="truncate">{row.label}:</span>
               <span className="sensitive slashed-zero min-w-0 max-w-[55%] truncate text-right tabular-nums">
-                {row.value ??
-                  formatBitcoinValue(
-                    row.amountSat,
-                    info?.bitcoinDisplayFormat,
-                    bitcoinDenomination
-                  )}
+                {row.value ?? (
+                  <BitcoinValueText
+                    amountSat={row.amountSat}
+                    displayFormat={info?.bitcoinDisplayFormat}
+                    denomination={bitcoinDenomination}
+                  />
+                )}
               </span>
             </div>
           ))}

--- a/frontend/src/components/CurrencyInputField.tsx
+++ b/frontend/src/components/CurrencyInputField.tsx
@@ -1,4 +1,3 @@
-import { ArrowRightLeftIcon } from "lucide-react";
 import * as React from "react";
 import { toast } from "sonner";
 import {
@@ -200,11 +199,15 @@ export function CurrencyInputField({
   }, [isBtcDenominated, mode, valueSat]);
 
   function handleToggleMode() {
-    if (!canUseFiat || disabled) {
+    if (disabled) {
       return;
     }
 
     if (mode === "bitcoin") {
+      if (!canUseFiat) {
+        return;
+      }
+
       setFiatValue(formatFiatInput(valueSat, rate, currency));
       setMode("fiat");
       return;
@@ -215,6 +218,14 @@ export function CurrencyInputField({
     }
 
     setMode("bitcoin");
+  }
+
+  function handleAlternateValueClick() {
+    if (disabled || (!isFiatMode && !canUseFiat)) {
+      return;
+    }
+
+    handleToggleMode();
   }
 
   function handleToggleBitcoinDenomination() {
@@ -348,55 +359,47 @@ export function CurrencyInputField({
           value={inputValue}
         />
         <InputGroupAddon align="inline-start">
-          <InputGroupText>
-            {isFiatMode
-              ? getCurrencySymbol(currency)
-              : isBtcDenominated
-                ? "BTC"
-                : bitcoinUnit}
-          </InputGroupText>
+          {isFiatMode ? (
+            <InputGroupText>{getCurrencySymbol(currency)}</InputGroupText>
+          ) : (
+            <InputGroupButton
+              aria-label={
+                isBtcDenominated
+                  ? "Display bitcoin amounts in satoshis"
+                  : "Display bitcoin amounts in BTC"
+              }
+              aria-pressed={isBtcDenominated}
+              disabled={disabled}
+              onClick={handleToggleBitcoinDenomination}
+              size="xs"
+              className="h-full rounded-none px-2 text-muted-foreground hover:text-foreground aria-pressed:bg-accent aria-pressed:text-accent-foreground"
+              title={
+                isBtcDenominated
+                  ? "Display bitcoin amounts in satoshis"
+                  : "Display bitcoin amounts in BTC"
+              }
+            >
+              {isBtcDenominated ? "BTC" : bitcoinUnit}
+            </InputGroupButton>
+          )}
         </InputGroupAddon>
         <InputGroupAddon
           align="inline-end"
-          className="!mr-0 min-w-0 self-stretch gap-0 py-0 pr-0"
+          className="!mr-0 min-w-0 self-stretch py-0 pr-1"
         >
-          <InputGroupText className="sensitive slashed-zero mr-2 min-w-0 max-w-28 truncate tabular-nums sm:max-w-none">
+          <InputGroupButton
+            aria-label={
+              isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
+            }
+            disabled={disabled || (!isFiatMode && !canUseFiat)}
+            onClick={handleAlternateValueClick}
+            size="xs"
+            className="sensitive slashed-zero h-full min-w-0 max-w-28 justify-end truncate rounded-none px-2 text-muted-foreground tabular-nums hover:text-foreground sm:max-w-none"
+            title={
+              isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
+            }
+          >
             {alternateValue ?? <Skeleton className="h-4 w-16" />}
-          </InputGroupText>
-          <InputGroupButton
-            aria-label={
-              isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
-            }
-            disabled={!canUseFiat || disabled}
-            onClick={handleToggleMode}
-            size="icon-sm"
-            className="peer/swap !size-9 rounded-none border-l border-input p-0 focus-visible:border-l-transparent focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-            title={
-              isFiatMode ? "Enter amount in bitcoin" : "Enter amount in fiat"
-            }
-          >
-            <ArrowRightLeftIcon className="size-4" />
-          </InputGroupButton>
-          <InputGroupButton
-            aria-label={
-              isBtcDenominated
-                ? "Display bitcoin amounts in satoshis"
-                : "Display bitcoin amounts in BTC"
-            }
-            aria-pressed={isBtcDenominated}
-            disabled={disabled}
-            onClick={handleToggleBitcoinDenomination}
-            size="icon-sm"
-            className="!size-9 rounded-none rounded-r-md border-l border-input p-0 focus-visible:border-l-transparent focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring peer-focus-visible/swap:border-l-transparent aria-pressed:bg-accent aria-pressed:text-accent-foreground"
-            title={
-              isBtcDenominated
-                ? "Display bitcoin amounts in satoshis"
-                : "Display bitcoin amounts in BTC"
-            }
-          >
-            <span className="text-xs leading-none">
-              {isBtcDenominated ? "BTC" : bitcoinUnit}
-            </span>
           </InputGroupButton>
         </InputGroupAddon>
       </InputGroup>


### PR DESCRIPTION
- Removed the outer bordered wrapper around the input + context rows; InputGroup now handles its own
  border and focus ring (focus only highlights the input).
- Moved contextRows out of the bordered area so they no longer look like an input.
- Added cursor-default to the contextRows wrapper to neutralize the inherited cursor: pointer from the
   global [data-slot="field"] rule.
- Always render the leading unit addon so "sats" displays when BIP-177 is not active (in addition to
  "₿", "BTC", or fiat symbol).
- Added a toast("Switched to BTC for decimal amount") when typing/pasting a decimal auto-switches the denomination to BTC.
- Replaced the embedded buttons' default focus ring with an inset 2px ring-inset ring-ring, plus  peer-focus-visible so the adjacent divider borders go transparent on focus (cleaner ring, no clipped
  vertical stripes).
  - Rounded the rightmost button's right corners (rounded-r-md) so the inset ring follows the InputGroup's curve.
  - Changed the right-side button label to show "BTC" when BTC is active and the user's preferred sats
  unit (₿ for BIP-177, otherwise sats) when sats is active.
  
  
<img width="1118" height="700" alt="image" src="https://github.com/user-attachments/assets/21a6752c-d450-45e6-9378-7353315b6d33" />

<img width="1118" height="700" alt="image" src="https://github.com/user-attachments/assets/d6a5dc97-bbe4-40ae-bb58-3d43d8bd7e4a" />


<img width="2351" height="1531" alt="image" src="https://github.com/user-attachments/assets/4f65dbc8-c0c0-4b58-8720-d0c9a2a2bbb0" />
