### PR TITLE
CLN balance offer fix and makeoffer fix

### DIFF
--- a/lnclient/cln/cln.go
+++ b/lnclient/cln/cln.go
@@ -2128,6 +2128,7 @@ func (c *CLNService) MakeOffer(ctx context.Context, description string) (string,
 	}).Debug("Make Offer")
 
 	req := &clngrpc.OfferRequest{
+		Amount:      "any",
 		Description: &description,
 	}
 	resp, err := c.client.Offer(ctx, req)

--- a/lnclient/cln/cln.go
+++ b/lnclient/cln/cln.go
@@ -994,25 +994,25 @@ func (c *CLNService) GetBalances(ctx context.Context, includeInactiveChannels bo
 
 		if ch.SpendableMsat != nil {
 			spendable := int64(ch.SpendableMsat.Msat)
-			lightning.TotalSpendable += spendable
+			lightning.TotalSpendableMsat += spendable
 
-			if spendable > lightning.NextMaxSpendable {
-				lightning.NextMaxSpendable = spendable
+			if spendable > lightning.NextMaxSpendableMsat {
+				lightning.NextMaxSpendableMsat = spendable
 			}
 		}
 
 		if ch.ReceivableMsat != nil {
 			receivable := int64(ch.ReceivableMsat.Msat)
-			lightning.TotalReceivable += receivable
+			lightning.TotalReceivableMsat += receivable
 
-			if receivable > lightning.NextMaxReceivable {
-				lightning.NextMaxReceivable = receivable
+			if receivable > lightning.NextMaxReceivableMsat {
+				lightning.NextMaxReceivableMsat = receivable
 			}
 		}
 	}
 
-	lightning.NextMaxSpendableMPP = lightning.TotalSpendable
-	lightning.NextMaxReceivableMPP = lightning.TotalReceivable
+	lightning.NextMaxSpendableMPPMsat = lightning.TotalSpendableMsat
+	lightning.NextMaxReceivableMPPMsat = lightning.TotalReceivableMsat
 
 	return &lnclient.BalancesResponse{
 		Onchain:   *onchainBalance,
@@ -1274,24 +1274,24 @@ func (c *CLNService) GetOnchainBalance(ctx context.Context) (*lnclient.OnchainBa
 		}
 
 		amt := satInt64(utxo.AmountMsat)
-		balances.Total += amt
+		balances.TotalSat += amt
 
 		if utxo.Reserved {
-			balances.Reserved += amt
+			balances.ReservedSat += amt
 			reservedSats += amt
 		}
 
 		switch utxo.Status {
 		case clngrpc.ListfundsOutputs_CONFIRMED:
 			if !utxo.Reserved {
-				balances.Spendable += amt
+				balances.SpendableSat += amt
 			}
 
 		case clngrpc.ListfundsOutputs_UNCONFIRMED:
 			balances.PendingSweepBalancesDetails = append(
 				balances.PendingSweepBalancesDetails,
 				lnclient.PendingBalanceDetails{
-					Amount:        uint64(amt),
+					AmountSat:     uint64(amt),
 					FundingTxId:   hex.EncodeToString(utxo.Txid),
 					FundingTxVout: utxo.Output,
 				},
@@ -1305,13 +1305,13 @@ func (c *CLNService) GetOnchainBalance(ctx context.Context) (*lnclient.OnchainBa
 		}
 
 		amt := sat(ch.OurAmountMsat)
-		balances.PendingBalancesFromChannelClosures += amt
+		balances.PendingBalancesFromChannelClosuresSat += amt
 		chanIdStr := hex.EncodeToString(ch.ChannelId)
 
 		detail := lnclient.PendingBalanceDetails{
 			ChannelId: chanIdStr,
 			NodeId:    hex.EncodeToString(ch.PeerId),
-			Amount:    amt,
+			AmountSat: amt,
 		}
 
 		if pc, ok := chByID[chanIdStr]; ok {


### PR DESCRIPTION
Fixes: #2361

I think these fields got deprecated between opening and merging the original CLN PR. In `go` my editor is not able to show deprecated fields for some reason...

Also fixes makeoffer, it was missing the amount field which is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal mechanisms for balance calculation and tracking across all balance management systems have been improved to enhance accuracy and consistency in balance reporting. This includes standardized handling of balance data and improved offer request configuration. These refinements ensure better system reliability, accuracy, and overall compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getAlby/hub/pull/2373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->