### PR TITLE
fix: prevent scrollbar on incoming capacity page

### DIFF
--- a/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
+++ b/frontend/src/screens/channels/IncreaseIncomingCapacity.tsx
@@ -487,8 +487,8 @@ function NewChannelInternal({
           <Button size="lg">Review Order</Button>
         </form>
 
-        <div className="flex-1 flex flex-col justify-end items-center gap-4">
-          <p className="mt-32 text-sm text-muted-foreground text-center">
+        <div className="flex-1 flex flex-col justify-end gap-2">
+          <p className="text-sm text-muted-foreground text-center">
             Other options
           </p>
           <LinkButton


### PR DESCRIPTION
The Open Channel with Lightning page (`/channels/incoming`) was overflowing the viewport at standard sizes due to a `mt-32` margin pushing the "Other options" section past the fold.

## Summary
- Drop the 128px top margin on the "Other options" label — `flex-1 justify-end` already anchors it to the bottom of the column
- Tighten the gap between the label and the buttons (`gap-4` → `gap-2`)

## Test plan
- [ ] Open `/channels/incoming` at 1440x900 — page fits with no scrollbar
- [ ] Confirm "Other options" section still reads as a distinct footer block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout and spacing in the "Other options" footer area of the Increase Incoming Capacity screen for better visual alignment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getAlby/hub/pull/2383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->