### PR TITLE
fix: stop retrying NIP47 info publish for deleted apps

### DIFF
--- a/nip47/nip47_service.go
+++ b/nip47/nip47_service.go
@@ -2,6 +2,7 @@ package nip47
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/getAlby/go-nostr"
@@ -114,6 +115,18 @@ func (svc *nip47Service) StartNip47InfoPublisher(ctx context.Context, pool *nost
 			case req := <-svc.nip47InfoPublishQueue.Channel():
 				_, err := svc.PublishNip47Info(ctx, pool, req.AppId, req.AppWalletPubKey, req.AppWalletPrivKey, req.RelayUrl, lnClient)
 				if err != nil {
+					// the app connection no longer exists (e.g. it was deleted),
+					// so the info event can never be published - drop the item
+					// instead of retrying forever
+					if errors.Is(err, gorm.ErrRecordNotFound) {
+						logger.Logger.WithError(err).WithFields(logrus.Fields{
+							"app_id":        req.AppId,
+							"wallet_pubkey": req.AppWalletPubKey,
+							"relay_url":     req.RelayUrl,
+						}).Warn("Skipping NIP47 info publish for deleted app")
+						continue
+					}
+
 					logger.Logger.WithError(err).WithFields(logrus.Fields{
 						"wallet_pubkey": req.AppWalletPubKey,
 						"relay_url":     req.RelayUrl,

--- a/nip47/publish_nip47_info_test.go
+++ b/nip47/publish_nip47_info_test.go
@@ -1,0 +1,36 @@
+package nip47
+
+import (
+	"context"
+	"testing"
+
+	"github.com/getAlby/go-nostr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/getAlby/hub/alby"
+	"github.com/getAlby/hub/tests"
+)
+
+// When an app connection has been deleted, publishing its NIP47 info must
+// surface gorm.ErrRecordNotFound so the publish queue can drop the item
+// instead of retrying forever.
+func TestPublishNip47Info_AppNotFound(t *testing.T) {
+	svc, err := tests.CreateTestService(t)
+	require.NoError(t, err)
+	defer svc.Remove()
+
+	albyOAuthSvc := alby.NewAlbyOAuthService(svc.DB, svc.Cfg, svc.Keys, svc.EventPublisher)
+	nip47svc := NewNip47Service(svc.DB, svc.Cfg, svc.Keys, svc.EventPublisher, albyOAuthSvc)
+
+	walletPrivKey := nostr.GeneratePrivateKey()
+	walletPubKey, err := nostr.GetPublicKey(walletPrivKey)
+	require.NoError(t, err)
+
+	// app id 9999999 does not exist; the DB lookup fails before the relay pool
+	// is ever used, so a nil pool/lnClient is fine here.
+	_, err = nip47svc.PublishNip47Info(context.Background(), nil, 9999999, walletPubKey, walletPrivKey, "wss://relay.example.com", nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}


### PR DESCRIPTION


## Problem

The NIP47 info publish queue (`StartNip47InfoPublisher` in `nip47/nip47_service.go`) re-enqueues **every** failed publish with an incrementing backoff and **no terminal condition**.

When an app connection has been deleted, `PublishNip47Info` fails the `db.First(&app, appId)` lookup with `gorm.ErrRecordNotFound` on every attempt — so the queue item is retried **forever** (~once a minute). In the last 24h of production logs this showed up as a steady stream of `Failed to publish NIP47 info from queue` errors (`error: record not found`) concentrated on individual instances stuck retrying deleted apps.

## Fix

When the publish fails with `gorm.ErrRecordNotFound`, the app no longer exists and the info event can never be published — so we **drop the queue item** instead of requeuing. All other errors (offline relay, publish timeouts) still retry with backoff as before.

## Test

Added `TestPublishNip47Info_AppNotFound` which locks the contract the fix relies on: publishing info for a non-existent app surfaces `gorm.ErrRecordNotFound` (so the loop's `errors.Is` drop logic stays correct if the error handling is ever refactored).

`go test ./nip47/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

fixes #2390 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced NIP47 info publishing with improved error detection: when an app connection is not found, the system now drops the queued request instead of retrying indefinitely, with appropriate warning logs.

* **Tests**
  * Added test case validating error handling for non-existent app connections during publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->