### PR TITLE
fix: change first payment checklist item to receive-only (#2393)

### DIFF
--- a/frontend/src/hooks/useOnboardingData.ts
+++ b/frontend/src/hooks/useOnboardingData.ts
@@ -3,6 +3,7 @@
 import { ALBY_ACCOUNT_APP_NAME } from "src/constants";
 import { useAlbyMe } from "src/hooks/useAlbyMe";
 import { useApps } from "src/hooks/useApps";
+import { useBalances } from "src/hooks/useBalances";
 import { useChannels } from "src/hooks/useChannels";
 import { useInfo } from "src/hooks/useInfo";
 import { useNodeConnectionInfo } from "src/hooks/useNodeConnectionInfo";
@@ -24,6 +25,7 @@ interface UseOnboardingDataResponse {
 export const useOnboardingData = (): UseOnboardingDataResponse => {
   const { data: albyMe } = useAlbyMe();
   const { data: appsData } = useApps();
+  const { data: balances } = useBalances();
   const { data: channels } = useChannels();
   const { data: info, hasChannelManagement, hasMnemonic } = useInfo();
   const { data: nodeConnectionInfo } = useNodeConnectionInfo();
@@ -31,6 +33,7 @@ export const useOnboardingData = (): UseOnboardingDataResponse => {
 
   const isLoading =
     !appsData ||
+    !balances ||
     !channels ||
     !info ||
     !nodeConnectionInfo ||
@@ -55,7 +58,8 @@ export const useOnboardingData = (): UseOnboardingDataResponse => {
   const hasCustomApp =
     appsData &&
     appsData.apps.find((x) => x.name !== ALBY_ACCOUNT_APP_NAME) !== undefined;
-  const hasTransaction = transactions.totalCount > 0;
+  const hasFundsOrTransaction =
+    transactions.totalCount > 0 || balances.lightning.totalSpendableSat > 0;
 
   const checklistItems: Omit<ChecklistItem, "disabled">[] = [
     ...(hasChannelManagement
@@ -81,9 +85,9 @@ export const useOnboardingData = (): UseOnboardingDataResponse => {
         ]
       : []),
     {
-      title: "Send or receive your first payment",
-      description: "Add funds to your wallet, then make your first payment.",
-      checked: hasTransaction,
+      title: "Receive your first payment",
+      description: "Add funds to your wallet to start using it.",
+      checked: hasFundsOrTransaction,
       to: "/wallet",
     },
     {


### PR DESCRIPTION
Closes #2393

## What
- Renames the onboarding checklist item from **"Send or receive your first payment"** to **"Receive your first payment"**, with copy updated to match ("Add funds to your wallet to start using it.").
- Marks the item complete when the wallet has a non-zero spendable lightning balance, in addition to the existing "has a transaction" check.

## Why
Users who open an outbound channel end up with a spendable balance but no transaction yet. Previously the checklist item stayed unchecked, giving a confusing experience. Now it's considered done once funds are available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved first payment checklist detection to recognize available wallet funds in addition to completed transactions.
  * Updated the checklist item from "Send or receive your first payment" to "Receive your first payment" with refreshed description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->