### PR TITLE
ci: align Wails CLI version

### DIFF
--- a/.github/workflows/wails.yml
+++ b/.github/workflows/wails.yml
@@ -76,7 +76,7 @@ jobs:
           node-version: "20.x"
 
       - name: Install Wails
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.11.0
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
         shell: bash
 
       - name: Install Linux Wails deps


### PR DESCRIPTION
## Summary
- update the Wails CLI installed in the Wails build workflow from v2.11.0 to v2.12.0
- aligns the CI CLI version with `github.com/wailsapp/wails/v2 v2.12.0` in `go.mod` to remove the version mismatch warning

## Testing
- `python3` assertion: workflow installs Wails CLI v2.12.0, no v2.11.0 install remains, and `go.mod` requires Wails v2.12.0
- parsed `.github/workflows/wails.yml` with PyYAML
- `git diff --check`

No local Wails build was run because this change only updates the CI-installed Wails CLI pin; GitHub CI will exercise the actual Wails build matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to use the latest version of the build tooling for improved build reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->