### PR TITLE
fix: update Bark FFI bindings

### DIFF
--- a/.github/workflows/wails.yml
+++ b/.github/workflows/wails.yml
@@ -123,19 +123,9 @@ jobs:
         run: wails build --platform linux/amd64 -webview2 embed -o "${{ env.EXEC_NAME }}" -tags "wails,webkit2_41" -ldflags "-X 'github.com/getAlby/hub/version.Tag=${{ env.TAG }}'"
         shell: bash
 
-      # The bark FFI static library is built for the GNU/mingw target and embeds
-      # Rust's getrandom/ring code, which references Windows CNG symbols such as
-      # BCryptGenRandom. The upstream bark bindings only link -lbark_ffi_go, so
-      # we link the missing Windows system libraries via CGO_LDFLAGS (cgo reads
-      # this directly; -ldflags/-extldflags get dropped by wails). They are
-      # wrapped together with bark in a --start-group so the linker re-scans the
-      # group and resolves the symbols regardless of library order on the line.
       - name: Build Windows App
         if: runner.os == 'Windows'
-        run: |
-          BARK_LIB="$(go list -m -f '{{.Dir}}' gitlab.com/ark-bitcoin/bark-ffi-bindings/golang)/lib/windows_amd64"
-          export CGO_LDFLAGS="-Wl,--start-group -L${BARK_LIB} -lbark_ffi_go -lbcrypt -lntdll -luserenv -lws2_32 -lcrypt32 -lncrypt -lsecur32 -ladvapi32 -Wl,--end-group"
-          wails build --platform windows/amd64 -webview2 embed -o "${{ env.EXEC_NAME }}.exe" -tags "wails" -ldflags "-X 'github.com/getAlby/hub/version.Tag=${{ env.TAG }}'"
+        run: wails build --platform windows/amd64 -webview2 embed -o "${{ env.EXEC_NAME }}.exe" -tags "wails" -ldflags "-X 'github.com/getAlby/hub/version.Tag=${{ env.TAG }}'"
         shell: bash
 
       - name: Import Code-Signing Certificates for macOS

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/wailsapp/wails/v2 v2.12.0
-	gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.6.2
+	gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.7.0
 	golang.org/x/crypto v0.52.0
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/grpc v1.79.3

--- a/go.sum
+++ b/go.sum
@@ -662,8 +662,8 @@ github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5t
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
-gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.6.2 h1:UwqTPL4dmG4N+RDJaci6D2MhiWvBbBsCss4nDbYt8TM=
-gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.6.2/go.mod h1:1jAwB/XR4i3D72fz3qWAd41tQLYcOCGfWZHMagn5fNg=
+gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.7.0 h1:X8h/JbdfDoHGvw2UQZJmIkpwAgANzBK5KxrZG7zChmc=
+gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.7.0/go.mod h1:1jAwB/XR4i3D72fz3qWAd41tQLYcOCGfWZHMagn5fNg=
 go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
 go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 go.etcd.io/etcd/api/v3 v3.5.16 h1:WvmyJVbjWqK4R1E+B12RRHz3bRGy9XVfh++MgbN+6n0=

--- a/lnclient/bark/bark.go
+++ b/lnclient/bark/bark.go
@@ -474,7 +474,7 @@ func (bs *BarkService) SendPaymentSync(invoice string, amountMsat *uint64) (*lnc
 	}
 	defer bs.clearInflightSend(paymentHash)
 
-	if _, err := bs.wallet.PayLightningInvoice(invoice, nil); err != nil {
+	if _, err := bs.wallet.PayLightningInvoice(invoice, nil, false); err != nil {
 		return nil, fmt.Errorf("bark PayLightningInvoice failed: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- update `gitlab.com/ark-bitcoin/bark-ffi-bindings/golang` from `v0.6.2` to `v0.7.0` (GitLab release `v0.7.0+bark.0.2.2`)
- adapt `PayLightningInvoice` call to the new Bark API signature
- remove the temporary Windows `CGO_LDFLAGS` workaround from the Wails workflow

Fixes #2399

## Notes
- The new Bark FFI `v0.7.0` module includes Windows cgo link directives for `-lbcrypt`, `-lntdll`, `-lws2_32`, `-luserenv`, and `-ladvapi32`, so Hub no longer needs to inject those libraries in the workflow.
- I could not locally run the actual Windows Wails build because `x86_64-w64-mingw32-gcc` is not installed in this Linux environment; the GitHub Wails Windows job should verify the real issue path.

## Testing
- `git diff --check`
- static assertion: workflow no longer contains `CGO_LDFLAGS`/`BARK_LIB`; Bark FFI v0.7.0 cgo directives contain required Windows system libraries
- `yarn tsc:compile`
- `go test ./lnclient/bark ./service ./api ./transactions`
- `go list ./... | grep -Ev '/(cmd/http|frontend|http)$' | xargs go test -run '^$'`\n\n`yarn build:http` was also attempted but was OOM-killed in this droplet (`exit 137`) during Vite rendering; TypeScript compilation passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go module dependencies to latest versions for improved stability
  * Streamlined Windows build configuration for optimized deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->