### PR TITLE
fix: ignore 404 when deleting a lightning address (#2323)

### DIFF
--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -418,6 +418,13 @@ func (svc *albyOAuthService) DeleteLightningAddress(ctx context.Context, address
 		return errors.New("failed to read response body")
 	}
 
+	if res.StatusCode == http.StatusNotFound {
+		// The lightning address was already deleted on the Alby account
+		// (e.g. removed previously). Treat as success so deletion is idempotent.
+		logger.Logger.WithField("address", address).Info("Lightning address already deleted on Alby account, ignoring 404")
+		return nil
+	}
+
 	if res.StatusCode >= 300 {
 		return fmt.Errorf("DELETE request to /internal/lightning_addresses/%s returned non-success status: %d %s", address, res.StatusCode, string(responseBody))
 	}


### PR DESCRIPTION

Fixes #2323.

getalby.com returns `404` when the lightning address is already deleted, so we now ignore that status and the deletion succeeds instead of showing a "Failed to delete lightning address" error toast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of lightning address deletion; the system now gracefully handles cases where the address has already been removed, treating this scenario as a successful operation rather than an error condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->