### PR TITLE
feat: generate CLN invoice preimage ourselves to support sub-wallets

### DIFF
--- a/apps/apps_service.go
+++ b/apps/apps_service.go
@@ -59,9 +59,10 @@ func (svc *appsService) CreateApp(name string, pubkey string, maxAmountSat uint6
 		if backendType != config.LDKBackendType &&
 			backendType != config.LNDBackendType &&
 			backendType != config.PhoenixBackendType &&
-			backendType != config.BarkBackendType {
+			backendType != config.BarkBackendType &&
+			backendType != config.CLNBackendType {
 			return nil, "", fmt.Errorf(
-				"sub-wallets are currently not supported on your node backend. Try LDK or LND")
+				"sub-wallets are currently not supported on your node backend. Try LDK, LND, PHOENIX, BARK, or CLN")
 		}
 	}
 

--- a/apps/tests/apps_service_test.go
+++ b/apps/tests/apps_service_test.go
@@ -54,5 +54,5 @@ func TestHandleCreateApp_IsolatedUnsupportedBackendType(t *testing.T) {
 	assert.Nil(t, app)
 	assert.Equal(t, "", secretKey)
 	require.Error(t, err)
-	assert.Equal(t, "sub-wallets are currently not supported on your node backend. Try LDK or LND", err.Error())
+	assert.Equal(t, "sub-wallets are currently not supported on your node backend. Try LDK, LND, PHOENIX, BARK, or CLN", err.Error())
 }

--- a/lnclient/cln/cln.go
+++ b/lnclient/cln/cln.go
@@ -2,6 +2,7 @@ package cln
 
 import (
 	"context"
+	crand "crypto/rand"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
@@ -9,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/rand"
+	mrand "math/rand"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -680,7 +681,7 @@ func (c *CLNService) subscribeOpenHoldInvoices(ctx context.Context) {
 
 			backoff := min(baseBackoff*time.Duration(1<<attempt), maxBackoff)
 
-			jitter := time.Duration(rand.Int63n(int64(backoff / 2)))
+			jitter := time.Duration(mrand.Int63n(int64(backoff / 2)))
 			sleep := backoff/2 + jitter
 
 			logger.Logger.WithError(err).
@@ -2055,9 +2056,15 @@ func (c *CLNService) MakeInvoice(ctx context.Context, amountMsat int64, descript
 			Value: &clngrpc.AmountOrAny_Any{Any: true}}
 	}
 
+	preimage, err := GeneratePreimage()
+	if err != nil {
+		return nil, err
+	}
+
 	req := &clngrpc.InvoiceRequest{
 		Description:  description,
 		Label:        label,
+		Preimage:     preimage,
 		Expiry:       &myExpiry,
 		Deschashonly: &deschashonly,
 		AmountMsat:   &Amount,
@@ -2068,7 +2075,7 @@ func (c *CLNService) MakeInvoice(ctx context.Context, amountMsat int64, descript
 	if throughNodePubkey != nil {
 		throughNodePubkeyBytes, err := hex.DecodeString(*throughNodePubkey)
 		if err != nil {
-			return nil, fmt.Errorf("Could not convert throughNodePubkey to bytes")
+			return nil, err
 		}
 		lpc, err := c.client.ListPeerChannels(ctx, &clngrpc.ListpeerchannelsRequest{
 			Id: throughNodePubkeyBytes,
@@ -2108,7 +2115,7 @@ func (c *CLNService) MakeInvoice(ctx context.Context, amountMsat int64, descript
 		Invoice:         resp.Bolt11,
 		Description:     description,
 		DescriptionHash: descriptionHash,
-		Preimage:        "",
+		Preimage:        hex.EncodeToString(preimage),
 		PaymentHash:     hex.EncodeToString(resp.PaymentHash),
 		AmountMsat:      amountMsat,
 		FeesPaidMsat:    0,
@@ -2120,6 +2127,17 @@ func (c *CLNService) MakeInvoice(ctx context.Context, amountMsat int64, descript
 	}
 
 	return transaction, nil
+}
+
+func GeneratePreimage() ([]byte, error) {
+	preimage := make([]byte, 32)
+
+	_, err := crand.Read(preimage[:])
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate preimage: %w", err)
+	}
+
+	return preimage, nil
 }
 
 func (c *CLNService) MakeOffer(ctx context.Context, description string) (string, error) {

--- a/nip47/controllers/create_connection_controller_test.go
+++ b/nip47/controllers/create_connection_controller_test.go
@@ -130,7 +130,7 @@ func TestHandleCreateConnectionEvent_IsolatedUnsupportedBackendType(t *testing.T
 
 	assert.NotNil(t, publishedResponse.Error)
 	assert.Equal(t, constants.ERROR_INTERNAL, publishedResponse.Error.Code)
-	assert.Equal(t, "sub-wallets are currently not supported on your node backend. Try LDK or LND", publishedResponse.Error.Message)
+	assert.Equal(t, "sub-wallets are currently not supported on your node backend. Try LDK, LND, PHOENIX, BARK, or CLN", publishedResponse.Error.Message)
 	assert.Equal(t, models.CREATE_CONNECTION_METHOD, publishedResponse.ResultType)
 }
 


### PR DESCRIPTION
Fixes: #2411



We can't generate a preimage for keysend in CLN. You only get it after payment is done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Isolated app support now includes PHOENIX, BARK, and CLN backends in addition to existing options.
  * CLN backend now generates and returns invoice preimages for invoices.

* **Bug Fixes**
  * Improved randomness and retry jitter handling in CLN invoice workflows.
  * Error messages for unsupported backends updated to list the expanded supported set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->