### PR TITLE
fix: add validation on MakeInvoice for zero and non-whole satoshi amounts

### DIFF
--- a/transactions/make_invoice_test.go
+++ b/transactions/make_invoice_test.go
@@ -26,7 +26,7 @@ func TestMakeInvoice_NoApp(t *testing.T) {
 	txMetadata["randomkey"] = strings.Repeat("a", constants.INVOICE_METADATA_MAX_LENGTH-16) // json encoding adds 16 characters - {"randomkey":""}
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.MakeInvoice(ctx, 1234, "Hello world", "", 0, txMetadata, svc.LNClient, nil, nil, nil)
+	transaction, err := transactionsService.MakeInvoice(ctx, 1000, "Hello world", "", 0, txMetadata, svc.LNClient, nil, nil, nil)
 	assert.NoError(t, err)
 
 	var metadata map[string]interface{}
@@ -50,10 +50,40 @@ func TestMakeInvoice_MetadataTooLarge(t *testing.T) {
 	metadata["randomkey"] = strings.Repeat("a", constants.INVOICE_METADATA_MAX_LENGTH-15) // json encoding adds 16 characters
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.MakeInvoice(ctx, 1234, "Hello world", "", 0, metadata, svc.LNClient, nil, nil, nil)
+	transaction, err := transactionsService.MakeInvoice(ctx, 1000, "Hello world", "", 0, metadata, svc.LNClient, nil, nil, nil)
 
 	assert.Error(t, err)
 	assert.Equal(t, fmt.Sprintf("encoded invoice metadata provided is too large. Limit: %d Received: %d", constants.INVOICE_METADATA_MAX_LENGTH, constants.INVOICE_METADATA_MAX_LENGTH+1), err.Error())
+	assert.Nil(t, transaction)
+}
+
+func TestMakeInvoice_AmountNotWholeSats(t *testing.T) {
+	ctx := context.TODO()
+
+	svc, err := tests.CreateTestService(t)
+	require.NoError(t, err)
+	defer svc.Remove()
+
+	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
+	transaction, err := transactionsService.MakeInvoice(ctx, 1234, "Hello world", "", 0, nil, svc.LNClient, nil, nil, nil)
+
+	require.Error(t, err)
+	assert.Equal(t, "the amount must be a whole number of satoshis", err.Error())
+	assert.Nil(t, transaction)
+}
+
+func TestMakeInvoice_AmountTooLow(t *testing.T) {
+	ctx := context.TODO()
+
+	svc, err := tests.CreateTestService(t)
+	require.NoError(t, err)
+	defer svc.Remove()
+
+	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
+	transaction, err := transactionsService.MakeInvoice(ctx, 0, "Hello world", "", 0, nil, svc.LNClient, nil, nil, nil)
+
+	require.Error(t, err)
+	assert.Equal(t, "the amount must be at least 1 satoshi", err.Error())
 	assert.Nil(t, transaction)
 }
 
@@ -72,7 +102,7 @@ func TestMakeInvoice_App(t *testing.T) {
 	assert.NoError(t, err)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.MakeInvoice(ctx, 1234, "Hello world", "", 0, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
+	transaction, err := transactionsService.MakeInvoice(ctx, 1000, "Hello world", "", 0, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(tests.MockLNClientTransaction.AmountMsat), transaction.AmountMsat)

--- a/transactions/transactions_service.go
+++ b/transactions/transactions_service.go
@@ -152,6 +152,13 @@ func (svc *transactionsService) MakeInvoice(ctx context.Context, amountMsat uint
 		"metadata":         metadata,
 	}).Debug("Making invoice")
 
+	if amountMsat%1000 != 0 {
+		return nil, errors.New("the amount must be a whole number of satoshis")
+	}
+	if amountMsat < 1000 {
+		return nil, errors.New("the amount must be at least 1 satoshi")
+	}
+
 	var metadataBytes []byte
 	if metadata != nil {
 		var err error


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice amount validation: The invoice creation service now includes validation to ensure all amounts are whole satoshis (no fractional satoshi amounts allowed) and meet a minimum requirement of 1 satoshi per invoice. Users attempting to create invoices with fractional or below-minimum amounts will receive clear, helpful error messages explaining the validation constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->