### PR TITLE
feat: pass selected provider to card topup app

### DIFF
--- a/frontend/src/components/connections/BitcoinCardTopupInstallGuide.tsx
+++ b/frontend/src/components/connections/BitcoinCardTopupInstallGuide.tsx
@@ -26,9 +26,7 @@ export function BitcoinCardTopupInstallGuide() {
           </span>{" "}
           (or bookmark it) so you can reopen it later.
         </li>
-        <li>
-          Enter your card's deposit address, network, and currency to set it up.
-        </li>
+        <li>Enter your card's deposit details to set it up.</li>
       </ul>
     </div>
   );

--- a/frontend/src/components/connections/BitcoinCardTopupInstallGuide.tsx
+++ b/frontend/src/components/connections/BitcoinCardTopupInstallGuide.tsx
@@ -1,0 +1,35 @@
+import { useLocation } from "react-router";
+import ExternalLink from "src/components/ExternalLink";
+
+// The card topup app supports configuration presets selected via a `provider`
+// query param (e.g. linked from the Cards page). Read it straight from the URL
+// so the link opens card.albylabs.com pre-configured for the chosen provider.
+export function BitcoinCardTopupInstallGuide() {
+  const provider = new URLSearchParams(useLocation().search).get("provider");
+  const url = provider
+    ? `https://card.albylabs.com?provider=${encodeURIComponent(provider)}`
+    : "https://card.albylabs.com";
+
+  return (
+    <div>
+      <ul className="list-inside list-decimal text-muted-foreground">
+        <li>
+          Open{" "}
+          <ExternalLink to={url} className="underline">
+            card.albylabs.com
+          </ExternalLink>{" "}
+          on the device you'll top up from.
+        </li>
+        <li>
+          <span className="font-medium text-foreground">
+            Add it to your home screen
+          </span>{" "}
+          (or bookmark it) so you can reopen it later.
+        </li>
+        <li>
+          Enter your card's deposit address, network, and currency to set it up.
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/connections/SuggestedAppData.tsx
+++ b/frontend/src/components/connections/SuggestedAppData.tsx
@@ -1,5 +1,5 @@
 import { ZapIcon } from "lucide-react";
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 import topup2fiat from "src/assets/suggested-apps/2fiat-topup.png";
 import albyExtension from "src/assets/suggested-apps/alby-extension.png";
 import albyGo from "src/assets/suggested-apps/alby-go.png";
@@ -55,6 +55,39 @@ import zapstore from "src/assets/suggested-apps/zapstore.png";
 import zeus from "src/assets/suggested-apps/zeus.png";
 import ExternalLink from "src/components/ExternalLink";
 import { App } from "src/types";
+
+// The card topup app supports configuration presets selected via a `provider`
+// query param (e.g. linked from the Cards page). Read it straight from the URL
+// so the link opens card.albylabs.com pre-configured for the chosen provider.
+function BitcoinCardTopupInstallGuide() {
+  const provider = new URLSearchParams(useLocation().search).get("provider");
+  const url = provider
+    ? `https://card.albylabs.com?provider=${encodeURIComponent(provider)}`
+    : "https://card.albylabs.com";
+
+  return (
+    <div>
+      <ul className="list-inside list-decimal text-muted-foreground">
+        <li>
+          Open{" "}
+          <ExternalLink to={url} className="underline">
+            card.albylabs.com
+          </ExternalLink>{" "}
+          on the device you'll top up from.
+        </li>
+        <li>
+          <span className="font-medium text-foreground">
+            Add it to your home screen
+          </span>{" "}
+          (or bookmark it) so you can reopen it later.
+        </li>
+        <li>
+          Enter your card's deposit address, network, and currency to set it up.
+        </li>
+      </ul>
+    </div>
+  );
+}
 
 export type AppStoreApp = {
   id: string;
@@ -228,34 +261,7 @@ export const appStoreApps: AppStoreApp[] = (
       extendedDescription:
         "A generic top-up app that swaps Lightning sats to a stablecoin and sends them to your card's deposit address. Works with RedotPay, Freedomia, Nexo, Bybit, and any other card that accepts on-chain crypto deposits.",
       webLink: "https://card.albylabs.com",
-      installGuide: (
-        <>
-          <div>
-            <ul className="list-inside list-decimal text-muted-foreground">
-              <li>
-                Open{" "}
-                <ExternalLink
-                  to="https://card.albylabs.com"
-                  className="underline"
-                >
-                  card.albylabs.com
-                </ExternalLink>{" "}
-                on the device you'll top up from.
-              </li>
-              <li>
-                <span className="font-medium text-foreground">
-                  Add it to your home screen
-                </span>{" "}
-                (or bookmark it) so you can reopen it later.
-              </li>
-              <li>
-                Enter your card's deposit address, network, and currency to set
-                it up.
-              </li>
-            </ul>
-          </div>
-        </>
-      ),
+      installGuide: <BitcoinCardTopupInstallGuide />,
       finalizeGuide: (
         <>
           <div>

--- a/frontend/src/components/connections/SuggestedAppData.tsx
+++ b/frontend/src/components/connections/SuggestedAppData.tsx
@@ -1,5 +1,5 @@
 import { ZapIcon } from "lucide-react";
-import { Link, useLocation } from "react-router";
+import { Link } from "react-router";
 import topup2fiat from "src/assets/suggested-apps/2fiat-topup.png";
 import albyExtension from "src/assets/suggested-apps/alby-extension.png";
 import albyGo from "src/assets/suggested-apps/alby-go.png";
@@ -53,41 +53,9 @@ import zapplepay from "src/assets/suggested-apps/zapple-pay.png";
 import zappybird from "src/assets/suggested-apps/zappy-bird.png";
 import zapstore from "src/assets/suggested-apps/zapstore.png";
 import zeus from "src/assets/suggested-apps/zeus.png";
+import { BitcoinCardTopupInstallGuide } from "src/components/connections/BitcoinCardTopupInstallGuide";
 import ExternalLink from "src/components/ExternalLink";
 import { App } from "src/types";
-
-// The card topup app supports configuration presets selected via a `provider`
-// query param (e.g. linked from the Cards page). Read it straight from the URL
-// so the link opens card.albylabs.com pre-configured for the chosen provider.
-function BitcoinCardTopupInstallGuide() {
-  const provider = new URLSearchParams(useLocation().search).get("provider");
-  const url = provider
-    ? `https://card.albylabs.com?provider=${encodeURIComponent(provider)}`
-    : "https://card.albylabs.com";
-
-  return (
-    <div>
-      <ul className="list-inside list-decimal text-muted-foreground">
-        <li>
-          Open{" "}
-          <ExternalLink to={url} className="underline">
-            card.albylabs.com
-          </ExternalLink>{" "}
-          on the device you'll top up from.
-        </li>
-        <li>
-          <span className="font-medium text-foreground">
-            Add it to your home screen
-          </span>{" "}
-          (or bookmark it) so you can reopen it later.
-        </li>
-        <li>
-          Enter your card's deposit address, network, and currency to set it up.
-        </li>
-      </ul>
-    </div>
-  );
-}
 
 export type AppStoreApp = {
   id: string;

--- a/frontend/src/screens/cards/Cards.tsx
+++ b/frontend/src/screens/cards/Cards.tsx
@@ -776,10 +776,16 @@ function ConnectCardDialog({
             if (!p.appStoreId) {
               return null;
             }
+            // The generic card topup app pre-configures itself from a `provider`
+            // query param; pass the selected provider so its preset is applied.
+            const to =
+              p.appStoreId === "bitcoin-card-topup"
+                ? `/apps/new?app=${p.appStoreId}&provider=${encodeURIComponent(p.id)}`
+                : `/apps/new?app=${p.appStoreId}`;
             return (
               <Link
                 key={p.id}
-                to={`/apps/new?app=${p.appStoreId}`}
+                to={to}
                 onClick={() => {
                   sendEvent("debit_card_connect", { name: p.name });
                   onOpenChange(false);


### PR DESCRIPTION
## Summary

The Bitcoin Card Topup app (`card.albylabs.com`) now has configuration presets per card provider, which simplifies the initial setup. This passes the provider selected on the Cards page through to the topup app so its preset is pre-applied.

Closes #2384

## Changes

- **`Cards.tsx`** — the "Connect card" dialog now appends `&provider=<id>` to the `/apps/new` link, but only for providers routed through the generic `bitcoin-card-topup` app (RedotPay, Freedomia). Separate apps (2fiat, Bringin, wavecard) and the "Other card" path are unchanged.
- **`SuggestedAppData.tsx`** — the `bitcoin-card-topup` install guide is now a small self-contained component that reads the `provider` query param from the URL and builds the `https://card.albylabs.com?provider=<id>` link.

`provider` is treated as just a query param local to the card topup guide — it is **not** added to the generic app-install machinery (`InstallApp`, `AppStoreApp`, `NewApp`, `AppLinksCard` all stay untouched).

## Testing

- Cards → Connect card → **RedotPay** → `/apps/new?app=bitcoin-card-topup&provider=redotpay`; the install link points to `https://card.albylabs.com?provider=redotpay`.
- **Freedomia** → `?provider=freedomia`.
- **Other card** → no provider param; link stays bare `https://card.albylabs.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced informational alert for Just-in-Time (JIT) channel users with configured liquidity sources and no existing channels
  * Added provider-specific Bitcoin card topup installation guide with customized setup links based on selected provider

<!-- end of auto-generated comment: release notes by coderabbit.ai -->