### PR TITLE
chore: document branch naming conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,16 @@ Code under `frontend/platform_specific/http/` and `frontend/platform_specific/wa
 - New screens added to `frontend/src/routes.tsx`.
 - ESLint + Prettier enforced via pre-commit hooks (husky).
 
+### Branches
+
+Use a type prefix followed by a short, dash-separated summary: `feat/`, `chore/`, or `fix/`. For example:
+
+```text
+feat/add-cashu-backend
+fix/payment-timeout-crash
+chore/bump-go-1.25
+```
+
 ### Commits
 
 Follow **Conventional Commits** format (`feat:`, `fix:`, `chore:`, etc.) — enforced by commitlint.


### PR DESCRIPTION
## Summary

Adds a **Branches** section to `AGENTS.md` (symlinked as `CLAUDE.md`) documenting the branch naming convention used in this repo: a `feat/`, `chore/`, or `fix/` type prefix followed by a short, dash-separated summary, with examples.

## Test plan

Docs-only change — no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines with new branch naming convention requirements, including mandatory type prefixes (feat/, chore/, fix/) and clear examples for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->