### PR TITLE
fix: reduce wallet balance/transaction polling interval to 10s

### DIFF
--- a/frontend/src/hooks/useBalances.ts
+++ b/frontend/src/hooks/useBalances.ts
@@ -4,7 +4,9 @@ import { BalancesResponse } from "src/types";
 import { swrFetcher } from "src/utils/swr";
 
 const pollConfiguration: SWRConfiguration = {
-  refreshInterval: 3000,
+  // SWR also revalidates on window focus, so a longer interval keeps the
+  // balance fresh without flooding the backend from long-lived open tabs.
+  refreshInterval: 10000,
 };
 
 export function useBalances(poll = false) {

--- a/frontend/src/hooks/useBalances.ts
+++ b/frontend/src/hooks/useBalances.ts
@@ -4,8 +4,6 @@ import { BalancesResponse } from "src/types";
 import { swrFetcher } from "src/utils/swr";
 
 const pollConfiguration: SWRConfiguration = {
-  // SWR also revalidates on window focus, so a longer interval keeps the
-  // balance fresh without flooding the backend from long-lived open tabs.
   refreshInterval: 10000,
 };
 

--- a/frontend/src/hooks/useTransactions.ts
+++ b/frontend/src/hooks/useTransactions.ts
@@ -4,7 +4,9 @@ import { ListTransactionsResponse } from "src/types";
 import { swrFetcher } from "src/utils/swr";
 
 const pollConfiguration: SWRConfiguration = {
-  refreshInterval: 3000,
+  // SWR also revalidates on window focus, so a longer interval keeps the
+  // transaction list fresh without flooding the backend from long-lived open tabs.
+  refreshInterval: 10000,
 };
 
 export function getTransactionsUrl(appId?: number, limit = 100, page = 1) {

--- a/frontend/src/hooks/useTransactions.ts
+++ b/frontend/src/hooks/useTransactions.ts
@@ -4,8 +4,6 @@ import { ListTransactionsResponse } from "src/types";
 import { swrFetcher } from "src/utils/swr";
 
 const pollConfiguration: SWRConfiguration = {
-  // SWR also revalidates on window focus, so a longer interval keeps the
-  // transaction list fresh without flooding the backend from long-lived open tabs.
   refreshInterval: 10000,
 };
 


### PR DESCRIPTION
## Summary

The wallet dashboard polls `/api/balances` and `/api/transactions` every **3 seconds** via SWR's `refreshInterval`. When a hub is left open in a browser tab, this generates a high, continuous stream of identical requests (and matching backend access logs) around the clock — with little UX benefit, since SWR already revalidates on window focus, so a longer interval keeps the data fresh without flooding the backend from long-lived open tabs.

This raises the polling interval for the balances and transactions-list hooks from **3s → 10s**.

## Changes

- `useBalances`: `refreshInterval` 3000 → 10000
- `useTransactions`: `refreshInterval` 3000 → 10000

The single-transaction hook (`useTransaction`, used while waiting for a specific invoice/payment to settle) is intentionally left at 3s — there fast updates matter and the polling is short-lived.

## Impact

- ~3x fewer balance/transaction poll requests from open dashboards, reducing backend load and log volume.
- Balance changes and received-payment notifications may surface up to ~10s later when the tab is already in focus; switching to the tab still triggers an immediate refresh.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated polling configuration for balance and transaction data refresh to reduce update frequency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->