### PR TITLE
chore: update bark bindings to v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Bark connects to an [Ark](https://second.tech/) server. It can be configured via
 - `LN_BACKEND_TYPE`: BARK
 - `BARK_SERVER`: the Ark server URL. For signet use `https://ark.signet.2nd.dev`
 - `BARK_ESPLORA_SERVER`: the Esplora server URL used for chain data. For signet use `https://esplora.signet.2nd.dev`.
-- `BARK_SERVER_ACCESS_TOKEN`: an optional access token required by the Ark server (pre-public mainnet launch).
+- `BARK_SERVER_ACCESS_TOKEN`: an optional access token, only required if using a private Ark server.
 - `BARK_LOG_LEVEL`: Log level for Bark. Higher is more verbose. Default: 3. This is separate from the main application log level, allowing you to enable more verbose Bark logging (e.g., level 4 or 5) without enabling verbose logging for the entire application.
 
 ### Alby OAuth

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/wailsapp/wails/v2 v2.12.0
-	gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.7.0
+	gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.8.0
 	golang.org/x/crypto v0.52.0
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/grpc v1.79.3

--- a/go.sum
+++ b/go.sum
@@ -662,8 +662,8 @@ github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5t
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
-gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.7.0 h1:X8h/JbdfDoHGvw2UQZJmIkpwAgANzBK5KxrZG7zChmc=
-gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.7.0/go.mod h1:1jAwB/XR4i3D72fz3qWAd41tQLYcOCGfWZHMagn5fNg=
+gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.8.0 h1:YKHSM8iNFMmTQ/QPUxC5U9KVim10F7sIGt3ou2wet+o=
+gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.8.0/go.mod h1:1jAwB/XR4i3D72fz3qWAd41tQLYcOCGfWZHMagn5fNg=
 go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
 go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 go.etcd.io/etcd/api/v3 v3.5.16 h1:WvmyJVbjWqK4R1E+B12RRHz3bRGy9XVfh++MgbN+6n0=


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/2423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the BARK_SERVER_ACCESS_TOKEN environment variable is optional and only required when using a private server.

* **Chores**
  * Updated dependencies for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->