### PR TITLE
feat: add FeeRateField component to set fee rates for swaps

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -997,7 +997,7 @@ func (api *api) GetSwapOutInfo() (*SwapInfoResponse, error) {
 	}, nil
 }
 
-func (api *api) InitiateSwapOut(ctx context.Context, initiateSwapOutRequest *InitiateSwapRequest) (*swaps.SwapResponse, error) {
+func (api *api) InitiateSwapOut(ctx context.Context, initiateSwapOutRequest *InitiateSwapOutRequest) (*swaps.SwapResponse, error) {
 	lnClient := api.svc.GetLNClient()
 	if lnClient == nil {
 		return nil, ErrLNClientNotStarted
@@ -1030,7 +1030,7 @@ func (api *api) InitiateSwapOut(ctx context.Context, initiateSwapOutRequest *Ini
 	return swapOutResponse, nil
 }
 
-func (api *api) InitiateSwapIn(ctx context.Context, initiateSwapInRequest *InitiateSwapRequest) (*swaps.SwapResponse, error) {
+func (api *api) InitiateSwapIn(ctx context.Context, initiateSwapInRequest *InitiateSwapInRequest) (*swaps.SwapResponse, error) {
 	lnClient := api.svc.GetLNClient()
 	if lnClient == nil {
 		return nil, ErrLNClientNotStarted

--- a/api/api.go
+++ b/api/api.go
@@ -1050,10 +1050,11 @@ func (api *api) InitiateSwapIn(ctx context.Context, initiateSwapInRequest *Initi
 		return nil, errors.New("invalid swap amount")
 	}
 
-	swapInResponse, err := api.svc.GetSwapsService().SwapIn(amountSat, false)
+	swapInResponse, err := api.svc.GetSwapsService().SwapIn(amountSat, false, initiateSwapInRequest.InternalPayment, initiateSwapInRequest.FeeRate)
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
-			"amount_sat": amountSat,
+			"amount_sat":       amountSat,
+			"internal_payment": initiateSwapInRequest.InternalPayment,
 		}).WithError(err).Error("Failed to initiate swap in")
 		return nil, err
 	}

--- a/api/models.go
+++ b/api/models.go
@@ -69,8 +69,8 @@ type API interface {
 	ListSwaps() (*ListSwapsResponse, error)
 	GetSwapInInfo() (*SwapInfoResponse, error)
 	GetSwapOutInfo() (*SwapInfoResponse, error)
-	InitiateSwapIn(ctx context.Context, initiateSwapInRequest *InitiateSwapRequest) (*swaps.SwapResponse, error)
-	InitiateSwapOut(ctx context.Context, initiateSwapOutRequest *InitiateSwapRequest) (*swaps.SwapResponse, error)
+	InitiateSwapIn(ctx context.Context, initiateSwapInRequest *InitiateSwapInRequest) (*swaps.SwapResponse, error)
+	InitiateSwapOut(ctx context.Context, initiateSwapOutRequest *InitiateSwapOutRequest) (*swaps.SwapResponse, error)
 	RefundSwap(refundSwapRequest *RefundSwapRequest) error
 	GetSwapMnemonic() string
 	GetAutoSwapConfig() (*GetAutoSwapConfigResponse, error)
@@ -168,12 +168,17 @@ type CreateLightningAddressRequest struct {
 	AppId   uint   `json:"appId"`
 }
 
-type InitiateSwapRequest struct {
+type InitiateSwapInRequest struct {
 	SwapAmount      *uint64 `json:"swapAmount"` // deprecated
 	SwapAmountSat   *uint64 `json:"swapAmountSat"`
-	Destination     string  `json:"destination"`
 	InternalPayment bool    `json:"internalPayment"`
 	FeeRate         *uint64 `json:"feeRate"`
+}
+
+type InitiateSwapOutRequest struct {
+	SwapAmount    *uint64 `json:"swapAmount"` // deprecated
+	SwapAmountSat *uint64 `json:"swapAmountSat"`
+	Destination   string  `json:"destination"`
 }
 
 type RefundSwapRequest struct {

--- a/api/models.go
+++ b/api/models.go
@@ -169,9 +169,11 @@ type CreateLightningAddressRequest struct {
 }
 
 type InitiateSwapRequest struct {
-	SwapAmount    *uint64 `json:"swapAmount"` // deprecated
-	SwapAmountSat *uint64 `json:"swapAmountSat"`
-	Destination   string  `json:"destination"`
+	SwapAmount      *uint64 `json:"swapAmount"` // deprecated
+	SwapAmountSat   *uint64 `json:"swapAmountSat"`
+	Destination     string  `json:"destination"`
+	InternalPayment bool    `json:"internalPayment"`
+	FeeRate         *uint64 `json:"feeRate"`
 }
 
 type RefundSwapRequest struct {
@@ -304,38 +306,38 @@ type InfoResponseRelay struct {
 }
 
 type InfoResponse struct {
-	BackendType                 string              `json:"backendType"`
-	SetupCompleted              bool                `json:"setupCompleted"`
-	OAuthRedirect               bool                `json:"oauthRedirect"`
-	Running                     bool                `json:"running"`
-	Unlocked                    bool                `json:"unlocked"`
-	AlbyAuthUrl                 string              `json:"albyAuthUrl"`
-	NextBackupReminder          string              `json:"nextBackupReminder"`
-	AlbyUserIdentifier          string              `json:"albyUserIdentifier"`
-	AlbyAccountConnected        bool                `json:"albyAccountConnected"`
-	Version                     string              `json:"version"`
-	Network                     string              `json:"network"`
-	EnableAdvancedSetup         bool                `json:"enableAdvancedSetup"`
-	LdkVssEnabled               bool                `json:"ldkVssEnabled"`
-	VssSupported                bool                `json:"vssSupported"`
-	StartupState                string              `json:"startupState"`
-	StartupError                string              `json:"startupError"`
-	StartupErrorTime            time.Time           `json:"startupErrorTime"`
-	AutoUnlockPasswordSupported bool                `json:"autoUnlockPasswordSupported"`
-	AutoUnlockPasswordEnabled   bool                `json:"autoUnlockPasswordEnabled"`
-	Currency                    string              `json:"currency"`
-	BitcoinDisplayFormat        string              `json:"bitcoinDisplayFormat"`
-	Relays                      []InfoResponseRelay `json:"relays"`
-	NodeAlias                   string              `json:"nodeAlias"`
-	MempoolUrl                  string              `json:"mempoolUrl"`
-	ChainDataSourceType         string              `json:"chainDataSourceType,omitempty"`
-	ChainDataSourceAddress      string              `json:"chainDataSourceAddress,omitempty"`
-	JitChannelsLiquiditySource  string              `json:"jitChannelsLiquiditySource,omitempty"`
-	JitChannelsMinPaymentSizeMsat *uint64           `json:"jitChannelsMinPaymentSizeMsat,omitempty"`
-	JitChannelsMaxPaymentSizeMsat *uint64           `json:"jitChannelsMaxPaymentSizeMsat,omitempty"`
-	JitChannelsEnabled          bool                `json:"jitChannelsEnabled"`
-	HideUpdateBanner            bool                `json:"hideUpdateBanner"`
-	SupportsBolt12              bool                `json:"supportsBolt12"`
+	BackendType                   string              `json:"backendType"`
+	SetupCompleted                bool                `json:"setupCompleted"`
+	OAuthRedirect                 bool                `json:"oauthRedirect"`
+	Running                       bool                `json:"running"`
+	Unlocked                      bool                `json:"unlocked"`
+	AlbyAuthUrl                   string              `json:"albyAuthUrl"`
+	NextBackupReminder            string              `json:"nextBackupReminder"`
+	AlbyUserIdentifier            string              `json:"albyUserIdentifier"`
+	AlbyAccountConnected          bool                `json:"albyAccountConnected"`
+	Version                       string              `json:"version"`
+	Network                       string              `json:"network"`
+	EnableAdvancedSetup           bool                `json:"enableAdvancedSetup"`
+	LdkVssEnabled                 bool                `json:"ldkVssEnabled"`
+	VssSupported                  bool                `json:"vssSupported"`
+	StartupState                  string              `json:"startupState"`
+	StartupError                  string              `json:"startupError"`
+	StartupErrorTime              time.Time           `json:"startupErrorTime"`
+	AutoUnlockPasswordSupported   bool                `json:"autoUnlockPasswordSupported"`
+	AutoUnlockPasswordEnabled     bool                `json:"autoUnlockPasswordEnabled"`
+	Currency                      string              `json:"currency"`
+	BitcoinDisplayFormat          string              `json:"bitcoinDisplayFormat"`
+	Relays                        []InfoResponseRelay `json:"relays"`
+	NodeAlias                     string              `json:"nodeAlias"`
+	MempoolUrl                    string              `json:"mempoolUrl"`
+	ChainDataSourceType           string              `json:"chainDataSourceType,omitempty"`
+	ChainDataSourceAddress        string              `json:"chainDataSourceAddress,omitempty"`
+	JitChannelsLiquiditySource    string              `json:"jitChannelsLiquiditySource,omitempty"`
+	JitChannelsMinPaymentSizeMsat *uint64             `json:"jitChannelsMinPaymentSizeMsat,omitempty"`
+	JitChannelsMaxPaymentSizeMsat *uint64             `json:"jitChannelsMaxPaymentSizeMsat,omitempty"`
+	JitChannelsEnabled            bool                `json:"jitChannelsEnabled"`
+	HideUpdateBanner              bool                `json:"hideUpdateBanner"`
+	SupportsBolt12                bool                `json:"supportsBolt12"`
 }
 
 type UpdateSettingsRequest struct {

--- a/frontend/src/components/CloseChannelDialogContent.tsx
+++ b/frontend/src/components/CloseChannelDialogContent.tsx
@@ -94,7 +94,7 @@ export function CloseChannelDialogContent({ alias, channel }: Props) {
               Are you sure you want to close the channel with {alias}?
             </AlertDialogTitle>
             <AlertDialogDescription>
-              This channel is inactive. Some channels require up to 6 onchain
+              This channel is inactive. Some channels require up to 6 on-chain
               confirmations before they are usable.
             </AlertDialogDescription>
           </AlertDialogHeader>

--- a/frontend/src/components/FeeRateField.tsx
+++ b/frontend/src/components/FeeRateField.tsx
@@ -1,0 +1,84 @@
+import { AlertTriangleIcon, ExternalLinkIcon } from "lucide-react";
+import ExternalLink from "src/components/ExternalLink";
+import { Button } from "src/components/ui/button";
+import { Input } from "src/components/ui/input";
+import { Label } from "src/components/ui/label";
+
+type RecommendedFees = {
+  fastestFee: number;
+  halfHourFee: number;
+  economyFee: number;
+  minimumFee: number;
+};
+
+type FeeRateFieldProps = {
+  feeRate: string;
+  onFeeRateChange: (value: string) => void;
+  recommendedFees?: RecommendedFees;
+  hasMempoolError?: boolean;
+  mempoolUrl?: string;
+};
+
+export function FeeRateField({
+  feeRate,
+  onFeeRateChange,
+  recommendedFees,
+  hasMempoolError,
+  mempoolUrl,
+}: FeeRateFieldProps) {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor="fee-rate">On-chain Fee Rate (sat/vB)</Label>
+      {hasMempoolError && (
+        <div className="text-muted-foreground text-xs flex gap-1 items-center">
+          <AlertTriangleIcon className="h-3 w-3" />
+          Failed to fetch fee estimates. Try refreshing the page.
+        </div>
+      )}
+      <Input
+        id="fee-rate"
+        type="number"
+        value={feeRate}
+        step={1}
+        required
+        min={recommendedFees?.minimumFee || 1}
+        onChange={(e) => {
+          onFeeRateChange(e.target.value);
+        }}
+      />
+      {recommendedFees && (
+        <div className="flex items-center mt-2 gap-4">
+          <Button
+            variant="positive"
+            className="rounded-full"
+            type="button"
+            onClick={() =>
+              onFeeRateChange(recommendedFees.economyFee.toString())
+            }
+          >
+            Low priority: {recommendedFees.economyFee}
+          </Button>
+          <Button
+            variant="positive"
+            className="rounded-full"
+            type="button"
+            onClick={() =>
+              onFeeRateChange(recommendedFees.fastestFee.toString())
+            }
+          >
+            High priority: {recommendedFees.fastestFee}
+          </Button>
+          {mempoolUrl && (
+            <ExternalLink
+              to={mempoolUrl}
+              className="text-muted-foreground text-sm underline flex items-center gap-2"
+            >
+              View on Mempool
+              <ExternalLinkIcon className="w-4 h-4" />
+            </ExternalLink>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/FeeRateField.tsx
+++ b/frontend/src/components/FeeRateField.tsx
@@ -1,8 +1,12 @@
-import { AlertTriangleIcon, ExternalLinkIcon } from "lucide-react";
+import { AlertTriangleIcon, ExternalLinkIcon, PencilIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import ExternalLink from "src/components/ExternalLink";
+import Loading from "src/components/Loading";
 import { Button } from "src/components/ui/button";
 import { Input } from "src/components/ui/input";
 import { Label } from "src/components/ui/label";
+import { useInfo } from "src/hooks/useInfo";
+import { useMempoolApi } from "src/hooks/useMempoolApi";
 
 type RecommendedFees = {
   fastestFee: number;
@@ -14,22 +18,65 @@ type RecommendedFees = {
 type FeeRateFieldProps = {
   feeRate: string;
   onFeeRateChange: (value: string) => void;
-  recommendedFees?: RecommendedFees;
-  hasMempoolError?: boolean;
-  mempoolUrl?: string;
 };
 
-export function FeeRateField({
-  feeRate,
-  onFeeRateChange,
-  recommendedFees,
-  hasMempoolError,
-  mempoolUrl,
-}: FeeRateFieldProps) {
+export function FeeRateField({ feeRate, onFeeRateChange }: FeeRateFieldProps) {
+  const { data: info } = useInfo();
+  const { data: recommendedFees, error: mempoolError } =
+    useMempoolApi<RecommendedFees>("/v1/fees/recommended");
+  const [isEditing, setIsEditing] = useState(false);
+  const hasInitializedDefaultFee = useRef(false);
+
+  useEffect(() => {
+    if (
+      recommendedFees?.fastestFee &&
+      !hasInitializedDefaultFee.current &&
+      !feeRate
+    ) {
+      hasInitializedDefaultFee.current = true;
+      onFeeRateChange(recommendedFees.fastestFee.toString());
+    }
+  }, [feeRate, onFeeRateChange, recommendedFees]);
+
+  useEffect(() => {
+    if (mempoolError) {
+      setIsEditing(true);
+    }
+  }, [mempoolError]);
+
+  if (!info || (!recommendedFees && !mempoolError)) {
+    return (
+      <div className="flex items-center justify-between">
+        <Label>On-chain Fee Rate (sat/vB)</Label>
+        <Loading className="w-4 h-4" />
+      </div>
+    );
+  }
+
+  if (!isEditing) {
+    return (
+      <div className="flex items-center justify-between">
+        <Label>On-chain Fee Rate (sat/vB)</Label>
+        {feeRate ? (
+          <button
+            type="button"
+            className="flex items-center gap-2 cursor-pointer"
+            onClick={() => setIsEditing(true)}
+          >
+            <p className="text-sm">{feeRate} sat/vB</p>
+            <PencilIcon className="w-4 h-4" />
+          </button>
+        ) : (
+          <Loading className="w-4 h-4" />
+        )}
+      </div>
+    );
+  }
+
   return (
     <div className="grid gap-2">
       <Label htmlFor="fee-rate">On-chain Fee Rate (sat/vB)</Label>
-      {hasMempoolError && (
+      {mempoolError && (
         <div className="text-muted-foreground text-xs flex gap-1 items-center">
           <AlertTriangleIcon className="h-3 w-3" />
           Failed to fetch fee estimates. Try refreshing the page.
@@ -68,9 +115,9 @@ export function FeeRateField({
           >
             High priority: {recommendedFees.fastestFee}
           </Button>
-          {mempoolUrl && (
+          {info.mempoolUrl && (
             <ExternalLink
-              to={mempoolUrl}
+              to={info.mempoolUrl}
               className="text-muted-foreground text-sm underline flex items-center gap-2"
             >
               View on Mempool

--- a/frontend/src/screens/channels/CurrentChannelOrder.tsx
+++ b/frontend/src/screens/channels/CurrentChannelOrder.tsx
@@ -302,7 +302,7 @@ function PayBitcoinChannelOrderTopup({ order }: { order: NewChannelOrder }) {
           </p>
           <p className="text-xs text-muted-foreground">
             This amount includes cost for the channel opening and potential
-            channel onchain reserves.
+            channel on-chain reserves.
           </p>
           <div className="flex flex-row gap-2 items-center">
             <Input

--- a/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
+++ b/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
@@ -229,11 +229,9 @@ export default function WithdrawOnchainFunds() {
               cannot be reversed.
             </p>
           </div>
-          {(info?.backendType === "LDK" || info?.backendType === "LND") && (
-            <div className="border-t pt-4">
-              <FeeRateField feeRate={feeRate} onFeeRateChange={setFeeRate} />
-            </div>
-          )}
+          <div className="border-t pt-4">
+            <FeeRateField feeRate={feeRate} onFeeRateChange={setFeeRate} />
+          </div>
 
           <div>
             <AlertDialog

--- a/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
+++ b/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
@@ -1,9 +1,4 @@
-import {
-  AlertTriangleIcon,
-  CopyIcon,
-  ExternalLinkIcon,
-  InfoIcon,
-} from "lucide-react";
+import { AlertTriangleIcon, CopyIcon, ExternalLinkIcon } from "lucide-react";
 import React from "react";
 import { toast } from "sonner";
 import { AnchorReserveAlert } from "src/components/AnchorReserveAlert";
@@ -246,14 +241,6 @@ export default function WithdrawOnchainFunds() {
               open={confirmDialogOpen}
             >
               <Button className="w-full">Withdraw</Button>
-              {feeRate && (
-                <div className="mt-2 text-muted-foreground text-sm flex gap-1 items-center justify-center">
-                  <InfoIcon className="h-4 w-4" />
-                  On-chain payment will be made with{" "}
-                  <span className="font-semibold">{feeRate} sat/vB</span> fee
-                </div>
-              )}
-
               <AlertDialogContent>
                 <AlertDialogHeader>
                   <AlertDialogTitle>

--- a/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
+++ b/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import { AnchorReserveAlert } from "src/components/AnchorReserveAlert";
 import AppHeader from "src/components/AppHeader";
 import ExternalLink from "src/components/ExternalLink";
+import { FeeRateField } from "src/components/FeeRateField";
 import { FixedFloatButton } from "src/components/FixedFloatButton";
 import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import Loading from "src/components/Loading";
@@ -257,57 +258,13 @@ export default function WithdrawOnchainFunds() {
           {(info?.backendType === "LDK" || info?.backendType === "LND") && (
             <>
               {showAdvanced && (
-                <div className="grid gap-2">
-                  <Label htmlFor="fee-rate">Fee Rate (Sat/vB)</Label>
-                  {mempoolError && (
-                    <div className="text-muted-foreground text-xs flex gap-1 items-center">
-                      <AlertTriangleIcon className="h-3 w-3" />
-                      Failed to fetch fee estimates. Try refreshing the page.
-                    </div>
-                  )}
-                  <Input
-                    id="fee-rate"
-                    type="number"
-                    value={feeRate}
-                    step={1}
-                    required
-                    min={recommendedFees?.minimumFee || 1}
-                    onChange={(e) => {
-                      setFeeRate(e.target.value);
-                    }}
-                  />
-                  {recommendedFees && (
-                    <div className="flex items-center mt-2 gap-4">
-                      <Button
-                        variant="positive"
-                        className="rounded-full"
-                        type="button"
-                        onClick={() =>
-                          setFeeRate(recommendedFees.economyFee.toString())
-                        }
-                      >
-                        Low priority: {recommendedFees.economyFee}
-                      </Button>{" "}
-                      <Button
-                        variant="positive"
-                        className="rounded-full"
-                        type="button"
-                        onClick={() =>
-                          setFeeRate(recommendedFees.fastestFee.toString())
-                        }
-                      >
-                        High priority: {recommendedFees.fastestFee}
-                      </Button>{" "}
-                      <ExternalLink
-                        to={info?.mempoolUrl}
-                        className="text-sm text-muted-foreground underline flex items-center gap-2"
-                      >
-                        View on Mempool
-                        <ExternalLinkIcon className="w-4 h-4" />
-                      </ExternalLink>
-                    </div>
-                  )}
-                </div>
+                <FeeRateField
+                  feeRate={feeRate}
+                  onFeeRateChange={setFeeRate}
+                  recommendedFees={recommendedFees}
+                  hasMempoolError={Boolean(mempoolError)}
+                  mempoolUrl={info?.mempoolUrl}
+                />
               )}
               {!showAdvanced && (
                 <Button

--- a/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
+++ b/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
@@ -1,6 +1,5 @@
 import {
   AlertTriangleIcon,
-  ChevronDownIcon,
   CopyIcon,
   ExternalLinkIcon,
   InfoIcon,
@@ -34,7 +33,6 @@ import { Separator } from "src/components/ui/separator";
 import { ONCHAIN_DUST_SATS } from "src/constants";
 import { useBalances } from "src/hooks/useBalances";
 import { useInfo } from "src/hooks/useInfo";
-import { useMempoolApi } from "src/hooks/useMempoolApi";
 
 import { copyToClipboard } from "src/lib/clipboard";
 import {
@@ -46,32 +44,13 @@ import { request } from "src/utils/request";
 export default function WithdrawOnchainFunds() {
   const { data: info } = useInfo();
   const { data: balances } = useBalances();
-  const { data: recommendedFees, error: mempoolError } = useMempoolApi<{
-    fastestFee: number;
-    halfHourFee: number;
-    economyFee: number;
-    minimumFee: number;
-  }>("/v1/fees/recommended");
   const [isLoading, setLoading] = React.useState(false);
   const [onchainAddress, setOnchainAddress] = React.useState("");
   const [amountSat, setAmountSat] = React.useState("");
   const [feeRate, setFeeRate] = React.useState("");
   const [sendAll, setSendAll] = React.useState(false);
-  const [showAdvanced, setShowAdvanced] = React.useState(false);
   const [transactionId, setTransactionId] = React.useState("");
   const [confirmDialogOpen, setConfirmDialogOpen] = React.useState(false);
-
-  React.useEffect(() => {
-    if (mempoolError) {
-      setShowAdvanced(true);
-    }
-  }, [mempoolError]);
-
-  React.useEffect(() => {
-    if (recommendedFees?.fastestFee) {
-      setFeeRate(recommendedFees.fastestFee.toString());
-    }
-  }, [recommendedFees]);
 
   const copy = (text: string) => {
     copyToClipboard(text);
@@ -158,7 +137,7 @@ export default function WithdrawOnchainFunds() {
     );
   }
 
-  if (!info || !balances || (!recommendedFees && !mempoolError)) {
+  if (!info || !balances) {
     return <Loading />;
   }
 
@@ -256,28 +235,9 @@ export default function WithdrawOnchainFunds() {
             </p>
           </div>
           {(info?.backendType === "LDK" || info?.backendType === "LND") && (
-            <>
-              {showAdvanced && (
-                <FeeRateField
-                  feeRate={feeRate}
-                  onFeeRateChange={setFeeRate}
-                  recommendedFees={recommendedFees}
-                  hasMempoolError={Boolean(mempoolError)}
-                  mempoolUrl={info?.mempoolUrl}
-                />
-              )}
-              {!showAdvanced && (
-                <Button
-                  type="button"
-                  variant="link"
-                  className="text-muted-foreground text-xs"
-                  onClick={() => setShowAdvanced((current) => !current)}
-                >
-                  <ChevronDownIcon />
-                  Advanced Options
-                </Button>
-              )}
-            </>
+            <div className="border-t pt-4">
+              <FeeRateField feeRate={feeRate} onFeeRateChange={setFeeRate} />
+            </div>
           )}
 
           <div>

--- a/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
+++ b/frontend/src/screens/wallet/WithdrawOnchainFunds.tsx
@@ -55,7 +55,7 @@ export default function WithdrawOnchainFunds() {
     setLoading(true);
     try {
       if (!onchainAddress) {
-        throw new Error("No onchain address");
+        throw new Error("No on-chain address");
       }
       if (!feeRate) {
         throw new Error("No fee rate set");
@@ -86,14 +86,14 @@ export default function WithdrawOnchainFunds() {
           body: JSON.stringify(payload),
         }
       );
-      console.info("Redeemed onchain funds", response);
+      console.info("Redeemed on-chain funds", response);
       if (!response?.txId) {
         throw new Error("No address in response");
       }
       setTransactionId(response.txId);
     } catch (error) {
       console.error(error);
-      toast.error("Failed to redeem onchain funds", {
+      toast.error("Failed to redeem on-chain funds", {
         description: "" + error,
       });
     }
@@ -139,7 +139,7 @@ export default function WithdrawOnchainFunds() {
   if (balances.onchain.spendableSat <= ONCHAIN_DUST_SATS) {
     return (
       <p>
-        You currently don't have enough sats to pay for an onchain transaction.
+        You currently don't have enough sats to pay for an on-chain transaction.
       </p>
     );
   }
@@ -149,12 +149,12 @@ export default function WithdrawOnchainFunds() {
       <AppHeader
         pageTitle="Withdraw On-Chain Balance"
         title="Withdraw On-Chain Balance"
-        description="Withdraw your onchain funds to another bitcoin wallet"
+        description="Withdraw your on-chain funds to another bitcoin wallet"
       />
 
       <div className="max-w-lg">
         <p>
-          Your on-chain balance will be withdrawn to the onchain bitcoin wallet
+          Your on-chain balance will be withdrawn to the on-chain bitcoin wallet
           address you specify below.
         </p>
         <form
@@ -169,7 +169,7 @@ export default function WithdrawOnchainFunds() {
               <Label htmlFor="amount">Amount</Label>
               <div className="flex justify-between items-center">
                 <p className="text-sm text-muted-foreground sensitive slashed-zero">
-                  Current onchain balance:{" "}
+                  Current on-chain balance:{" "}
                   <FormattedBitcoinAmount
                     amountMsat={balances.onchain.spendableSat * 1000}
                   />
@@ -202,7 +202,7 @@ export default function WithdrawOnchainFunds() {
                 <AlertTriangleIcon />
                 <AlertTitle>Entire wallet balance will be sent</AlertTitle>
                 <AlertDescription>
-                  Your entire wallet balance will be sent minus onchain
+                  Your entire wallet balance will be sent minus on-chain
                   transaction fees. The exact amount cannot be determined until
                   the payment is made.
                 </AlertDescription>
@@ -214,7 +214,7 @@ export default function WithdrawOnchainFunds() {
             />
           </div>
           <div className="grid gap-2">
-            <Label htmlFor="onchain-address">Onchain Address</Label>
+            <Label htmlFor="onchain-address">On-chain Address</Label>
             <Input
               id="onchain-address"
               type="text"
@@ -244,7 +244,7 @@ export default function WithdrawOnchainFunds() {
               <AlertDialogContent>
                 <AlertDialogHeader>
                   <AlertDialogTitle>
-                    Confirm Onchain Transaction
+                    Confirm On-chain Transaction
                   </AlertDialogTitle>
                   <AlertDialogDescription>
                     <div>

--- a/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveOnchain.tsx
@@ -16,7 +16,7 @@ import { useMempoolApi } from "src/hooks/useMempoolApi";
 import { useSwapInfo } from "src/hooks/useSwaps";
 import {
   CreateInvoiceRequest,
-  InitiateSwapRequest,
+  InitiateSwapInRequest,
   SwapResponse,
   Transaction,
 } from "src/types";
@@ -75,7 +75,7 @@ export default function ReceiveOnchain() {
         return;
       }
 
-      const payload: InitiateSwapRequest = {
+      const payload: InitiateSwapInRequest = {
         swapAmountSat: parseInt(swapAmountSat),
       };
       const swapInResponse = await request<SwapResponse>("/api/swaps/in", {

--- a/frontend/src/screens/wallet/send/Onchain.tsx
+++ b/frontend/src/screens/wallet/send/Onchain.tsx
@@ -19,7 +19,7 @@ import { useBalances } from "src/hooks/useBalances";
 import { useMempoolApi } from "src/hooks/useMempoolApi";
 import { useSwapInfo } from "src/hooks/useSwaps";
 import {
-  InitiateSwapRequest,
+  InitiateSwapOutRequest,
   RedeemOnchainFundsRequest,
   RedeemOnchainFundsResponse,
   SwapResponse,
@@ -233,7 +233,7 @@ function SwapForm({
     event.preventDefault();
     try {
       setLoading(true);
-      const payload: InitiateSwapRequest = {
+      const payload: InitiateSwapOutRequest = {
         swapAmountSat: +amountSat,
         destination: address,
       };

--- a/frontend/src/screens/wallet/send/Onchain.tsx
+++ b/frontend/src/screens/wallet/send/Onchain.tsx
@@ -1,25 +1,17 @@
-import {
-  AlertTriangleIcon,
-  ExternalLinkIcon,
-  InfoIcon,
-  PencilIcon,
-  XIcon,
-} from "lucide-react";
+import { InfoIcon, PencilIcon, XIcon } from "lucide-react";
 import React from "react";
 import { Link, useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { AnchorReserveAlert } from "src/components/AnchorReserveAlert";
 import AppHeader from "src/components/AppHeader";
 import { CurrencyInputField } from "src/components/CurrencyInputField";
-import ExternalLink from "src/components/ExternalLink";
+import { FeeRateField } from "src/components/FeeRateField";
 import { InsufficientLightningBalanceAlert } from "src/components/InsufficientLightningBalanceAlert";
 import Loading from "src/components/Loading";
 import { MempoolAlert } from "src/components/MempoolAlert";
 import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
-import { Button } from "src/components/ui/button";
 import { LinkButton } from "src/components/ui/custom/link-button";
 import { LoadingButton } from "src/components/ui/custom/loading-button";
-import { Input } from "src/components/ui/input";
 import { Label } from "src/components/ui/label";
 import { Switch } from "src/components/ui/switch";
 import { ONCHAIN_DUST_SATS } from "src/constants";
@@ -134,6 +126,12 @@ function OnchainForm({
     }
   }, [recommendedFees]);
 
+  React.useEffect(() => {
+    if (mempoolError) {
+      setEditFee(true);
+    }
+  }, [mempoolError]);
+
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     try {
@@ -212,8 +210,9 @@ function OnchainForm({
       <div className="grid gap-2 text-sm border-t pt-6">
         {!editFee ? (
           <div className="flex items-center justify-between">
-            <p className="text-muted-foreground">On-chain Fee Rate</p>
-            <div
+            <Label>On-chain Fee Rate (sat/vB)</Label>
+            <button
+              type="button"
               className="flex items-center gap-2 cursor-pointer"
               onClick={() => setEditFee(true)}
             >
@@ -223,60 +222,16 @@ function OnchainForm({
                 <Loading className="w-4 h-4" />
               )}
               <PencilIcon className="w-4 h-4" />
-            </div>
+            </button>
           </div>
         ) : (
-          <div className="grid gap-2">
-            <Label htmlFor="fee-rate">Fee Rate (Sat/vB)</Label>
-            {mempoolError && (
-              <div className="text-muted-foreground text-xs flex gap-1 items-center">
-                <AlertTriangleIcon className="h-3 w-3" />
-                Failed to fetch fee estimates. Try refreshing the page.
-              </div>
-            )}
-            <Input
-              id="fee-rate"
-              type="number"
-              value={feeRate}
-              step={1}
-              required
-              min={recommendedFees?.minimumFee || 1}
-              onChange={(e) => {
-                setFeeRate(e.target.value);
-              }}
-            />
-            {recommendedFees && (
-              <div className="flex items-center mt-2 gap-4">
-                <Button
-                  variant="positive"
-                  className="rounded-full"
-                  type="button"
-                  onClick={() =>
-                    setFeeRate(recommendedFees.economyFee.toString())
-                  }
-                >
-                  Low priority: {recommendedFees.economyFee}
-                </Button>{" "}
-                <Button
-                  variant="positive"
-                  className="rounded-full"
-                  type="button"
-                  onClick={() =>
-                    setFeeRate(recommendedFees.fastestFee.toString())
-                  }
-                >
-                  High priority: {recommendedFees.fastestFee}
-                </Button>{" "}
-                <ExternalLink
-                  to={info?.mempoolUrl}
-                  className="text-muted-foreground underline flex items-center gap-2"
-                >
-                  View on Mempool
-                  <ExternalLinkIcon className="w-4 h-4" />
-                </ExternalLink>
-              </div>
-            )}
-          </div>
+          <FeeRateField
+            feeRate={feeRate}
+            onFeeRateChange={setFeeRate}
+            recommendedFees={recommendedFees}
+            hasMempoolError={Boolean(mempoolError)}
+            mempoolUrl={info?.mempoolUrl}
+          />
         )}
       </div>
       {amountSat && +amountSat < 10_000 && (
@@ -388,7 +343,7 @@ function SwapForm({
       </div>
       <div className="grid gap-2 text-sm border-t pt-6">
         <div className="flex items-center justify-between">
-          <p className="text-muted-foreground">On-chain Fee Rate</p>
+          <Label>On-chain Fee Rate</Label>
           <p>
             {recommendedFees?.fastestFee ? (
               <p>{recommendedFees?.fastestFee} sat/vB</p>

--- a/frontend/src/screens/wallet/send/Onchain.tsx
+++ b/frontend/src/screens/wallet/send/Onchain.tsx
@@ -1,4 +1,4 @@
-import { InfoIcon, PencilIcon, XIcon } from "lucide-react";
+import { InfoIcon, XIcon } from "lucide-react";
 import React from "react";
 import { Link, useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
@@ -16,7 +16,6 @@ import { Label } from "src/components/ui/label";
 import { Switch } from "src/components/ui/switch";
 import { ONCHAIN_DUST_SATS } from "src/constants";
 import { useBalances } from "src/hooks/useBalances";
-import { useInfo } from "src/hooks/useInfo";
 import { useMempoolApi } from "src/hooks/useMempoolApi";
 import { useSwapInfo } from "src/hooks/useSwaps";
 import {
@@ -107,30 +106,10 @@ function OnchainForm({
   setSwap: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
   const navigate = useNavigate();
-  const { data: info } = useInfo();
   const { data: balances } = useBalances();
-  const { data: recommendedFees, error: mempoolError } = useMempoolApi<{
-    fastestFee: number;
-    halfHourFee: number;
-    economyFee: number;
-    minimumFee: number;
-  }>("/v1/fees/recommended");
 
   const [feeRate, setFeeRate] = React.useState("");
   const [isLoading, setLoading] = React.useState(false);
-  const [editFee, setEditFee] = React.useState(false);
-
-  React.useEffect(() => {
-    if (recommendedFees?.fastestFee) {
-      setFeeRate(recommendedFees.fastestFee.toString());
-    }
-  }, [recommendedFees]);
-
-  React.useEffect(() => {
-    if (mempoolError) {
-      setEditFee(true);
-    }
-  }, [mempoolError]);
 
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -180,7 +159,7 @@ function OnchainForm({
     }
   };
 
-  if (!info || !balances || (!recommendedFees && !mempoolError)) {
+  if (!balances) {
     return <Loading />;
   }
 
@@ -208,31 +187,7 @@ function OnchainForm({
         <Switch id="swap" onCheckedChange={setSwap} />
       </div>
       <div className="grid gap-2 text-sm border-t pt-6">
-        {!editFee ? (
-          <div className="flex items-center justify-between">
-            <Label>On-chain Fee Rate (sat/vB)</Label>
-            <button
-              type="button"
-              className="flex items-center gap-2 cursor-pointer"
-              onClick={() => setEditFee(true)}
-            >
-              {feeRate ? (
-                <p>{feeRate} sat/vB</p>
-              ) : (
-                <Loading className="w-4 h-4" />
-              )}
-              <PencilIcon className="w-4 h-4" />
-            </button>
-          </div>
-        ) : (
-          <FeeRateField
-            feeRate={feeRate}
-            onFeeRateChange={setFeeRate}
-            recommendedFees={recommendedFees}
-            hasMempoolError={Boolean(mempoolError)}
-            mempoolUrl={info?.mempoolUrl}
-          />
-        )}
+        <FeeRateField feeRate={feeRate} onFeeRateChange={setFeeRate} />
       </div>
       {amountSat && +amountSat < 10_000 && (
         <Alert>

--- a/frontend/src/screens/wallet/swap/SwapInStatus.tsx
+++ b/frontend/src/screens/wallet/swap/SwapInStatus.tsx
@@ -52,6 +52,7 @@ export default function SwapInStatus() {
   const [searchParams] = useSearchParams();
 
   const isInternalSwap = searchParams.has("internal", "true");
+  const feeRate = searchParams.get("feeRate") || "";
   const [, setPaidWithAlbyHub] = React.useState(false);
 
   useEffect(() => {
@@ -70,6 +71,7 @@ export default function SwapInStatus() {
         const payload: RedeemOnchainFundsRequest = {
           toAddress: swap.lockupAddress,
           amountSat: swap.sendAmountSat,
+          feeRate: +feeRate,
         };
         const response = await request<RedeemOnchainFundsResponse>(
           "/api/wallet/redeem-onchain-funds",
@@ -93,7 +95,7 @@ export default function SwapInStatus() {
         setPaying(false);
       }
     })();
-  }, [swap]);
+  }, [feeRate, swap]);
 
   React.useEffect(() => {
     // only auto-redeem while the swap is still awaiting its on-chain deposit,

--- a/frontend/src/screens/wallet/swap/SwapInStatus.tsx
+++ b/frontend/src/screens/wallet/swap/SwapInStatus.tsx
@@ -6,9 +6,7 @@ import {
   CopyIcon,
   ExternalLinkIcon,
 } from "lucide-react";
-import React, { useEffect, useState } from "react";
 import { useParams, useSearchParams } from "react-router";
-import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
 import ExternalLink from "src/components/ExternalLink";
 import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
@@ -35,12 +33,7 @@ import { useInfo } from "src/hooks/useInfo";
 import { useSwap } from "src/hooks/useSwaps";
 import { useSyncWallet } from "src/hooks/useSyncWallet";
 import { copyToClipboard } from "src/lib/clipboard";
-import {
-  RedeemOnchainFundsRequest,
-  RedeemOnchainFundsResponse,
-  SwapIn,
-} from "src/types";
-import { request } from "src/utils/request";
+import { SwapIn } from "src/types";
 
 export default function SwapInStatus() {
   const { data: info } = useInfo();
@@ -48,76 +41,9 @@ export default function SwapInStatus() {
   const { swapId } = useParams() as { swapId: string };
   const { data: swap } = useSwap<SwapIn>(swapId, true);
 
-  const [isPaying, setPaying] = useState(false);
   const [searchParams] = useSearchParams();
 
   const isInternalSwap = searchParams.has("internal", "true");
-  const feeRate = searchParams.get("feeRate") || "";
-  const [, setPaidWithAlbyHub] = React.useState(false);
-
-  useEffect(() => {
-    if (isPaying && swap?.lockupTxId) {
-      setPaying(false);
-    }
-  }, [isPaying, swap?.lockupTxId]);
-
-  const payWithAlbyHub = React.useCallback(() => {
-    (async () => {
-      setPaying(true);
-      try {
-        if (!swap) {
-          throw new Error("swap not loaded");
-        }
-        const payload: RedeemOnchainFundsRequest = {
-          toAddress: swap.lockupAddress,
-          amountSat: swap.sendAmountSat,
-          ...(feeRate ? { feeRate: +feeRate } : {}),
-        };
-        const response = await request<RedeemOnchainFundsResponse>(
-          "/api/wallet/redeem-onchain-funds",
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify(payload),
-          }
-        );
-        if (!response?.txId) {
-          throw new Error("No address in response");
-        }
-        console.info("Redeemed on-chain funds", response);
-      } catch (error) {
-        console.error(error);
-        toast.error("Failed to redeem on-chain funds", {
-          description: "" + error,
-        });
-        setPaying(false);
-      }
-    })();
-  }, [feeRate, swap]);
-
-  React.useEffect(() => {
-    // only auto-redeem while the swap is still awaiting its on-chain deposit,
-    // otherwise a refresh/revisit of ?internal=true would submit a second
-    // redeem request for an already-funded swap
-    if (
-      isInternalSwap &&
-      swap &&
-      swap.state === "PENDING" &&
-      !swap.lockupTxId
-    ) {
-      setPaidWithAlbyHub((current) => {
-        if (current) {
-          return current;
-        }
-        setTimeout(() => {
-          payWithAlbyHub();
-        }, 1);
-        return true;
-      });
-    }
-  }, [isInternalSwap, payWithAlbyHub, swap]);
 
   if (!swap) {
     return <Loading />;

--- a/frontend/src/screens/wallet/swap/SwapInStatus.tsx
+++ b/frontend/src/screens/wallet/swap/SwapInStatus.tsx
@@ -86,10 +86,10 @@ export default function SwapInStatus() {
         if (!response?.txId) {
           throw new Error("No address in response");
         }
-        console.info("Redeemed onchain funds", response);
+        console.info("Redeemed on-chain funds", response);
       } catch (error) {
         console.error(error);
-        toast.error("Failed to redeem onchain funds", {
+        toast.error("Failed to redeem on-chain funds", {
           description: "" + error,
         });
         setPaying(false);
@@ -249,7 +249,7 @@ export default function SwapInStatus() {
                     <div className="flex items-center text-muted-foreground text-sm">
                       <CircleCheckIcon className="w-5 h-5 mr-2 text-green-600 dark:text-emerald-500" />
                       <div className="flex items-center gap-2">
-                        <p>Onchain deposit confirmed</p>
+                        <p>On-chain deposit confirmed</p>
                         <ExternalLink
                           to={`${info?.mempoolUrl}/tx/${swap.lockupTxId}`}
                           className="flex items-center underline text-foreground"
@@ -303,7 +303,7 @@ export default function SwapInStatus() {
                         <Tooltip>
                           <TooltipTrigger>
                             <div className="flex items-center gap-2">
-                              <p>Onchain deposit failed</p>
+                              <p>On-chain deposit failed</p>
                               <ExternalLink
                                 to={`${info?.mempoolUrl}/tx/${swap.lockupTxId}`}
                                 className="flex items-center underline text-foreground"
@@ -339,7 +339,7 @@ export default function SwapInStatus() {
                     <Tooltip>
                       <TooltipTrigger>
                         <div className="flex items-center gap-2">
-                          <p>Onchain deposit failed</p>
+                          <p>On-chain deposit failed</p>
                           <ExternalLink
                             to={`${info?.mempoolUrl}/address/${swap.lockupAddress}`}
                             className="flex items-center underline text-foreground"

--- a/frontend/src/screens/wallet/swap/SwapInStatus.tsx
+++ b/frontend/src/screens/wallet/swap/SwapInStatus.tsx
@@ -71,7 +71,7 @@ export default function SwapInStatus() {
         const payload: RedeemOnchainFundsRequest = {
           toAddress: swap.lockupAddress,
           amountSat: swap.sendAmountSat,
-          feeRate: +feeRate,
+          ...(feeRate ? { feeRate: +feeRate } : {}),
         };
         const response = await request<RedeemOnchainFundsResponse>(
           "/api/wallet/redeem-onchain-funds",

--- a/frontend/src/screens/wallet/swap/SwapOutStatus.tsx
+++ b/frontend/src/screens/wallet/swap/SwapOutStatus.tsx
@@ -122,7 +122,7 @@ export default function SwapOutStatus() {
                       <div className="flex items-center text-muted-foreground text-sm">
                         <CircleCheckIcon className="w-5 h-5 mr-2 text-green-600 dark:text-emerald-500" />
                         <div className="flex items-center gap-2">
-                          <p>Confirmed onchain</p>
+                          <p>Confirmed on-chain</p>
                           <ExternalLink
                             to={`${info?.mempoolUrl}/tx/${swap.claimTxId}`}
                             className="flex items-center underline text-foreground"

--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -33,7 +33,8 @@ import { useInfo } from "src/hooks/useInfo";
 import { useSwapInfo } from "src/hooks/useSwaps";
 import {
   CreateInvoiceRequest,
-  InitiateSwapRequest,
+  InitiateSwapInRequest,
+  InitiateSwapOutRequest,
   SwapResponse,
   Transaction,
 } from "src/types";
@@ -130,7 +131,7 @@ function SwapInForm() {
         return;
       }
 
-      const payload: InitiateSwapRequest = {
+      const payload: InitiateSwapInRequest = {
         swapAmountSat: parseInt(swapAmountSat),
         ...(swapFrom === "internal"
           ? {
@@ -338,7 +339,7 @@ function SwapOutForm() {
 
     try {
       setLoading(true);
-      const payload: InitiateSwapRequest = {
+      const payload: InitiateSwapOutRequest = {
         swapAmountSat: parseInt(swapAmountSat),
         destination,
       };

--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -135,7 +135,7 @@ function SwapInForm() {
         ...(swapFrom === "internal"
           ? {
               internalPayment: true,
-              ...(feeRate ? { feeRate: parseInt(feeRate) } : {}),
+              ...(feeRate ? { feeRate: +feeRate } : {}),
             }
           : {}),
       };

--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -2,7 +2,6 @@ import {
   ClipboardPasteIcon,
   ExternalLinkIcon,
   MoveRightIcon,
-  PencilIcon,
   RefreshCwIcon,
 } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -31,7 +30,6 @@ import {
 } from "src/components/ui/tabs";
 import { useBalances } from "src/hooks/useBalances";
 import { useInfo } from "src/hooks/useInfo";
-import { useMempoolApi } from "src/hooks/useMempoolApi";
 import { useSwapInfo } from "src/hooks/useSwaps";
 import {
   CreateInvoiceRequest,
@@ -100,29 +98,10 @@ function SwapInForm() {
   const navigate = useNavigate();
 
   const [swapAmountSat, setSwapAmountSat] = useState("");
-  const { data: recommendedFees, error: mempoolError } = useMempoolApi<{
-    fastestFee: number;
-    halfHourFee: number;
-    economyFee: number;
-    minimumFee: number;
-  }>("/v1/fees/recommended");
   const [feeRate, setFeeRate] = useState("");
-  const [editFee, setEditFee] = useState(false);
   const [loading, setLoading] = useState(false);
   const [cryptoTransaction, setCryptoTransaction] =
     useState<Transaction | null>(null);
-
-  useEffect(() => {
-    if (recommendedFees?.fastestFee) {
-      setFeeRate(recommendedFees.fastestFee.toString());
-    }
-  }, [recommendedFees]);
-
-  useEffect(() => {
-    if (mempoolError) {
-      setEditFee(true);
-    }
-  }, [mempoolError]);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -313,33 +292,7 @@ function SwapInForm() {
         <>
           <div className="flex flex-col pt-4 gap-4 border-t">
             {isInternalSwap && (
-              <>
-                {!editFee ? (
-                  <div className="flex items-center justify-between">
-                    <Label>On-chain Fee Rate (sat/vB)</Label>
-                    <button
-                      type="button"
-                      className="flex items-center gap-2 cursor-pointer"
-                      onClick={() => setEditFee(true)}
-                    >
-                      {feeRate ? (
-                        <p className="text-sm">{feeRate} sat/vB</p>
-                      ) : (
-                        <Loading className="w-4 h-4" />
-                      )}
-                      <PencilIcon className="w-4 h-4" />
-                    </button>
-                  </div>
-                ) : (
-                  <FeeRateField
-                    feeRate={feeRate}
-                    onFeeRateChange={setFeeRate}
-                    recommendedFees={recommendedFees}
-                    hasMempoolError={Boolean(mempoolError)}
-                    mempoolUrl={info?.mempoolUrl}
-                  />
-                )}
-              </>
+              <FeeRateField feeRate={feeRate} onFeeRateChange={setFeeRate} />
             )}
             <div className="flex items-center justify-between">
               <Label>{isInternalSwap ? "Swap Fee" : "Fee"}</Label>

--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -2,6 +2,7 @@ import {
   ClipboardPasteIcon,
   ExternalLinkIcon,
   MoveRightIcon,
+  PencilIcon,
   RefreshCwIcon,
 } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -10,6 +11,7 @@ import { toast } from "sonner";
 import { AnchorReserveAlert } from "src/components/AnchorReserveAlert";
 import AppHeader from "src/components/AppHeader";
 import { CurrencyInputField } from "src/components/CurrencyInputField";
+import { FeeRateField } from "src/components/FeeRateField";
 import { FixedFloatButton } from "src/components/FixedFloatButton";
 import { FixedFloatSwapInFlow } from "src/components/FixedFloatSwapInFlow";
 import Loading from "src/components/Loading";
@@ -29,6 +31,7 @@ import {
 } from "src/components/ui/tabs";
 import { useBalances } from "src/hooks/useBalances";
 import { useInfo } from "src/hooks/useInfo";
+import { useMempoolApi } from "src/hooks/useMempoolApi";
 import { useSwapInfo } from "src/hooks/useSwaps";
 import {
   CreateInvoiceRequest,
@@ -97,9 +100,29 @@ function SwapInForm() {
   const navigate = useNavigate();
 
   const [swapAmountSat, setSwapAmountSat] = useState("");
+  const { data: recommendedFees, error: mempoolError } = useMempoolApi<{
+    fastestFee: number;
+    halfHourFee: number;
+    economyFee: number;
+    minimumFee: number;
+  }>("/v1/fees/recommended");
+  const [feeRate, setFeeRate] = useState("");
+  const [editFee, setEditFee] = useState(false);
   const [loading, setLoading] = useState(false);
   const [cryptoTransaction, setCryptoTransaction] =
     useState<Transaction | null>(null);
+
+  useEffect(() => {
+    if (recommendedFees?.fastestFee) {
+      setFeeRate(recommendedFees.fastestFee.toString());
+    }
+  }, [recommendedFees]);
+
+  useEffect(() => {
+    if (mempoolError) {
+      setEditFee(true);
+    }
+  }, [mempoolError]);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -142,7 +165,11 @@ function SwapInForm() {
         throw new Error("Error swapping in");
       }
       navigate(
-        `/wallet/swap/in/status/${swapInResponse.swapId}${swapFrom === "internal" ? "?internal=true" : ""}`
+        `/wallet/swap/in/status/${swapInResponse.swapId}${
+          swapFrom === "internal"
+            ? `?internal=true&feeRate=${encodeURIComponent(feeRate)}`
+            : ""
+        }`
       );
       toast("Initiated swap");
     } catch (error) {
@@ -284,12 +311,43 @@ function SwapInForm() {
         />
       ) : (
         <>
-          <div className="flex items-center justify-between border-t pt-4">
-            <Label>Fee</Label>
-            <p className="text-muted-foreground text-sm">
-              {swapInfo.albyServiceFee + swapInfo.boltzServiceFee}% + on-chain
-              fees
-            </p>
+          <div className="flex flex-col pt-4 gap-4 border-t">
+            {isInternalSwap && (
+              <>
+                {!editFee ? (
+                  <div className="flex items-center justify-between">
+                    <Label>On-chain Fee Rate (sat/vB)</Label>
+                    <button
+                      type="button"
+                      className="flex items-center gap-2 cursor-pointer"
+                      onClick={() => setEditFee(true)}
+                    >
+                      {feeRate ? (
+                        <p className="text-sm">{feeRate} sat/vB</p>
+                      ) : (
+                        <Loading className="w-4 h-4" />
+                      )}
+                      <PencilIcon className="w-4 h-4" />
+                    </button>
+                  </div>
+                ) : (
+                  <FeeRateField
+                    feeRate={feeRate}
+                    onFeeRateChange={setFeeRate}
+                    recommendedFees={recommendedFees}
+                    hasMempoolError={Boolean(mempoolError)}
+                    mempoolUrl={info?.mempoolUrl}
+                  />
+                )}
+              </>
+            )}
+            <div className="flex items-center justify-between">
+              <Label>{isInternalSwap ? "Swap Fee" : "Fee"}</Label>
+              <p className="text-muted-foreground text-sm">
+                {swapInfo.albyServiceFee + swapInfo.boltzServiceFee}%
+                {!isInternalSwap && " + on-chain fees"}
+              </p>
+            </div>
           </div>
           <div className="grid gap-2">
             <LoadingButton className="w-full" loading={loading}>

--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -302,8 +302,8 @@ function SwapInForm() {
             <div className="flex items-center justify-between">
               <Label>{isInternalSwap ? "Swap Fee" : "Fee"}</Label>
               <p className="text-muted-foreground text-sm">
-                {swapInfo.albyServiceFee + swapInfo.boltzServiceFee}%
-                {!isInternalSwap && " + on-chain fees"}
+                {swapInfo.albyServiceFee + swapInfo.boltzServiceFee}% + on-chain
+                fees
               </p>
             </div>
           </div>

--- a/frontend/src/screens/wallet/swap/index.tsx
+++ b/frontend/src/screens/wallet/swap/index.tsx
@@ -132,6 +132,12 @@ function SwapInForm() {
 
       const payload: InitiateSwapRequest = {
         swapAmountSat: parseInt(swapAmountSat),
+        ...(swapFrom === "internal"
+          ? {
+              internalPayment: true,
+              ...(feeRate ? { feeRate: parseInt(feeRate) } : {}),
+            }
+          : {}),
       };
       const swapInResponse = await request<SwapResponse>("/api/swaps/in", {
         method: "POST",
@@ -145,9 +151,7 @@ function SwapInForm() {
       }
       navigate(
         `/wallet/swap/in/status/${swapInResponse.swapId}${
-          swapFrom === "internal"
-            ? `?internal=true&feeRate=${encodeURIComponent(feeRate)}`
-            : ""
+          swapFrom === "internal" ? "?internal=true" : ""
         }`
       );
       toast("Initiated swap");

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -594,11 +594,15 @@ export type AutoSwapRequest = {
   unlockPassword?: string;
 };
 
-export type InitiateSwapRequest = {
-  swapAmountSat?: number;
-  destination?: string;
+export type InitiateSwapInRequest = {
+  swapAmountSat: number;
   internalPayment?: boolean;
   feeRate?: number;
+};
+
+export type InitiateSwapOutRequest = {
+  swapAmountSat: number;
+  destination: string;
 };
 
 export type LSPOrderResponse = {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -597,6 +597,8 @@ export type AutoSwapRequest = {
 export type InitiateSwapRequest = {
   swapAmountSat?: number;
   destination?: string;
+  internalPayment?: boolean;
+  feeRate?: number;
 };
 
 export type LSPOrderResponse = {

--- a/http/http_service.go
+++ b/http/http_service.go
@@ -1479,7 +1479,7 @@ func (httpSvc *HttpService) getSwapInInfoHandler(c echo.Context) error {
 }
 
 func (httpSvc *HttpService) initiateSwapOutHandler(c echo.Context) error {
-	var initiateSwapOutRequest api.InitiateSwapRequest
+	var initiateSwapOutRequest api.InitiateSwapOutRequest
 	if err := c.Bind(&initiateSwapOutRequest); err != nil {
 		return c.JSON(http.StatusBadRequest, ErrorResponse{
 			Message: fmt.Sprintf("Bad request: %s", err.Error()),
@@ -1497,7 +1497,7 @@ func (httpSvc *HttpService) initiateSwapOutHandler(c echo.Context) error {
 }
 
 func (httpSvc *HttpService) initiateSwapInHandler(c echo.Context) error {
-	var initiateSwapInRequest api.InitiateSwapRequest
+	var initiateSwapInRequest api.InitiateSwapInRequest
 	if err := c.Bind(&initiateSwapInRequest); err != nil {
 		return c.JSON(http.StatusBadRequest, ErrorResponse{
 			Message: fmt.Sprintf("Bad request: %s", err.Error()),

--- a/swaps/swaps_service.go
+++ b/swaps/swaps_service.go
@@ -56,7 +56,7 @@ type SwapsService interface {
 	StopAutoSwapOut()
 	EnableAutoSwapOut(encryptionKey string) error
 	SwapOut(amountSat uint64, destination string, autoSwap, usedXpubDerivation bool) (*SwapResponse, error)
-	SwapIn(amountSat uint64, autoSwap bool) (*SwapResponse, error)
+	SwapIn(amountSat uint64, autoSwap bool, internalPayment bool, feeRate *uint64) (*SwapResponse, error)
 	GetSwapOutInfo() (*SwapInfo, error)
 	GetSwapInInfo() (*SwapInfo, error)
 	RefundSwap(swapId, address string, enableRetries bool) error
@@ -379,7 +379,7 @@ func (svc *swapsService) SwapOut(amountSat uint64, destination string, autoSwap,
 	}, nil
 }
 
-func (svc *swapsService) SwapIn(amountSat uint64, autoSwap bool) (*SwapResponse, error) {
+func (svc *swapsService) SwapIn(amountSat uint64, autoSwap bool, internalPayment bool, feeRate *uint64) (*SwapResponse, error) {
 	amountMsat := amountSat * 1000
 	invoice, err := svc.transactionsService.MakeInvoice(svc.ctx, amountMsat, "On-chain to lightning swap", "", 0, nil, svc.lnClient, nil, nil, nil)
 	if err != nil {
@@ -497,6 +497,30 @@ func (svc *swapsService) SwapIn(amountSat uint64, autoSwap bool) (*SwapResponse,
 	}
 
 	logger.Logger.WithField("swapId", swap.Id).Info("Swap created")
+
+	if internalPayment {
+		var lockupTxId string
+		lockupTxId, err = svc.lnClient.RedeemOnchainFunds(svc.ctx, swap.Address, swap.ExpectedAmount, feeRate, false)
+		if err != nil {
+			logger.Logger.WithError(err).WithFields(logrus.Fields{
+				"swapId":    swap.Id,
+				"amountSat": swap.ExpectedAmount,
+			}).Error("Failed to fund internal swap in")
+			return nil, err
+		}
+
+		err = svc.db.Model(&dbSwap).Updates(&db.Swap{
+			LockupTxId: lockupTxId,
+		}).Error
+		if err != nil {
+			logger.Logger.WithError(err).WithFields(logrus.Fields{
+				"swapId":     swap.Id,
+				"lockupTxId": lockupTxId,
+			}).Error("Failed to save internal swap lockup txid")
+			return nil, err
+		}
+		dbSwap.LockupTxId = lockupTxId
+	}
 
 	go svc.startSwapInListener(&dbSwap)
 

--- a/swaps/swaps_service.go
+++ b/swaps/swaps_service.go
@@ -499,8 +499,7 @@ func (svc *swapsService) SwapIn(amountSat uint64, autoSwap bool, internalPayment
 	logger.Logger.WithField("swapId", swap.Id).Info("Swap created")
 
 	if internalPayment {
-		var lockupTxId string
-		lockupTxId, err = svc.lnClient.RedeemOnchainFunds(svc.ctx, swap.Address, swap.ExpectedAmount, feeRate, false)
+		_, err = svc.lnClient.RedeemOnchainFunds(svc.ctx, swap.Address, swap.ExpectedAmount, feeRate, false)
 		if err != nil {
 			logger.Logger.WithError(err).WithFields(logrus.Fields{
 				"swapId":    swap.Id,
@@ -508,18 +507,6 @@ func (svc *swapsService) SwapIn(amountSat uint64, autoSwap bool, internalPayment
 			}).Error("Failed to fund internal swap in")
 			return nil, err
 		}
-
-		err = svc.db.Model(&dbSwap).Updates(&db.Swap{
-			LockupTxId: lockupTxId,
-		}).Error
-		if err != nil {
-			logger.Logger.WithError(err).WithFields(logrus.Fields{
-				"swapId":     swap.Id,
-				"lockupTxId": lockupTxId,
-			}).Error("Failed to save internal swap lockup txid")
-			return nil, err
-		}
-		dbSwap.LockupTxId = lockupTxId
 	}
 
 	go svc.startSwapInListener(&dbSwap)

--- a/wails/wails_handlers.go
+++ b/wails/wails_handlers.go
@@ -1154,7 +1154,7 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 		}
 		return WailsRequestRouterResponse{Body: swapInInfo, Error: ""}
 	case "/api/swaps/out":
-		initiateSwapOutRequest := &api.InitiateSwapRequest{}
+		initiateSwapOutRequest := &api.InitiateSwapOutRequest{}
 		err := json.Unmarshal([]byte(body), initiateSwapOutRequest)
 		if err != nil {
 			logger.Logger.WithFields(logrus.Fields{
@@ -1175,7 +1175,7 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 		}
 		return WailsRequestRouterResponse{Body: swapOutResponse, Error: ""}
 	case "/api/swaps/in":
-		initiateSwapInRequest := &api.InitiateSwapRequest{}
+		initiateSwapInRequest := &api.InitiateSwapInRequest{}
 		err := json.Unmarshal([]byte(body), initiateSwapInRequest)
 		if err != nil {
 			logger.Logger.WithFields(logrus.Fields{


### PR DESCRIPTION
Fixes #2429

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an editable on-chain fee field with view/edit mode, automatic initialization from recommended fees, validation, priority quick-selects, fee-estimate error hinting, and an optional “View on Mempool”.
  * Internal swap-in requests can now include a fee rate, and the internal flow surfaces it in the shared fee field.
* **Refactor**
  * Unified fee-rate editing across withdraw, on-chain send, and swap flows using the shared component.
* **Bug Fixes**
  * Updated on-chain wording and hyphenation (e.g., “Confirmed on-chain”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->