### PR TITLE
fix: send referrer header on stories YouTube embed

### DIFF
--- a/frontend/src/components/home/widgets/StoriesWidget.tsx
+++ b/frontend/src/components/home/widgets/StoriesWidget.tsx
@@ -198,6 +198,9 @@ export function StoriesWidget() {
                     src={youTubeEmbedUrl(activeStory.videoId)}
                     title={activeStory.title}
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                    // the server's global no-referrer policy breaks YouTube
+                    // embeds (error 153); send the origin for this frame only
+                    referrerPolicy="strict-origin-when-cross-origin"
                     allowFullScreen
                   />
                   <DialogClose asChild>


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub/issues/2431

## Problem

Stories videos fail in production with YouTube **Error 153 – Video player configuration error** (screenshot from user report).

## Root cause

YouTube now requires embedded players to receive an HTTP `Referer` header. The Hub's Echo secure middleware sets a global `Referrer-Policy: no-referrer` header (`http/http_service.go`), so the stories iframe sends no referrer and YouTube refuses to play.

This never surfaced in development because the Vite dev server doesn't apply that middleware — the header only exists when the Go server serves the built frontend.

## Fix

Add `referrerPolicy="strict-origin-when-cross-origin"` to the stories iframe. The element-level attribute overrides the document policy for this frame only, sending just the origin (no path) to YouTube. The global no-referrer policy stays intact for everything else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed YouTube story embeds that were failing to load due to referrer policy conflicts, resolving error 153 that appeared when viewing video stories in certain network configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->