### PR TITLE
fix: filter keysend preimage from custom TLVs

### DIFF
--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -530,8 +530,7 @@ func (svc *LNDService) SendKeysend(amountMsat uint64, destination string, custom
 		destCustomRecords[record.Type] = decodedValue
 	}
 	const MAX_PARTIAL_PAYMENTS = 16
-	const KEYSEND_CUSTOM_RECORD = 5482373484
-	destCustomRecords[KEYSEND_CUSTOM_RECORD] = preImageBytes
+	destCustomRecords[lnclient.KeysendPreimageTlvType] = preImageBytes
 	sendPaymentRequest := &routerrpc.SendPaymentRequest{
 		Dest:              destBytes,
 		AmtMsat:           int64(amountMsat),

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -14,6 +14,9 @@ type TLVRecord struct {
 	Value string `json:"value"`
 }
 
+// KeysendPreimageTlvType identifies the protocol-defined keysend preimage record.
+const KeysendPreimageTlvType uint64 = 5482373484
+
 type Metadata = map[string]interface{}
 
 type NodeInfo struct {

--- a/transactions/keysend_test.go
+++ b/transactions/keysend_test.go
@@ -17,6 +17,18 @@ import (
 	"github.com/getAlby/hub/tests"
 )
 
+type recordingKeysendLNClient struct {
+	lnclient.LNClient
+	customRecords []lnclient.TLVRecord
+	preimage      string
+}
+
+func (client *recordingKeysendLNClient) SendKeysend(amountMsat uint64, destination string, customRecords []lnclient.TLVRecord, preimage string) (*lnclient.PayKeysendResponse, error) {
+	client.customRecords = append([]lnclient.TLVRecord(nil), customRecords...)
+	client.preimage = preimage
+	return &lnclient.PayKeysendResponse{FeeMsat: 1}, nil
+}
+
 func TestSendKeysend(t *testing.T) {
 	svc, err := tests.CreateTestService(t)
 	require.NoError(t, err)
@@ -69,6 +81,70 @@ func TestSendKeysend_CustomPreimage(t *testing.T) {
 	assert.Zero(t, transaction.FeeReserveMsat)
 	assert.NotNil(t, transaction.Preimage)
 	assert.Equal(t, customPreimage, *transaction.Preimage)
+}
+
+func TestSendKeysend_FiltersKeysendPreimageTlv(t *testing.T) {
+	svc, err := tests.CreateTestService(t)
+	require.NoError(t, err)
+	defer svc.Remove()
+
+	lnClient := &recordingKeysendLNClient{LNClient: svc.LNClient}
+	customRecords := []lnclient.TLVRecord{
+		{
+			Type:  lnclient.KeysendPreimageTlvType,
+			Value: "not-hex",
+		},
+	}
+
+	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
+	transaction, err := transactionsService.SendKeysend(uint64(1000), "fake destination", customRecords, "", lnClient, nil, nil)
+	require.NoError(t, err)
+
+	assert.Empty(t, lnClient.customRecords)
+	assert.Len(t, lnClient.preimage, 64)
+	assert.Equal(t, lnClient.preimage, *transaction.Preimage)
+	assert.Len(t, customRecords, 1)
+
+	var metadata struct {
+		TLVRecords []lnclient.TLVRecord `json:"tlv_records"`
+	}
+	require.NoError(t, json.Unmarshal(transaction.Metadata, &metadata))
+	assert.Empty(t, metadata.TLVRecords)
+}
+
+func TestSendKeysend_FiltersKeysendPreimageTlvAndPreservesCustomRecords(t *testing.T) {
+	svc, err := tests.CreateTestService(t)
+	require.NoError(t, err)
+	defer svc.Remove()
+
+	lnClient := &recordingKeysendLNClient{LNClient: svc.LNClient}
+	customPreimage := "018465013e2337234a7e5530a21c4a8cf70d84231f4a8ff0b1e2cce3cb2bd03b"
+	applicationRecord := lnclient.TLVRecord{
+		Type:  1234567,
+		Value: "010203",
+	}
+	customRecords := []lnclient.TLVRecord{
+		{
+			Type:  lnclient.KeysendPreimageTlvType,
+			Value: "not-hex",
+		},
+		applicationRecord,
+	}
+
+	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
+	transaction, err := transactionsService.SendKeysend(uint64(1000), "fake destination", customRecords, customPreimage, lnClient, nil, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, customPreimage, lnClient.preimage)
+	assert.Equal(t, customPreimage, *transaction.Preimage)
+	assert.Equal(t, []lnclient.TLVRecord{applicationRecord}, lnClient.customRecords)
+	assert.Len(t, customRecords, 2)
+
+	var metadata struct {
+		TLVRecords []lnclient.TLVRecord `json:"tlv_records"`
+	}
+	require.NoError(t, json.Unmarshal(transaction.Metadata, &metadata))
+	assert.Equal(t, []lnclient.TLVRecord{applicationRecord}, metadata.TLVRecords)
 }
 
 func TestSendKeysend_App_NoPermission(t *testing.T) {

--- a/transactions/transactions_service.go
+++ b/transactions/transactions_service.go
@@ -431,6 +431,10 @@ func (svc *transactionsService) SendPaymentSync(payReq string, amountMsat *uint6
 }
 
 func (svc *transactionsService) SendKeysend(amountMsat uint64, destination string, customRecords []lnclient.TLVRecord, preimage string, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error) {
+	customRecords = slices.DeleteFunc(slices.Clone(customRecords), func(record lnclient.TLVRecord) bool {
+		return record.Type == lnclient.KeysendPreimageTlvType
+	})
+
 	if preimage == "" {
 		preImageBytes, err := makePreimageHex()
 		if err != nil {


### PR DESCRIPTION
## Summary

Fixes #407.

Filters the keysend preimage TLV from custom TLV records before sending payments. This prevents LDK keysend payments from failing while preserving other custom TLVs.

## Testing

- Added tests for generated and custom preimages
- Added tests confirming other custom TLVs are preserved
- Keysend transaction and controller tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keysend payment handling to properly filter preimage records from custom metadata, ensuring only intended custom records are included in keysend transactions.

* **Tests**
  * Added comprehensive test coverage for keysend preimage record filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->