### PR TITLE
fix: add lightning tag to Freedomia card

### DIFF
--- a/frontend/src/screens/cards/Cards.tsx
+++ b/frontend/src/screens/cards/Cards.tsx
@@ -145,7 +145,7 @@ const providers: Provider[] = [
     applePay: false,
     googlePay: true,
     selfCustody: false,
-    lightningNative: false,
+    lightningNative: true,
     kyc: false,
     timeToGet: "Instant",
     cardCost: "$5–30 / mo",


### PR DESCRIPTION
Fixes #2434.

Adds the Lightning tag to the Freedomia card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Freedomia provider configuration to properly support Lightning-native functionality. Users filtering by the Lightning-native feature will now see accurate results that correctly include the Freedomia provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->