### PR TITLE
feat: use switch and improve copy on node settings page

### DIFF
--- a/frontend/src/screens/settings/NodeSettings.tsx
+++ b/frontend/src/screens/settings/NodeSettings.tsx
@@ -69,7 +69,7 @@ export function NodeSettings() {
           <Switch
             id="jit-channels"
             checked={info.jitChannelsEnabled}
-            disabled={!hasJitSource}
+            disabled={!hasJitSource && !info.jitChannelsEnabled}
             onCheckedChange={setJitChannelsEnabled}
           />
         </div>

--- a/frontend/src/screens/settings/NodeSettings.tsx
+++ b/frontend/src/screens/settings/NodeSettings.tsx
@@ -2,8 +2,8 @@ import { toast } from "sonner";
 import ExternalLink from "src/components/ExternalLink";
 import Loading from "src/components/Loading";
 import SettingsHeader from "src/components/SettingsHeader";
-import { Checkbox } from "src/components/ui/checkbox";
 import { Label } from "src/components/ui/label";
+import { Switch } from "src/components/ui/switch";
 
 import { useInfo } from "src/hooks/useInfo";
 import { handleRequestError } from "src/utils/handleRequestError";
@@ -31,9 +31,13 @@ export function NodeSettings() {
         body: JSON.stringify({ jitChannelsEnabled: enabled }),
       });
       await refetchInfo();
-      toast(enabled ? "JIT channels enabled" : "JIT channels disabled");
+      toast(
+        enabled
+          ? "Just-in-time channels enabled"
+          : "Just-in-time channels disabled"
+      );
     } catch (error) {
-      handleRequestError("Failed to update JIT channels setting", error);
+      handleRequestError("Failed to update just-in-time channels", error);
     }
   }
 
@@ -42,40 +46,36 @@ export function NodeSettings() {
       <SettingsHeader
         pageTitle="Node"
         title="Node"
-        description="Configure your node's behavior"
+        description="Configure how your node handles channels and payments."
       />
       <div className="flex flex-col gap-4">
-        <div>
-          <p className="text-muted-foreground">
-            JIT (just-in-time) channels let you receive payments larger than
-            your current inbound capacity by automatically opening a new channel
-            through a liquidity provider. The provider's fee is deducted from
-            the incoming payment.{" "}
-            <ExternalLink
-              to="https://guides.getalby.com/user-guide/alby-hub/faq/what-are-just-in-time-channels"
-              className="underline"
-            >
-              Learn more
-            </ExternalLink>
-          </p>
-        </div>
-        <div className="flex items-center">
-          <Checkbox
+        <div className="flex items-center justify-between gap-8">
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="jit-channels" className="cursor-pointer">
+              Just-in-time channels
+            </Label>
+            <p className="text-sm text-muted-foreground">
+              Automatically open a new channel through a liquidity provider when
+              you receive a payment that exceeds your receive limit. The
+              provider's fee is deducted from that payment.{" "}
+              <ExternalLink
+                to="https://guides.getalby.com/user-guide/alby-hub/faq/what-are-just-in-time-channels"
+                className="underline"
+              >
+                Learn more
+              </ExternalLink>
+            </p>
+          </div>
+          <Switch
             id="jit-channels"
             checked={info.jitChannelsEnabled}
             disabled={!hasJitSource}
-            onCheckedChange={(checked) =>
-              setJitChannelsEnabled(checked === true)
-            }
+            onCheckedChange={setJitChannelsEnabled}
           />
-          <Label htmlFor="jit-channels" className="ml-2 cursor-pointer">
-            Enable JIT channels for receiving
-          </Label>
         </div>
         {!hasJitSource && (
           <p className="text-sm text-muted-foreground">
-            No JIT liquidity source is available for your network, so JIT
-            channels can't be used.
+            Just-in-time channels are currently not available on your network.
           </p>
         )}
       </div>


### PR DESCRIPTION
Improves the Node settings page (Settings → Node):

- Replace the JIT channels checkbox with a `Switch` in the standard settings-row layout (title + description on the left, switch on the right, matching the pattern in `Permissions.tsx`)
- Improve copy:
  - Setting titled "Just-in-time channels" instead of the "Enable JIT channels for receiving" checkbox label
  - Shorter description phrased around the user's receive limit, with the existing "Learn more" link
  - Page subtitle: "Configure how your node handles channels and payments."
  - Toasts and the unavailable-state message spell out "Just-in-time channels"

| Before | After |
|---|---|
| checkbox + long intro paragraph | settings row with switch |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated Just-in-time channels toggle in Node Settings to a clearer switch control and improved interaction.
  * Refined header, explanatory, CTA and "not available" texts for better clarity and flow.
  * Updated success and error notifications to reference "Just-in-time channels" explicitly.

* **Bug Fixes**
  * Toggle disable behavior adjusted: it’s only disabled when no JIT source exists and the setting is currently off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->