### PR TITLE
fix: add fallback instructions if JIT LSP seems to be offline

### DIFF
--- a/frontend/src/components/FirstChannelJitAlert.tsx
+++ b/frontend/src/components/FirstChannelJitAlert.tsx
@@ -131,14 +131,18 @@ export default function FirstChannelJitAlert() {
     }
 
     // they already have channels but a JIT channel couldn't be obtained, so they
-    // can only receive up to their current capacity without opening one.
+    // can only receive up to their current capacity without opening one. Wait for
+    // balances so we don't claim a misleading "0" receivable amount.
+    if (!balances) {
+      return null;
+    }
     return (
       <Alert>
         <InfoIcon className="h-4 w-4" />
         <AlertDescription className="inline">
           You can currently receive up to{" "}
           <FormattedBitcoinAmount
-            amountMsat={balances?.lightning.totalReceivableMsat ?? 0}
+            amountMsat={balances.lightning.totalReceivableMsat}
           />
           . If you want to receive a larger payment,{" "}
           <Link className="underline" to="/channels/incoming">

--- a/frontend/src/components/FirstChannelJitAlert.tsx
+++ b/frontend/src/components/FirstChannelJitAlert.tsx
@@ -1,13 +1,21 @@
-import { InfoIcon } from "lucide-react";
+import { AlertTriangleIcon, InfoIcon } from "lucide-react";
+import React from "react";
+import { Link } from "react-router";
 import ExternalLink from "src/components/ExternalLink";
 import { FormattedBitcoinAmount } from "src/components/FormattedBitcoinAmount";
 import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
+import { useBalances } from "src/hooks/useBalances";
 import { useChannels } from "src/hooks/useChannels";
 import { useInfo } from "src/hooks/useInfo";
+import { CreateInvoiceRequest, Transaction } from "src/types";
+import { request } from "src/utils/request";
+
+const PROBE_TIMEOUT_MS = 5000;
 
 export default function FirstChannelJitAlert() {
   const { data: info } = useInfo();
   const { data: channels } = useChannels();
+  const { data: balances } = useBalances();
 
   // a JIT channel only opens when the feature is enabled AND an LSPS2 liquidity
   // source is actually configured (jitChannelsEnabled alone is just a settings
@@ -16,13 +24,125 @@ export default function FirstChannelJitAlert() {
     ? info.jitChannelsLiquiditySource
     : undefined;
 
-  // only relevant when the user has no channels yet - their first received
-  // payment will open the channel.
-  if (!lsps2Source || !channels || channels.length > 0) {
+  const minPaymentSizeMsat = info?.jitChannelsMinPaymentSizeMsat;
+
+  const isJitEnabled = !!lsps2Source && !!channels;
+  // the user's first received payment opens the channel when they have none yet.
+  const isFirstChannel = isJitEnabled && channels.length === 0;
+
+  // probe whether a JIT channel can actually be obtained by requesting an
+  // invoice for the minimum payment size. If it (or waiting for the minimum
+  // payment size) doesn't succeed within the timeout, we surface a fallback
+  // alert depending on whether the user already has channels.
+  const [probeState, setProbeState] = React.useState<
+    "loading" | "ok" | "failed"
+  >("loading");
+  const deadlineRef = React.useRef<number | null>(null);
+
+  React.useEffect(() => {
+    if (!isJitEnabled) {
+      deadlineRef.current = null;
+      return;
+    }
+
+    // start the 5s clock once when we enter JIT mode - it keeps ticking while
+    // we wait for the minimum payment size to become available.
+    if (deadlineRef.current === null) {
+      deadlineRef.current = Date.now() + PROBE_TIMEOUT_MS;
+    }
+
+    let cancelled = false;
+    const remainingMs = deadlineRef.current - Date.now();
+    if (remainingMs <= 0) {
+      setProbeState("failed");
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if (!cancelled) {
+        setProbeState("failed");
+      }
+    }, remainingMs);
+
+    // wait for the minimum payment size before requesting the probe invoice.
+    if (minPaymentSizeMsat) {
+      request<Transaction>("/api/invoices", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          amountMsat: minPaymentSizeMsat,
+          description: "",
+        } as CreateInvoiceRequest),
+      })
+        .then(() => {
+          if (!cancelled) {
+            clearTimeout(timer);
+            setProbeState("ok");
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            clearTimeout(timer);
+            setProbeState("failed");
+          }
+        });
+    }
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [isJitEnabled, minPaymentSizeMsat]);
+
+  if (!isJitEnabled || probeState === "loading") {
     return null;
   }
 
-  const minPaymentSizeMsat = info?.jitChannelsMinPaymentSizeMsat;
+  if (probeState === "failed") {
+    // no channels yet and a JIT channel couldn't be obtained - the user has no
+    // receiving capacity at all and will fail to receive until a channel opens.
+    if (isFirstChannel) {
+      return (
+        <Alert variant="warning">
+          <AlertTriangleIcon className="h-4 w-4" />
+          <AlertTitle>Can't receive payments yet</AlertTitle>
+          <AlertDescription className="inline">
+            You won't be able to receive payments until you{" "}
+            <Link className="underline" to="/channels/incoming">
+              open a channel
+            </Link>
+            .
+          </AlertDescription>
+        </Alert>
+      );
+    }
+
+    // they already have channels but a JIT channel couldn't be obtained, so they
+    // can only receive up to their current capacity without opening one.
+    return (
+      <Alert>
+        <InfoIcon className="h-4 w-4" />
+        <AlertDescription className="inline">
+          You can currently receive up to{" "}
+          <FormattedBitcoinAmount
+            amountMsat={balances?.lightning.totalReceivableMsat ?? 0}
+          />
+          . If you want to receive a larger payment,{" "}
+          <Link className="underline" to="/channels/incoming">
+            open a channel
+          </Link>
+          .
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  // probe succeeded - only the first-channel case needs an informational alert.
+  if (!isFirstChannel) {
+    return null;
+  }
 
   return (
     <Alert>

--- a/frontend/src/components/FirstChannelJitAlert.tsx
+++ b/frontend/src/components/FirstChannelJitAlert.tsx
@@ -38,10 +38,17 @@ export default function FirstChannelJitAlert() {
     "loading" | "ok" | "failed"
   >("loading");
   const deadlineRef = React.useRef<number | null>(null);
+  // single-flight the non-idempotent probe invoice: hold the in-flight request
+  // so effect re-entry (e.g. StrictMode remount) reuses the same POST instead
+  // of creating a duplicate invoice. Reset when the probe window ends.
+  const probeRequestRef = React.useRef<Promise<Transaction | undefined> | null>(
+    null
+  );
 
   React.useEffect(() => {
     if (!isJitEnabled) {
       deadlineRef.current = null;
+      probeRequestRef.current = null;
       return;
     }
 
@@ -66,16 +73,20 @@ export default function FirstChannelJitAlert() {
 
     // wait for the minimum payment size before requesting the probe invoice.
     if (minPaymentSizeMsat) {
-      request<Transaction>("/api/invoices", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          amountMsat: minPaymentSizeMsat,
-          description: "",
-        } as CreateInvoiceRequest),
-      })
+      // reuse an already in-flight probe so a re-run doesn't issue a second POST.
+      const probeRequest =
+        probeRequestRef.current ??
+        (probeRequestRef.current = request<Transaction>("/api/invoices", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            amountMsat: minPaymentSizeMsat,
+            description: "",
+          } as CreateInvoiceRequest),
+        }));
+      probeRequest
         .then(() => {
           if (!cancelled) {
             clearTimeout(timer);

--- a/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertTriangleIcon,
   ArrowLeftIcon,
   CopyIcon,
   LinkIcon,
@@ -7,6 +8,7 @@ import {
 } from "lucide-react";
 import TickSVG from "public/images/illustrations/tick.svg";
 import React from "react";
+import { Link } from "react-router";
 import { toast } from "sonner";
 import AppHeader from "src/components/AppHeader";
 import { CurrencyInputField } from "src/components/CurrencyInputField";
@@ -22,6 +24,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "src/components/ui/accordion";
+import { Alert, AlertDescription } from "src/components/ui/alert";
 import { Button } from "src/components/ui/button";
 import {
   Card,
@@ -53,6 +56,8 @@ export default function ReceiveInvoice() {
   const { data: channels } = useChannels();
 
   const [isLoading, setLoading] = React.useState(false);
+  const [jitChannelRequestFailed, setJitChannelRequestFailed] =
+    React.useState(false);
   const [amountSat, setAmountSat] = React.useState<string>("");
   const [description, setDescription] = React.useState<string>("");
   const [transaction, setTransaction] = React.useState<Transaction | null>(
@@ -111,6 +116,7 @@ export default function ReceiveInvoice() {
 
     try {
       setLoading(true);
+      setJitChannelRequestFailed(false);
       const invoice = await request<Transaction>("/api/invoices", {
         method: "POST",
         headers: {
@@ -149,6 +155,9 @@ export default function ReceiveInvoice() {
       toast.error("Failed to create invoice", {
         description,
       });
+      if (jitChannelsEnabled) {
+        setJitChannelRequestFailed(true);
+      }
       console.error(e);
     } finally {
       setLoading(false);
@@ -370,6 +379,17 @@ export default function ReceiveInvoice() {
               </form>
             )}
           </div>
+          {!transaction && jitChannelRequestFailed && (
+            <Alert variant="warning">
+              <AlertTriangleIcon className="h-4 w-4" />
+              <AlertDescription className="inline">
+                Failed to request a just-in-time channel invoice.{" "}
+                <Link className="underline" to="/channels/incoming">
+                  Manually open a channel.
+                </Link>
+              </AlertDescription>
+            </Alert>
+          )}
         </div>
         {!transaction &&
           (!info?.albyAccountConnected || !me?.lightning_address) && (

--- a/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
@@ -155,7 +155,7 @@ export default function ReceiveInvoice() {
       toast.error("Failed to create invoice", {
         description,
       });
-      if (jitChannelsEnabled) {
+      if (lsps2Source) {
         setJitChannelRequestFailed(true);
       }
       console.error(e);


### PR DESCRIPTION
In case we detect the JIT LSP is offline, the user needs to know that they can manually open a channel.
- For invoices this is done if creation of an invoice fails
- For lightning address, this is done if creation of a "probe" invoice fails or we time out (e.g. getting minimum payment size)

Invoice receive screen
<img width="1121" height="931" alt="image" src="https://github.com/user-attachments/assets/f32957d1-eaf3-4c83-8411-f156eaf156de" />

Lightning receive screen
1. User has no channels, JIT not working

<img width="1136" height="214" alt="image" src="https://github.com/user-attachments/assets/0f7a872f-49f9-474a-b19a-ec7fda715a47" />

2. User has no channels, JIT working

<img width="1136" height="214" alt="image" src="https://github.com/user-attachments/assets/48ab3301-23cd-4f06-a6b2-37f12fa0c421" />

3. User has channel(s), JIT not working

<img width="1136" height="214" alt="image" src="https://github.com/user-attachments/assets/c7b48e38-f195-499f-abd9-af8a8c4443c8" />

4. User has channels + JIT working = no alert

(no image)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a probe-with-timeout to verify Just-In-Time (JIT) channel availability before showing the “first payment opens a channel” alert, preventing premature or misleading alerts.
  * Improved handling and messaging when JIT channel invoice creation fails: the receive screen now shows a clear warning and a link to manually open an incoming channel when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->