### PR TITLE
fix: handle unavailable node

### DIFF
--- a/frontend/src/components/NodeUnavailable.tsx
+++ b/frontend/src/components/NodeUnavailable.tsx
@@ -1,0 +1,38 @@
+import { RefreshCwIcon, ServerOffIcon, SettingsIcon } from "lucide-react";
+import AppHeader from "src/components/AppHeader";
+import { Button } from "src/components/ui/button";
+import { LinkButton } from "src/components/ui/custom/link-button";
+
+type Props = {
+  onRetry: () => void;
+};
+
+export function NodeUnavailable({ onRetry }: Props) {
+  return (
+    <>
+      <AppHeader title="Node unavailable" pageTitle="Node unavailable" />
+      <div className="flex flex-1 items-center justify-center rounded-lg bg-muted p-8">
+        <div className="flex max-w-md flex-col items-center gap-1 text-center">
+          <ServerOffIcon className="size-10 text-muted-foreground" />
+          <h2 className="mt-4 text-lg font-semibold">
+            Your lightning node is unavailable
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Alby Hub cannot reach your lightning node right now. Check your node
+            settings or try again after the node is running.
+          </p>
+          <div className="mt-4 flex flex-wrap justify-center gap-2">
+            <Button onClick={onRetry}>
+              <RefreshCwIcon />
+              Try again
+            </Button>
+            <LinkButton to="/settings/node" variant="secondary">
+              <SettingsIcon />
+              Node settings
+            </LinkButton>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/redirects/DefaultRedirect.tsx
+++ b/frontend/src/components/redirects/DefaultRedirect.tsx
@@ -1,30 +1,56 @@
 import React from "react";
 import { Outlet, useLocation, useNavigate } from "react-router";
 import Loading from "src/components/Loading";
+import { NodeUnavailable } from "src/components/NodeUnavailable";
 import { localStorageKeys } from "src/constants";
 import { useInfo } from "src/hooks/useInfo";
+import { useNodeStatus } from "src/hooks/useNodeStatus";
+
+const nodeDependentPaths = ["/home", "/wallet", "/channels", "/peers"];
 
 export function DefaultRedirect() {
   const { data: info } = useInfo();
   const location = useLocation();
   const navigate = useNavigate();
+  const canAccessApp =
+    !!info?.running &&
+    !!info.unlocked &&
+    (info.albyAccountConnected || !info.albyUserIdentifier);
+  const isNodeDependentPath = nodeDependentPaths.some(
+    (path) =>
+      location.pathname === path || location.pathname.startsWith(`${path}/`)
+  );
+  const {
+    data: nodeStatus,
+    error: nodeStatusError,
+    isLoading: isNodeStatusLoading,
+    mutate: refetchNodeStatus,
+  } = useNodeStatus(canAccessApp && isNodeDependentPath);
 
   React.useEffect(() => {
-    if (
-      !info ||
-      (info.running &&
-        info.unlocked &&
-        (info.albyAccountConnected || !info.albyUserIdentifier))
-    ) {
+    if (!info || canAccessApp) {
       return;
     }
     const returnTo = location.pathname + location.search;
     window.localStorage.setItem(localStorageKeys.returnTo, returnTo);
     navigate("/");
-  }, [info, location, navigate]);
+  }, [canAccessApp, info, location, navigate]);
 
   if (!info) {
     return <Loading />;
+  }
+
+  if (canAccessApp && isNodeDependentPath && isNodeStatusLoading) {
+    return <Loading />;
+  }
+
+  if (
+    canAccessApp &&
+    isNodeDependentPath &&
+    !isNodeStatusLoading &&
+    (nodeStatusError || !nodeStatus?.isReady)
+  ) {
+    return <NodeUnavailable onRetry={() => void refetchNodeStatus()} />;
   }
 
   return <Outlet />;

--- a/frontend/src/hooks/useNodeStatus.ts
+++ b/frontend/src/hooks/useNodeStatus.ts
@@ -1,0 +1,16 @@
+import useSWR, { SWRConfiguration } from "swr";
+
+import { NodeStatus } from "src/types";
+import { swrFetcher } from "src/utils/swr";
+
+const pollConfiguration: SWRConfiguration = {
+  refreshInterval: 3000,
+};
+
+export function useNodeStatus(enabled = true) {
+  return useSWR<NodeStatus | null>(
+    enabled ? "/api/node/status" : null,
+    swrFetcher,
+    pollConfiguration
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -212,6 +212,11 @@ export type HealthResponse = {
   alarms: HealthAlarm[];
 };
 
+export type NodeStatus = {
+  isReady: boolean;
+  internalNodeStatus: unknown;
+};
+
 export type Network = "bitcoin" | "testnet" | "signet";
 
 export type AppMetadata = {


### PR DESCRIPTION
## Description

Shows a clear unavailable state when Alby Hub cannot reach the lightning node, instead of leaving node-dependent pages stuck loading or showing broken API errors.

The unavailable state is shown for core node-backed routes like Home, Wallet, Node/Channels, and Peers. Settings and Connections remain accessible so users can still inspect configuration or recover.

Fixes #410

## Changes

- Added a shared `/api/node/status` polling hook
- Added a reusable `NodeUnavailable` screen with retry and Node settings actions
- Updated route handling to show the unavailable screen only after Hub is otherwise accessible
- Added the frontend `NodeStatus` type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unavailable node state that displays when a lightning node connection is lost, with options to retry connection or navigate to settings
  * Implemented node availability validation on key app routes; access to wallet, channels, peers, and home sections now requires an active node connection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->