### PR TITLE
fix: soften channel routing warning

### DIFF
--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -978,7 +978,7 @@ func (ls *LDKService) ListChannels(ctx context.Context) ([]lnclient.Channel, err
 			channelError = &channelErrorValue
 		} else if ldkChannel.IsUsable && ldkChannel.CounterpartyForwardingInfoFeeBaseMsat == nil {
 			// if we don't have this, routing will not work (LND <-> LDK interoperability bug - https://github.com/lightningnetwork/lnd/issues/6870 )
-			channelErrorValue := "Counterparty forwarding info not available. Please contact support@getalby.com"
+			channelErrorValue := "Channel routing info is still syncing. Restart Alby Hub if this warning does not clear soon."
 			channelError = &channelErrorValue
 		}
 

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -978,7 +978,7 @@ func (ls *LDKService) ListChannels(ctx context.Context) ([]lnclient.Channel, err
 			channelError = &channelErrorValue
 		} else if ldkChannel.IsUsable && ldkChannel.CounterpartyForwardingInfoFeeBaseMsat == nil {
 			// if we don't have this, routing will not work (LND <-> LDK interoperability bug - https://github.com/lightningnetwork/lnd/issues/6870 )
-			channelErrorValue := "Channel routing info is still syncing. Restart Alby Hub if this warning does not clear soon."
+			channelErrorValue := "Counterparty forwarding info is not yet available, but normally resolves automatically. Try restarting Alby Hub if this warning does not resolve within a few hours."
 			channelError = &channelErrorValue
 		}
 


### PR DESCRIPTION
## Description

Softens the LDK channel warning shown when counterparty routing information is not available yet.

Instead of telling users to contact support immediately, the message now explains that channel routing info may still be syncing and suggests restarting Alby Hub if the warning does not clear soon.

Fixes #2346.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel error messaging to provide clearer guidance when routing information is syncing, including instructions to restart if the issue persists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->