### PR TITLE
test: use ldk async event binding

### DIFF
--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -306,23 +306,22 @@ func NewLDKService(ctx context.Context, cfg config.Config, eventPublisher events
 	// check for and forward new LDK events to LDKEventBroadcaster (through ldkEventConsumer)
 	go func() {
 		for {
+			if ldkCtx.Err() != nil {
+				return
+			}
+
+			event := node.WaitNextEvent()
+			eventPtr := &event
+
+			ls.handleLdkEvent(eventPtr)
 			select {
 			case <-ldkCtx.Done():
+			case ldkEventConsumer <- eventPtr:
+			}
+
+			node.EventHandled()
+			if ldkCtx.Err() != nil {
 				return
-			default:
-				// NOTE: currently do not use WaitNextEvent() as it can possibly block the LDK thread (to confirm)
-				event := node.NextEvent()
-				if event == nil {
-					// if there is no event, wait before polling again to avoid 100% CPU usage
-					// TODO: remove this and use WaitNextEvent()
-					time.Sleep(time.Duration(1000) * time.Millisecond)
-					continue
-				}
-
-				ls.handleLdkEvent(event)
-				ldkEventConsumer <- event
-
-				node.EventHandled()
 			}
 		}
 	}()


### PR DESCRIPTION
Switch LDK event handling from polling `NextEvent()` every second to blocking on `WaitNextEvent()`, confirming the current Go bindings can support LDK’s async event API direction.

Tests:
- `go test ./lnclient/ldk -count=1 -v -timeout 60s`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved event-forwarding mechanism for better efficiency and resource management. Enhanced context cancellation handling to enable graceful shutdown and prevent resource leaks during application termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->