### PR TITLE
chore: bump rebalance fees to ensure payment succeeds

### DIFF
--- a/api/rebalance.go
+++ b/api/rebalance.go
@@ -122,7 +122,7 @@ func (api *api) RebalanceChannel(ctx context.Context, rebalanceChannelRequest *R
 		return nil, err
 	}
 
-	if paymentRequest.MSatoshi > int64(float64(amountSat)*float64(1000)*float64(1.003)+1 /*0.3% fees*/) {
+	if paymentRequest.MSatoshi > int64(float64(amountSat)*float64(1000)*float64(1.005)+1 /*0.5% fees*/) {
 		return nil, errors.New("rebalance payment is more expensive than expected")
 	}
 

--- a/frontend/src/components/RebalanceChannelDialogContent.tsx
+++ b/frontend/src/components/RebalanceChannelDialogContent.tsx
@@ -134,7 +134,7 @@ export function RebalanceChannelDialogContent({
               }}
             />
             <p className="mt-2 text-xs text-muted-foreground">
-              Fee: 0.3%
+              Fee: 0.5%
               {!!amountSat && (
                 <>
                   &nbsp;(


### PR DESCRIPTION
Often Megalith's rebalancing service cannot find a route, which leads to a failed rebalance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rebalance payment validation to allow a slightly higher fee tolerance before rejecting a payment.
  * Updated the displayed rebalance fee estimate in the dialog from **0.3%** to **0.5%** so the UI matches the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->