### PR TITLE
fix: require full access api key for swaps/mnemonic

### DIFF
--- a/http/http_service.go
+++ b/http/http_service.go
@@ -148,7 +148,6 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	readOnlyApiGroup.GET("/swaps/:swapId", httpSvc.lookupSwapHandler)
 	readOnlyApiGroup.GET("/swaps/out/info", httpSvc.getSwapOutInfoHandler)
 	readOnlyApiGroup.GET("/swaps/in/info", httpSvc.getSwapInInfoHandler)
-	readOnlyApiGroup.GET("/swaps/mnemonic", httpSvc.swapMnemonicHandler)
 	readOnlyApiGroup.GET("/autoswap", httpSvc.getAutoSwapConfigHandler)
 	readOnlyApiGroup.GET("/forwards", httpSvc.forwardsHandler)
 
@@ -191,6 +190,7 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	fullAccessApiGroup.POST("/swaps/out", httpSvc.initiateSwapOutHandler)
 	fullAccessApiGroup.POST("/swaps/in", httpSvc.initiateSwapInHandler)
 	fullAccessApiGroup.POST("/swaps/refund", httpSvc.refundSwapHandler)
+	fullAccessApiGroup.GET("/swaps/mnemonic", httpSvc.swapMnemonicHandler)
 	fullAccessApiGroup.POST("/autoswap", httpSvc.enableAutoSwapOutHandler)
 	fullAccessApiGroup.DELETE("/autoswap", httpSvc.disableAutoSwapOutHandler)
 	fullAccessApiGroup.POST("/node/alias", httpSvc.setNodeAliasHandler)


### PR DESCRIPTION
the mnemonic could be considered a non read-only route because the mnemonic could be used.
This moves this route to the full access group to require a full access api key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted access to the mnemonic swap endpoint to full-access requests.
  * Read-only API access can no longer retrieve mnemonic swap data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->