### PR TITLE
fix: update wave.space affiliate URL

### DIFF
--- a/frontend/src/components/connections/SuggestedAppData.tsx
+++ b/frontend/src/components/connections/SuggestedAppData.tsx
@@ -1268,8 +1268,7 @@ export const appStoreApps: AppStoreApp[] = (
       title: "wavecard® by wave.space",
       description:
         "Spend Bitcoin from your AlbyHub at 150M+ merchants worldwide",
-      webLink:
-        "https://app.wave.space/spend/?utm_source=albyhub&affiliate=AlbyHub",
+      webLink: "https://app.wave.space/?utm_source=albyhub&affiliate=AlbyHub",
       logo: wavespace,
       extendedDescription:
         "The world's first Bitcoin VISA Debit Card that allows you to spend BTC globally, anywhere VISA is accepted – straight from the safety of your own NWC-enabled wallet. ✨ EXCLUSIVE ALBYHUB SPECIAL🐝 → Get 21% cashback on your wavecard transactions (up to 10,000 sats) using code »AlbyHub«",
@@ -1281,10 +1280,10 @@ export const appStoreApps: AppStoreApp[] = (
               <li>
                 Open{" "}
                 <ExternalLink
-                  to="https://app.wave.space/spend/?utm_source=albyhub&affiliate=AlbyHub"
+                  to="https://app.wave.space/?utm_source=albyhub&affiliate=AlbyHub"
                   className="font-medium text-foreground underline"
                 >
-                  wave.space/spend
+                  wave.space
                 </ExternalLink>{" "}
                 in your browser and{" "}
                 <span className="font-medium text-foreground">

--- a/frontend/src/screens/cards/Cards.tsx
+++ b/frontend/src/screens/cards/Cards.tsx
@@ -198,7 +198,7 @@ const providers: Provider[] = [
   {
     id: "wavespace",
     name: "wavecard by wave.space",
-    url: "https://app.wave.space/spend/?utm_source=albyhub&affiliate=AlbyHub",
+    url: "https://app.wave.space/?utm_source=albyhub&affiliate=AlbyHub",
     logo: wavespaceLogo,
     initials: "WS",
     networks: ["Visa"],


### PR DESCRIPTION
### Description

wave.space moved their product links, so the old `/spend` path no longer works. Updated the wavecard link to the new URL (`https://app.wave.space/?utm_source=albyhub&affiliate=AlbyHub`), keeping the affiliate and utm params intact.

Changed it in both places it's used ,the Cards screen, suggested apps list and updated the visible "wave.space/spend" text since that path is gone.

Closes #2472


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the wave.space links to open the main app landing page instead of the `/spend` section.
  * Updated installation guidance and displayed link text to match the new destination.
  * Updated provider cards so selecting or visiting wave.space opens the correct landing page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->