### PR TITLE
docs: add security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,8 @@ Once the user has authorized the app connection a `nwc:success` message is sent 
 If you need help contact support@getalby.com or reach out on Nostr: npub1getal6ykt05fsz5nqu4uld09nfj3y3qxmv8crys4aeut53unfvlqr80nfm
 You can also visit the chat of our Community on [Telegram](https://t.me/getalby).
 
+For security vulnerabilities, please follow our [security policy](SECURITY.md).
+
 ## ⚡️Donations
 
 Want to support the work on Alby?

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately by emailing [security@getalby.com](mailto:security@getalby.com). Do not open a public issue or disclose the vulnerability publicly until we have coordinated a fix.
+
+Please include the affected version or component, the potential impact, and clear steps to reproduce the issue. We will acknowledge your report and keep you informed as we investigate and address it.


### PR DESCRIPTION
## Summary

- add concise guidance for privately reporting security vulnerabilities
- direct reports to security@getalby.com
- request affected version, impact, and reproduction details
- link the policy from the README's Help section

## Testing

- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a security policy with instructions for privately reporting vulnerabilities.
  * Requests affected components, versions, impact, and reproduction details.
  * Clarifies coordinated disclosure expectations before public release.
  * Added a link to the security policy in the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->