### PR TITLE
ci: support builds for fork pull requests

### DIFF
--- a/.github/workflows/http.yml
+++ b/.github/workflows/http.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         build:
           [
@@ -128,7 +129,15 @@ jobs:
         run: go build ${{ env.GOTAGS }} -o build/bin/${{ env.PACKAGE_NAME }}/bin/${{ env.EXEC_NAME }} -ldflags "-X 'github.com/getAlby/hub/version.Tag=${{ env.TAG }}'" cmd/http/main.go
 
       - name: Import Code-Signing Certificates for macOS
-        if: runner.os == 'macOS'
+        if: >-
+          runner.os == 'macOS' &&
+          (
+            !github.event.pull_request ||
+            (
+              github.event.pull_request.head.repo.full_name == github.repository &&
+              github.actor != 'dependabot[bot]'
+            )
+          )
         uses: Apple-Actions/import-codesign-certs@v3
         with:
           # The certificates in a PKCS12 file encoded as a base64 string
@@ -165,7 +174,15 @@ jobs:
         shell: bash
 
       - name: Sign the MacOS binary and libraries
-        if: runner.os == 'macOS'
+        if: >-
+          runner.os == 'macOS' &&
+          (
+            !github.event.pull_request ||
+            (
+              github.event.pull_request.head.repo.full_name == github.repository &&
+              github.actor != 'dependabot[bot]'
+            )
+          )
         run: |
           /usr/bin/codesign -s "Developer ID Application: Alby Inc." -f -v --deep --timestamp --options runtime ./build/bin/${{ env.PACKAGE_NAME }}/bin/${{ env.EXEC_NAME }}
           /usr/bin/codesign -s "Developer ID Application: Alby Inc." -f -v --deep --timestamp --options runtime ./build/bin/${{ env.PACKAGE_NAME }}/lib/*.dylib
@@ -189,7 +206,16 @@ jobs:
           cd ../../..
 
       - name: Notarize the zip file
-        if: runner.os == 'macOS' && inputs.build-release
+        if: >-
+          runner.os == 'macOS' &&
+          inputs.build-release &&
+          (
+            !github.event.pull_request ||
+            (
+              github.event.pull_request.head.repo.full_name == github.repository &&
+              github.actor != 'dependabot[bot]'
+            )
+          )
         run: |
           echo "Notarizing Zip Files"
           gon -log-level=info -log-json ./build/darwin/http/gon-notarize.json

--- a/.github/workflows/wails.yml
+++ b/.github/workflows/wails.yml
@@ -129,7 +129,15 @@ jobs:
         shell: bash
 
       - name: Import Code-Signing Certificates for macOS
-        if: runner.os == 'macOS'
+        if: >-
+          runner.os == 'macOS' &&
+          (
+            !github.event.pull_request ||
+            (
+              github.event.pull_request.head.repo.full_name == github.repository &&
+              github.actor != 'dependabot[bot]'
+            )
+          )
         uses: Apple-Actions/import-codesign-certs@v3
         with:
           # The certificates in a PKCS12 file encoded as a base64 string
@@ -190,7 +198,15 @@ jobs:
           mv ./build/out/${{ env.PACKAGE_NAME }}.tar.bz2 ./build/bin/
 
       - name: Sign the macOS binary
-        if: runner.os == 'macOS'
+        if: >-
+          runner.os == 'macOS' &&
+          (
+            !github.event.pull_request ||
+            (
+              github.event.pull_request.head.repo.full_name == github.repository &&
+              github.actor != 'dependabot[bot]'
+            )
+          )
         run: |
           echo "Signing Package"
           /usr/bin/codesign -s "Developer ID Application: Alby Inc." -f -v --deep --timestamp --options runtime --entitlements ./build/darwin/entitlements.plist "./build/bin/${{ env.EXEC_NAME }}.app"
@@ -222,7 +238,15 @@ jobs:
           EOF
 
       - name: Notarize the DMG image
-        if: runner.os == 'macOS'
+        if: >-
+          runner.os == 'macOS' &&
+          (
+            !github.event.pull_request ||
+            (
+              github.event.pull_request.head.repo.full_name == github.repository &&
+              github.actor != 'dependabot[bot]'
+            )
+          )
         run: |
           echo "Notarizing Zip Files"
           gon -log-level=info -log-json ./build/darwin/gon-notarize.json


### PR DESCRIPTION
## Summary

- skip macOS certificate import, signing, and notarization for fork and Dependabot pull requests where repository secrets are unavailable
- preserve signing for pushes, same-repository pull requests, and reusable release builds
- disable fail-fast for the HTTP build matrix so independent architecture jobs can finish

## Context

Follow-up to #2491: both macOS builds completed before failing while importing the unavailable signing certificate, and the HTTP failure cancelled its ARM matrix jobs. Fork pull requests will now produce unsigned macOS artifacts instead of failing at the signing steps.

## Testing

- `actionlint v1.7.12 .github/workflows/http.yml .github/workflows/wails.yml`
- `git diff --check`
- verified the signing condition for fork PR, same-repository PR, Dependabot PR, and push scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build workflow resilience so other build targets can continue when one target encounters an issue.
  * Strengthened macOS application packaging and release validation checks.
  * Added safeguards to ensure signing and notarization steps run only in appropriate release or trusted build scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->