### PR TITLE
fix: use async LDK event polling to avoid polling delay

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.2.0
 	github.com/elnosh/gonuts v0.4.2
 	github.com/getAlby/go-nostr v0.0.0-20260513161014-22fb7840c7a4
-	github.com/getAlby/ldk-node-go v0.0.0-20260608130949-5ba22268f000
+	github.com/getAlby/ldk-node-go v0.0.0-20260804150503-a3db1213cce4
 	github.com/go-gormigrate/gormigrate/v2 v2.1.6
 	github.com/google/uuid v1.6.0
 	github.com/labstack/echo/v4 v4.15.4

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,8 @@ github.com/getAlby/go-nostr v0.0.0-20260513161014-22fb7840c7a4 h1:Z93wPXKIMY4Emr
 github.com/getAlby/go-nostr v0.0.0-20260513161014-22fb7840c7a4/go.mod h1:BtlkV9evCTjpY0YeFhoNgycp7XNFbnfVXJPoykp+NtM=
 github.com/getAlby/ldk-node-go v0.0.0-20260608130949-5ba22268f000 h1:rlW59HX0myVvttj1VKiyNPNP564ecEDlUHRxC2dIDYs=
 github.com/getAlby/ldk-node-go v0.0.0-20260608130949-5ba22268f000/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20260804150503-a3db1213cce4 h1:cgefKtvNpBxdQT/taKoYC9C4BTF8tH+Q0uIBfOPLvgI=
+github.com/getAlby/ldk-node-go v0.0.0-20260804150503-a3db1213cce4/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gormigrate/gormigrate/v2 v2.1.6 h1:VtX+l1Stj2v5RGubVQk0LS/8EPGXR+ldcOyCmlmKoyg=
 github.com/go-gormigrate/gormigrate/v2 v2.1.6/go.mod h1:PZpedQc4tWaxn6kvXicwhinh3L0seLpMc5ReKRX5id4=

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -62,6 +62,7 @@ type LDKService struct {
 	lsps2MinPaymentSizeMsat            *uint64
 	lsps2MaxPaymentSizeMsat            *uint64
 	shuttingDown                       bool
+	eventHandlingMutex                 sync.Mutex
 }
 
 const resetRouterKey = "ResetRouter"
@@ -311,19 +312,41 @@ func NewLDKService(ctx context.Context, cfg config.Config, eventPublisher events
 			case <-ldkCtx.Done():
 				return
 			default:
-				// NOTE: currently do not use WaitNextEvent() as it can possibly block the LDK thread (to confirm)
-				event := node.NextEvent()
-				if event == nil {
-					// if there is no event, wait before polling again to avoid 100% CPU usage
-					// TODO: remove this and use WaitNextEvent()
-					time.Sleep(time.Duration(1000) * time.Millisecond)
-					continue
+			}
+
+			// NextEventAsync parks this goroutine on a Go channel until the next event
+			// arrives - unlike WaitNextEvent it does not block an OS thread in FFI.
+			// NOTE: the call cannot be cancelled; after shutdown it stays parked until
+			// the node emits a final event or the process exits.
+			event := node.NextEventAsync()
+
+			// eventHandlingMutex is held while handling so Shutdown() can wait
+			// for in-flight event handling to finish before stopping the node.
+			// Events dropped without EventHandled() are redelivered by LDK on
+			// the next startup.
+			ok := func() bool {
+				ls.eventHandlingMutex.Lock()
+				defer ls.eventHandlingMutex.Unlock()
+
+				if ldkCtx.Err() != nil {
+					return false
 				}
 
-				ls.handleLdkEvent(event)
-				ldkEventConsumer <- event
+				ls.handleLdkEvent(&event)
 
-				node.EventHandled()
+				select {
+				case ldkEventConsumer <- &event:
+				case <-ldkCtx.Done():
+					return false
+				}
+
+				if err := node.EventHandled(); err != nil {
+					logger.Logger.WithError(err).Error("Failed to mark LDK event as handled")
+				}
+				return true
+			}()
+			if !ok {
+				return
 			}
 		}
 	}()
@@ -486,6 +509,13 @@ func (ls *LDKService) Shutdown() error {
 	logger.Logger.Info("shutting down LDK client")
 	logger.Logger.Info("cancelling LDK context")
 	ls.cancel()
+
+	// wait for in-flight LDK event handling to finish - handleLdkEvent makes
+	// node calls which must not run once the node is stopped and destroyed.
+	// Held until the end of Shutdown; the event loop checks the cancelled
+	// context under this mutex before touching the node.
+	ls.eventHandlingMutex.Lock()
+	defer ls.eventHandlingMutex.Unlock()
 
 	maxAttempts := 40
 	for i := 0; ls.syncing; i++ {


### PR DESCRIPTION
Closes #2454

## What

Switches the LDK event loop from polling `node.NextEvent()` every second to `node.NextEventAsync()`, made possible by the latest uniffi-bindgen-go release (bumped `ldk-node-go` in `go.mod`). This confirms we're compatible with LDK moving to a fully async API, and removes the 1-second polling latency on event delivery.

## How it works

`NextEventAsync()` parks the calling goroutine on a Go channel until the Rust future's waker fires - unlike `WaitNextEvent()` it does not block an OS thread in FFI or an LDK thread, so it's safe to call from a long-lived goroutine.

## Shutdown safety

The async call cannot be cancelled from Go (the bindings don't expose uniffi's future cancellation), so an event emitted *during* shutdown (e.g. by `node.Stop()`) could previously wake the loop and call into the node after `node.Destroy()`, panicking. To prevent this:

- Event handling now runs under `eventHandlingMutex`, which `Shutdown()` acquires after cancelling the context and holds through `Stop()`/`Destroy()` - so an in-flight handler always finishes against a live node, and nothing new starts.
- The loop re-checks the cancelled context under the mutex and drops late events without calling `EventHandled()` - LDK redelivers unhandled events on next startup.
- A goroutine may stay parked in `NextEventAsync()` after shutdown until the process exits; this is harmless (the bindings' refcounting defers freeing the node object) and goes away if ldk-node later resolves the event future on stop.

Also logs errors from `EventHandled()`, which now returns an error in the new bindings.

## Testing

- `go build ./...`, `go vet`, and `go test ./lnclient/...` pass
- Tested manually: node starts, receives events, and shuts down cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event processing reliability and handling during cancellation.
  * Ensured in-progress events are completed before the service shuts down.
  * Improved failure handling when processing or forwarding events.

* **Maintenance**
  * Updated the underlying Lightning service components for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->