### PR TITLE
fix: explain API access is unavailable in the desktop app

### DIFF
--- a/frontend/src/screens/settings/DeveloperSettings.tsx
+++ b/frontend/src/screens/settings/DeveloperSettings.tsx
@@ -13,10 +13,12 @@ import { Separator } from "src/components/ui/separator";
 import { useAlbyMe } from "src/hooks/useAlbyMe";
 import { copyToClipboard } from "src/lib/clipboard";
 import { AuthTokenResponse } from "src/types";
+import { isHttpMode } from "src/utils/isHttpMode";
 import { request } from "src/utils/request";
 
 export default function DeveloperSettings() {
   const { data: albyMe } = useAlbyMe();
+  const _isHttpMode = isHttpMode();
   const [token, setToken] = React.useState<string>();
   const [tokenPermission, setTokenPermission] = React.useState<string>();
   const [expiryDays, setExpiryDays] = React.useState<string>("365");
@@ -103,7 +105,14 @@ export default function DeveloperSettings() {
             be removed entirely in the future.
           </div>
         </div>
-        {!token && !showCreateTokenForm && (
+        {!_isHttpMode && (
+          <div className="text-sm text-muted-foreground">
+            API access is not available in the desktop app because it does not
+            expose an HTTP API. To use the API, install the Alby Hub server
+            version instead.
+          </div>
+        )}
+        {_isHttpMode && !token && !showCreateTokenForm && (
           <div>
             <Button
               size={"lg"}


### PR DESCRIPTION
## Summary

Creating a developer token under **Settings → Developer** in the desktop (Wails) build failed with a confusing `Unhandled route: POST /api/unlock` error. Developer tokens only work against the HTTP API, which the desktop app does not expose — so instead of surfacing a route error, the desktop build now hides the token creation form and shows an explanatory message:

> API access is not available in the desktop app because it does not expose an HTTP API. To use the API, install the Alby Hub server version instead.

The HTTP build is unchanged.

Fixes #2471

🤖 Generated with [Claude Code](https://claude.com/claude-code)