### PR TITLE
fix: Mandatory upgrade for bark SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/wailsapp/wails/v2 v2.12.0
-	gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.12.1
+	gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.15.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/grpc v1.79.3

--- a/go.sum
+++ b/go.sum
@@ -593,6 +593,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.12.1 h1:jEnl0leC9n7EsT9Rn339nC9e/9GWCMPXzmzowzxmY24=
 gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.12.1/go.mod h1:1jAwB/XR4i3D72fz3qWAd41tQLYcOCGfWZHMagn5fNg=
+gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.15.0 h1:X6TmMsVcvwOo5CxnlOQ/104OBO7cdOvYcTIatS5yfu4=
+gitlab.com/ark-bitcoin/bark-ffi-bindings/golang v0.15.0/go.mod h1:1jAwB/XR4i3D72fz3qWAd41tQLYcOCGfWZHMagn5fNg=
 go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
 go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 go.etcd.io/etcd/api/v3 v3.5.16 h1:WvmyJVbjWqK4R1E+B12RRHz3bRGy9XVfh++MgbN+6n0=


### PR DESCRIPTION
Bumps the bark bindings from `v0.12.1` (bark 0.4.0) to `v0.15.0` (bark 0.6.0).

**This is urgent: users on < bark 0.5.0 are unable to board, and users on < 0.6.0 cannot join rounds (so cannot refresh VTXOs) or use lightning.**

We apologize for having to make a breaking release but we've been extensively testing our codebase and responding to security vulnerabilities, as have many projects in bitcoin right now. As such we made the choice to break some existing functionality and push an emergency update.

No client API changes necessary, the new SDK ships the necessary client updates for users to upgrade to the new mandatory protocol version to enable all features again.

Current clients are able to make ark payments, offboard and unilaterally exit.

As an added bonus the users get the following by upgrading from the previous release:

- **Wallet recovery from seed alone.** VTXO IDs are posted to a seed-derived recovery mailbox, so a wallet can rebuild its spendable set from the mnemonic with no local state. Runs automatically on creation.
- **Crash-safe payments** Each incoming/outgoing payment type now runs as a resumable wallet action with a persisted checkpoint, so an interrupted operation resumes on the next sync instead of facing issues.
- **Fewer stuck funds.** Maintenance refresh no longer wedges on a single unusable VTXO, force-exited VTXOs are detected and recovered, claimable exits are counted in the pending exit balance, and clients no longer disconnect from the server every 10 minutes.
- **LNURL-pay support**
- Plus hardened permissions on the wallet database and filestore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal Bitcoin integration dependency to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->