### PR TITLE
fix: remove avatar from lightning address QR

### DIFF
--- a/frontend/src/components/ReceiveToLightning.tsx
+++ b/frontend/src/components/ReceiveToLightning.tsx
@@ -9,7 +9,6 @@ import { Link } from "react-router";
 import FirstChannelJitAlert from "src/components/FirstChannelJitAlert";
 import Loading from "src/components/Loading";
 import QRCode from "src/components/QRCode";
-import UserAvatar from "src/components/UserAvatar";
 import {
   Accordion,
   AccordionContent,
@@ -39,7 +38,6 @@ export function ReceiveToLightning() {
             value={me.lightning_address}
             className="h-auto w-full"
             frameType="lightning"
-            centerContent={<UserAvatar className="size-12 rounded-full" />}
           />
           <div className="flex max-w-full items-center justify-center gap-1">
             <p className="min-w-0 text-center font-medium text-lg break-all">


### PR DESCRIPTION
Fixes #2507

The user avatar overlaid on the lightning address QR code made it hard to scan, especially for short lightning addresses.

This removes the `centerContent` avatar from the lightning address `<QRCode>` in `ReceiveToLightning.tsx`. With no center content, the QR renders without any overlay and `QRCode.tsx` automatically drops the error correction level from "Q" back to "M", further improving scannability.

`UserAvatar` is still used elsewhere (sidebar, settings, connection card), so only the now-unused import was removed here. The `QRCode` component's generic `centerContent` API is left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)