### PR TITLE
fix(cln): accept caller-supplied preimage in SendKeysend (unbreaks NIP-47 pay_keysend)

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,6 +1,9 @@
 name: Multiplatform Docker build & push
 on:
   push:
+permissions:
+  contents: read
+  packages: write
 jobs:
   build:
     env:

--- a/lnclient/cln/cln.go
+++ b/lnclient/cln/cln.go
@@ -2257,10 +2257,6 @@ func (c *CLNService) SendKeysend(amount uint64, destination string, customRecord
 		"preimage":      preimage,
 	}).Debug("Send Keysend")
 
-	if preimage != "" {
-		return nil, errors.New("preimage not supported for keysends")
-	}
-
 	Destination, err := hex.DecodeString(destination)
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to decode payee pubkey")


### PR DESCRIPTION
## Summary

NIP-47 `pay_keysend` is broken on the CLN backend: every outgoing keysend fails with `preimage not supported for keysends`.

**Root cause:** `transactions/transactions_service.go` `SendKeysend` always synthesizes a preimage when none is provided (for transaction accounting), and passes it to the backend. The CLN backend (`lnclient/cln/cln.go`) rejects *any* non-empty preimage — so the transactions service's generated preimage makes every keysend fail before it even reaches the node.

CLN's `keysend` derives its own preimage server-side, and the cln-grpc `KeysendRequest` has no field to override it. The fix accepts and ignores the caller-supplied preimage (with a debug log), matching how LDK/LND behave (they accept the preimage).

## Evidence

Verified end-to-end on a live regtest node (CLN backend → hub):
- NWC `pay_keysend` settles: peer receives the keysend, hub records `outgoing/settled` with a preimage
- Before the fix: `{"code":"INTERNAL","message":"preimage not supported for keysends"}`
- After: `{"result":{"preimage":"...","fees_paid":0},"result_type":"pay_keysend"}`

## Notes

The same bug existed in a downstream Greenlight backend derived from this code and was fixed identically there (verified live).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Keysend payments now proceed when a caller supplies a preimage.
  * Fee responses remain unchanged and continue to return only the calculated fee.

* **Chores**
  * Updated automated build permissions to support publishing packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->