### PR TITLE
fix: bark onboarding, migration messaging and receive settlement for bark 0.6.0

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1730,10 +1730,12 @@ func (api *api) Setup(ctx context.Context, setupRequest *SetupRequest) error {
 		return errors.New("no unlock password provided")
 	}
 
-	// Bark and Cashu both store wallet state on local disk and have no
-	// remote-backup mechanism, so they cannot run in environments without
-	// persistent volumes (e.g. Alby Cloud). The default OAuth client ID
-	// identifies a local / self-hosted deployment.
+	// Bark and Cashu both store wallet state on local disk, so they cannot
+	// run in environments without persistent volumes (e.g. Alby Cloud). Bark
+	// can recover spendable VTXOs from the mnemonic alone, but in-flight
+	// payment checkpoints and wallet metadata are local-only, so persistent
+	// storage is still required. The default OAuth client ID identifies a
+	// local / self-hosted deployment.
 	if !api.cfg.GetEnv().IsDefaultClientId() {
 		switch setupRequest.LNBackendType {
 		case config.BarkBackendType, config.CashuBackendType:

--- a/frontend/src/screens/settings/Backup.tsx
+++ b/frontend/src/screens/settings/Backup.tsx
@@ -125,16 +125,6 @@ export default function Backup() {
                   phrase, you will lose access to your funds.
                 </AlertDescription>
               </Alert>
-              {info?.backendType === "BARK" && (
-                <Alert variant="destructive">
-                  <AlertTriangleIcon />
-                  <AlertTitle>Bark Support Coming Soon</AlertTitle>
-                  <AlertDescription>
-                    During the beta period, your recovery phrase is not
-                    sufficient to restore your funds.
-                  </AlertDescription>
-                </Alert>
-              )}
               {info?.backendType === "CASHU" && <CashuMnemonicWarning />}
 
               <div>

--- a/frontend/src/screens/setup/ImportMnemonic.tsx
+++ b/frontend/src/screens/setup/ImportMnemonic.tsx
@@ -1,11 +1,6 @@
 import * as bip39 from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
-import {
-  AlertTriangleIcon,
-  LifeBuoyIcon,
-  ShieldAlertIcon,
-  ShieldCheckIcon,
-} from "lucide-react";
+import { AlertTriangleIcon, LifeBuoyIcon, ShieldCheckIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 
@@ -14,14 +9,11 @@ import MnemonicInputs from "src/components/mnemonic/MnemonicInputs";
 import TwoColumnLayoutHeader from "src/components/TwoColumnLayoutHeader";
 import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
 import { Button } from "src/components/ui/button";
-import { Checkbox } from "src/components/ui/checkbox";
-import { Label } from "src/components/ui/label";
 import useSetupStore from "src/state/SetupStore";
 
 export function ImportMnemonic() {
   const navigate = useNavigate();
   const setupStore = useSetupStore();
-  const [backedUp, setIsBackedUp] = useState<boolean>(false);
 
   useEffect(() => {
     // in case the user presses back, remove their last-saved mnemonic
@@ -93,32 +85,11 @@ export function ImportMnemonic() {
               Keep it safe and private to ensure your funds remain secure.
             </span>
           </div>
-          <div className="flex gap-2 items-center">
-            <div className="shrink-0 text-muted-foreground">
-              <ShieldAlertIcon className="size-6" />
-            </div>
-            <span className="text-muted-foreground">
-              Your recovery phrase cannot restore funds from lightning channels.
-              If you had active channels on a different device, contact Alby
-              support before proceeding.
-            </span>
-          </div>
         </div>
       </Alert>
 
       <MnemonicInputs mnemonic={mnemonic} setMnemonic={setMnemonic} />
 
-      <div className="flex items-center mt-5">
-        <Checkbox
-          id="confirmedNoChannels"
-          required
-          onCheckedChange={() => setIsBackedUp(!backedUp)}
-        />
-        <Label htmlFor="confirmedNoChannels" className="ml-2 cursor-pointer">
-          I don't have another Alby Hub to migrate or open channels (funds from
-          channels will be lost!).
-        </Label>
-      </div>
       <Button>Next</Button>
     </form>
   );

--- a/frontend/src/screens/setup/SetupSecurity.tsx
+++ b/frontend/src/screens/setup/SetupSecurity.tsx
@@ -1,7 +1,6 @@
 import {
   ClockIcon,
   HandCoinsIcon,
-  HardDriveIcon,
   LandmarkIcon,
   ShieldAlertIcon,
   UnlockIcon,
@@ -76,14 +75,6 @@ export function SetupSecurity() {
                   small fee.
                 </span>
               </div>
-              <div className="flex gap-3 items-center">
-                <HardDriveIcon className="size-6 shrink-0" />
-                <span className="text-sm text-muted-foreground">
-                  During beta, your funds{" "}
-                  <span className="underline">cannot</span> be recovered from
-                  your recovery phrase alone.
-                </span>
-              </div>
             </>
           )}
           <div className="flex gap-3 items-center">
@@ -109,7 +100,7 @@ export function SetupSecurity() {
                 choose the LDK node type.
               </span>
             </div>
-          ) : store.nodeInfo.backendType === "BARK" ? null : (
+          ) : (
             <div className="flex gap-3 items-center">
               <div className="shrink-0">
                 <ShieldAlertIcon className="size-6" />

--- a/frontend/src/screens/setup/SetupSecurity.tsx
+++ b/frontend/src/screens/setup/SetupSecurity.tsx
@@ -100,6 +100,19 @@ export function SetupSecurity() {
                 choose the LDK node type.
               </span>
             </div>
+          ) : store.hasImportedMnemonic &&
+            store.nodeInfo.backendType === "LDK" ? (
+            <div className="flex gap-3 items-center">
+              <div className="shrink-0">
+                <ShieldAlertIcon className="size-6" />
+              </div>
+              <span className="text-sm text-muted-foreground">
+                Your recovery phrase can only restore funds from lightning
+                channels if you have dynamic channel backups enabled. If you had
+                active channels on a different device, contact Alby support
+                before proceeding.
+              </span>
+            </div>
           ) : (
             <div className="flex gap-3 items-center">
               <div className="shrink-0">

--- a/lnclient/bark/bark.go
+++ b/lnclient/bark/bark.go
@@ -745,6 +745,7 @@ const (
 	nodeCommandDebug                  = "debug"
 	nodeCommandClaimLightningReceives = "claimlightningreceives"
 	nodeCommandRunMaintenance         = "runmaintenance"
+	nodeCommandRecoveryReport         = "recoveryreport"
 )
 
 func (bs *BarkService) GetCustomNodeCommandDefinitions() []lnclient.CustomNodeCommandDef {
@@ -764,6 +765,11 @@ func (bs *BarkService) GetCustomNodeCommandDefinitions() []lnclient.CustomNodeCo
 			Description: "Run wallet maintenance, which progresses pending rounds and refreshes VTXOs. Use this to nudge funds that are stuck 'pending in round'.",
 			Args:        nil,
 		},
+		{
+			Name:        nodeCommandRecoveryReport,
+			Description: "Show the result of the seed-recovery scan that runs when a wallet is created from an existing recovery phrase. Use this to verify your funds were restored after migrating to a new device.",
+			Args:        nil,
+		},
 	}
 }
 
@@ -775,6 +781,8 @@ func (bs *BarkService) ExecuteCustomNodeCommand(ctx context.Context, command *ln
 		return bs.executeCommandClaimLightningReceives()
 	case nodeCommandRunMaintenance:
 		return bs.executeCommandRunMaintenance()
+	case nodeCommandRecoveryReport:
+		return bs.executeCommandRecoveryReport()
 	}
 
 	return nil, lnclient.ErrUnknownCustomNodeCommand
@@ -890,6 +898,32 @@ func (bs *BarkService) executeCommandClaimLightningReceives() (*lnclient.CustomN
 		Response: map[string]interface{}{
 			"claimedCount": len(claimed),
 			"claimed":      claimed,
+		},
+	}, nil
+}
+
+func (bs *BarkService) executeCommandRecoveryReport() (*lnclient.CustomNodeCommandResponse, error) {
+	// The report is produced by the seed-recovery scan bark runs during the
+	// wallet open that creates the wallet locally (e.g. when restoring from a
+	// recovery phrase on a new device). It is only available in the session
+	// that created the wallet; on subsequent starts no scan runs.
+	report := bs.wallet.RecoveryReport()
+	if report == nil {
+		return &lnclient.CustomNodeCommandResponse{
+			Response: map[string]interface{}{
+				"message": "No recovery scan ran on this wallet start. A scan only runs when the wallet is first created, e.g. after restoring from a recovery phrase.",
+			},
+		}, nil
+	}
+
+	return &lnclient.CustomNodeCommandResponse{
+		Response: map[string]interface{}{
+			"isComplete": report.IsComplete,
+			"recovered":  report.Recovered,
+			"skipped":    report.Skipped,
+			"foreign":    report.Foreign,
+			"failed":     report.Failed,
+			"exited":     report.Exited,
 		},
 	}, nil
 }

--- a/lnclient/bark/bark.go
+++ b/lnclient/bark/bark.go
@@ -34,8 +34,12 @@ const (
 	// Movement status reported once a movement has settled. A movement first
 	// appears as "pending" and is updated to this once complete.
 	movementStatusSuccessful = "successful"
-	// LightningReceive.State values in which we hold the preimage.
+	// LightningReceive.State values at or past preimage reveal.
+	// "delivering" (added in bark 0.6.0) sits between preimage reveal and
+	// settlement: the claim is recorded and delivery resumes automatically,
+	// so the funds are already irrevocably received.
 	receiveStatePreimageRevealed = "preimage-revealed"
+	receiveStateDelivering       = "delivering"
 	receiveStateSettled          = "settled"
 	// Grace period to allow the notification loop to unwind on shutdown.
 	shutdownGracePeriod = 10 * time.Second
@@ -562,15 +566,31 @@ func (bs *BarkService) lightningReceiveToTransaction(receive *bark.LightningRece
 		Description:     paymentRequest.Description,
 		DescriptionHash: paymentRequest.DescriptionHash,
 	}
-	// "preimage-revealed" until the claim is recorded, "settled" after.
-	if receive.State == receiveStatePreimageRevealed || receive.State == receiveStateSettled {
-		now := time.Now().Unix()
-		tx.SettledAt = &now
-		if receive.PaymentPreimage != nil {
-			tx.Preimage = *receive.PaymentPreimage
+	// Only report the receive as settled when we can include the preimage —
+	// a settled transaction without one is rejected by the transactions
+	// service.
+	if receive.PaymentPreimage != nil && receiveIsPaid(receive.State) {
+		tx.Preimage = *receive.PaymentPreimage
+		settledAt := time.Now().Unix()
+		if receive.SettledAt != nil {
+			settledAt = *receive.SettledAt
 		}
+		tx.SettledAt = &settledAt
 	}
 	return tx, nil
+}
+
+// receiveIsPaid reports whether a receive's state is at or past preimage
+// reveal, meaning the payer holds the preimage and the payment is final.
+// The state is the only reliable signal: bark generates and stores the
+// preimage at invoice creation, so LightningReceive.PaymentPreimage can be
+// set long before anything is paid.
+func receiveIsPaid(state string) bool {
+	switch state {
+	case receiveStatePreimageRevealed, receiveStateDelivering, receiveStateSettled:
+		return true
+	}
+	return false
 }
 
 func (bs *BarkService) GetBalances(ctx context.Context, includeInactiveChannels bool) (*lnclient.BalancesResponse, error) {


### PR DESCRIPTION
Follow-ups to the bark 0.6.0 SDK bump (#2502).

Closes #2512

## Onboarding + backup messaging (#2512)

Offchain funds are now recoverable from the mnemonic alone via the seed-derived recovery mailbox, so:

- **Setup Security**: removed the "During beta, your funds cannot be recovered from your recovery phrase alone" bullet; bark now shows the standard "balance can be recovered with your 12-word recovery phrase" guidance.
- **Settings → Backup**: removed the "Bark Support Coming Soon / recovery phrase is not sufficient" alert.
- Added a `recoveryreport` custom node command that returns the result of the seed-recovery scan bark runs when a wallet is created from an existing recovery phrase, so users migrating to a new device can verify their funds were restored (buckets: recovered/skipped/foreign/failed/exited + completeness).
- Updated the stale comment in `api.go` about why bark still requires persistent storage (in-flight payment checkpoints and wallet metadata are local-only).

## Bug fix: receives stuck pending on bark 0.6.0

bark 0.6.0 added a `delivering` receive state between `preimage-revealed` and `settled`. The claim handler didn't recognize it, so every claimed receive was published without a preimage and rejected by the transactions service (`no preimage in payment`) — paid invoices stayed "Waiting for Payment..." forever (and no NIP-47 notification was sent). Since delivery completion emits no further movement notification, there was no second chance to settle.

Fixed by treating all states at or past preimage reveal as paid via a `receiveIsPaid` helper. It's a positive allowlist, so an unknown future state degrades to "still pending" rather than "falsely settled" (the state is the only reliable paid-signal — bark stores the preimage from invoice creation, so `PaymentPreimage` being set means nothing). Also uses bark's own `settled_at` timestamp when available.

Reproduced and verified against `ark.signet.2nd.dev`.

## Import flow cleanup

The "I don't have another Alby Hub to migrate or open channels (funds from channels will be lost!)" checkbox on the import screen was required for every backend but only applied to LDK — and is wrong when dynamic channel backups (VSS) are enabled. Removed it; the channels caveat now appears on the Security & Recovery page instead, only when a mnemonic was imported and LDK was chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recovery scan status reporting, including unavailable and completed recovery results.
  * Improved recovery guidance for imported nodes.

* **Bug Fixes**
  * Improved payment settlement handling so transaction details are recorded only after a payment is confirmed.
  * Updated recovery messaging to clarify that spendable funds can be recovered from a mnemonic, while payment checkpoints and wallet metadata require persistent storage.

* **Documentation**
  * Removed outdated warnings suggesting recovery phrases were insufficient during beta.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->