### PR TITLE
fix: remove dollar sign from linux install scripts

### DIFF
--- a/scripts/linux-aarch64/README.md
+++ b/scripts/linux-aarch64/README.md
@@ -15,7 +15,7 @@ If you do a fresh server setup make sure to do the basic setup like for example 
 
 Run the installation script on your server:
 
-    $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/getAlby/hub/master/scripts/linux-aarch64/install.sh)"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/getAlby/hub/master/scripts/linux-aarch64/install.sh)"
 
 The install script will prompt you for an installation folder and will install Alby Hub.
 Optionally it can also create a systemd service for you.

--- a/scripts/linux-x86_64/README.md
+++ b/scripts/linux-x86_64/README.md
@@ -15,7 +15,7 @@ If you do a fresh server setup make sure to do the basic setup like for example 
 
 Run the installation script on your server:
 
-    $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/getAlby/hub/master/scripts/linux-x86_64/install.sh)"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/getAlby/hub/master/scripts/linux-x86_64/install.sh)"
 
 The install script will prompt you for an installation folder and will install Alby Hub.
 Optionally it can also create a systemd service for you.


### PR DESCRIPTION
If you copy the whole line then it will fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux ARM64 and x86_64 installation instructions to make commands easier to copy and run by removing the shell prompt marker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->