### PR TITLE
fix: keep showing migration success page after creating migration file

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -50,6 +50,9 @@ type api struct {
 	startupError     error
 	startupErrorTime time.Time
 	eventPublisher   events.EventPublisher
+	// set after a migration file is created; the hub is halted at that point
+	// and the frontend should keep showing the migration success page
+	nodeMigrationFileCreated bool
 }
 
 func NewAPI(svc service.Service, gormDB *gorm.DB, config config.Config, keys keys.Keys, albySvc alby.AlbyService, albyOAuthSvc alby.AlbyOAuthService, eventPublisher events.EventPublisher) *api {
@@ -1510,6 +1513,7 @@ func (api *api) GetInfo(ctx context.Context) (*InfoResponse, error) {
 	}
 	lnClient := api.svc.GetLNClient()
 	info.Running = lnClient != nil
+	info.NodeMigrationFileCreated = api.nodeMigrationFileCreated
 	info.BackendType = backendType
 	info.AlbyAuthUrl = api.albyOAuthSvc.GetAuthUrl()
 	info.OAuthRedirect = !api.cfg.GetEnv().IsDefaultClientId()

--- a/api/api.go
+++ b/api/api.go
@@ -1495,6 +1495,19 @@ func (api *api) RequestMempoolApi(ctx context.Context, endpoint string) (interfa
 
 func (api *api) GetInfo(ctx context.Context) (*InfoResponse, error) {
 	info := InfoResponse{}
+
+	if api.nodeMigrationFileCreated.Load() {
+		// the hub is halted and the database is closed after a migration file
+		// is created, so return a minimal response without reading any config
+		// or node state; the frontend only needs the flag to keep showing the
+		// migration success page
+		info.NodeMigrationFileCreated = true
+		info.SetupCompleted = true
+		info.Version = version.Tag
+		info.Relays = []InfoResponseRelay{}
+		return &info, nil
+	}
+
 	backendType, _ := api.cfg.Get("LNBackendType", "")
 	ldkVssEnabled, _ := api.cfg.Get("LdkVssEnabled", "")
 	jitChannelsEnabled, _ := api.cfg.Get("JitChannelsEnabled", "")

--- a/api/api.go
+++ b/api/api.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -52,7 +53,7 @@ type api struct {
 	eventPublisher   events.EventPublisher
 	// set after a migration file is created; the hub is halted at that point
 	// and the frontend should keep showing the migration success page
-	nodeMigrationFileCreated bool
+	nodeMigrationFileCreated atomic.Bool
 }
 
 func NewAPI(svc service.Service, gormDB *gorm.DB, config config.Config, keys keys.Keys, albySvc alby.AlbyService, albyOAuthSvc alby.AlbyOAuthService, eventPublisher events.EventPublisher) *api {
@@ -1513,7 +1514,7 @@ func (api *api) GetInfo(ctx context.Context) (*InfoResponse, error) {
 	}
 	lnClient := api.svc.GetLNClient()
 	info.Running = lnClient != nil
-	info.NodeMigrationFileCreated = api.nodeMigrationFileCreated
+	info.NodeMigrationFileCreated = api.nodeMigrationFileCreated.Load()
 	info.BackendType = backendType
 	info.AlbyAuthUrl = api.albyOAuthSvc.GetAuthUrl()
 	info.OAuthRedirect = !api.cfg.GetEnv().IsDefaultClientId()

--- a/api/backup.go
+++ b/api/backup.go
@@ -197,6 +197,8 @@ func (api *api) CreateBackup(unlockPassword string, w io.Writer) error {
 
 	logger.Logger.Info("Successfully created backup to migrate Alby Hub to another device")
 
+	api.nodeMigrationFileCreated = true
+
 	return nil
 }
 

--- a/api/backup.go
+++ b/api/backup.go
@@ -195,9 +195,17 @@ func (api *api) CreateBackup(unlockPassword string, w io.Writer) error {
 		}
 	}
 
+	// Finalize the archive before reporting success; the deferred close
+	// only covers early returns.
+	err = zw.Close()
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to finalize migration archive")
+		return fmt.Errorf("failed to finalize migration archive: %w", err)
+	}
+
 	logger.Logger.Info("Successfully created backup to migrate Alby Hub to another device")
 
-	api.nodeMigrationFileCreated = true
+	api.nodeMigrationFileCreated.Store(true)
 
 	return nil
 }

--- a/api/models.go
+++ b/api/models.go
@@ -338,6 +338,7 @@ type InfoResponse struct {
 	JitChannelsEnabled            bool                `json:"jitChannelsEnabled"`
 	HideUpdateBanner              bool                `json:"hideUpdateBanner"`
 	SupportsBolt12                bool                `json:"supportsBolt12"`
+	NodeMigrationFileCreated      bool                `json:"nodeMigrationFileCreated"`
 }
 
 type UpdateSettingsRequest struct {

--- a/frontend/src/components/redirects/HomeRedirect.tsx
+++ b/frontend/src/components/redirects/HomeRedirect.tsx
@@ -14,6 +14,13 @@ export function HomeRedirect() {
       return;
     }
 
+    if (info.nodeMigrationFileCreated) {
+      // the hub is halted after creating a migration file and should not be
+      // used anymore, so keep showing the migration success instructions
+      navigate("/create-node-migration-file-success", { replace: true });
+      return;
+    }
+
     const setupReturnTo = window.localStorage.getItem(
       localStorageKeys.setupReturnTo
     );

--- a/frontend/src/components/redirects/StartRedirect.tsx
+++ b/frontend/src/components/redirects/StartRedirect.tsx
@@ -9,6 +9,12 @@ export function StartRedirect({ children }: React.PropsWithChildren) {
   const navigate = useNavigate();
 
   React.useEffect(() => {
+    if (info?.nodeMigrationFileCreated) {
+      // the hub is halted after creating a migration file and should not be
+      // used anymore, so keep showing the migration success instructions
+      navigate("/create-node-migration-file-success", { replace: true });
+      return;
+    }
     if (!info || (info.setupCompleted && !info.running)) {
       if (info && !info.albyAccountConnected && info.albyUserIdentifier) {
         navigate("/alby/auth");

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -187,6 +187,7 @@ export interface InfoResponse {
   jitChannelsEnabled: boolean;
   hideUpdateBanner: boolean;
   supportsBolt12: boolean;
+  nodeMigrationFileCreated: boolean;
 }
 
 export type BitcoinDisplayFormat = "sats" | "bip177";


### PR DESCRIPTION
## Problem

After creating a node migration file (`/create-node-migration-file-success`), visiting the homepage on the same (now halted) hub kicked the user into the Alby OAuth flow.

The chain: `CreateBackup` stops the app and intentionally removes the OAuth access token (so the restored hub re-auths with the correct client). On the next visit to `/`, `HomeRedirect` sees `running: false` and goes to `/start`, where `StartRedirect` sees `!albyAccountConnected && albyUserIdentifier` and navigates to `/alby/auth`.

## Solution

- Track the halted-after-backup state with an in-memory `nodeMigrationFileCreated` flag on the `api` struct, set after a successful `CreateBackup`, and expose it in `/api/info`.
- `HomeRedirect` and `StartRedirect` check the flag first and redirect back to `/create-node-migration-file-success` instead of entering the unlock/OAuth flow.

The flag is deliberately in-memory: it survives page reloads while the halted process is running, but clears if the hub is restarted anyway — at that point the normal flow (including Alby re-auth) applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a success page for node migration file creation.
  * The app now automatically redirects to the success page after a migration file is created.
  * Migration file creation status is now reflected in application information.

* **Bug Fixes**
  * Improved reliability by confirming migration archive creation completes successfully before reporting success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->