### PR TITLE
fix: avoid leaking raw postgres error details in duplicate key response

### DIFF
--- a/nip47/controllers/map_nip47_error.go
+++ b/nip47/controllers/map_nip47_error.go
@@ -6,10 +6,12 @@ import (
 	"github.com/getAlby/hub/constants"
 	"github.com/getAlby/hub/nip47/models"
 	"github.com/getAlby/hub/transactions"
+	"gorm.io/gorm"
 )
 
 func mapNip47Error(err error) *models.Error {
 	code := constants.ERROR_INTERNAL
+	message := err.Error()
 	if errors.Is(err, transactions.NewNotFoundError()) {
 		code = constants.ERROR_NOT_FOUND
 	}
@@ -19,9 +21,13 @@ func mapNip47Error(err error) *models.Error {
 	if errors.Is(err, transactions.NewQuotaExceededError()) {
 		code = constants.ERROR_QUOTA_EXCEEDED
 	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		// avoid leaking raw driver/SQL error details (e.g. constraint names) to NWC apps
+		message = gorm.ErrDuplicatedKey.Error()
+	}
 
 	return &models.Error{
 		Code:    code,
-		Message: err.Error(),
+		Message: message,
 	}
 }


### PR DESCRIPTION
gorm.io/driver/postgres v1.6.2 (#2515) started wrapping the original pgconn error into `Translate()`'s output, so `err.Error()` on a duplicate-key violation now includes internal details like constraint names and SQLSTATE codes. `mapNip47Error` was passing `err.Error()` straight through to the NWC response, so use the stable `gorm.ErrDuplicatedKey` message instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses for duplicate records by replacing internal database details with a clear, generic message.
  * Preserved the original error message for other error types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->