### PR TITLE
chore: add Bark terms link and exit disclosure to security page

### DIFF
--- a/frontend/src/screens/setup/SetupSecurity.tsx
+++ b/frontend/src/screens/setup/SetupSecurity.tsx
@@ -77,24 +77,35 @@ export function SetupSecurity() {
               </div>
               <div className="flex gap-3 items-center">
                 <ClockIcon className="size-6 shrink-0" />
-                <span className="text-sm text-muted-foreground">
-                  Your funds will be refreshed automatically which will incur a
-                  small fee. Keep your Alby Hub online so your funds do not
-                  expire.
-                </span>
-              </div>
-              <div className="flex gap-3 items-center">
-                <ShieldAlertIcon className="size-6 shrink-0" />
-                <span className="text-sm text-muted-foreground">
-                  Unilateral exit is not implemented in Alby Hub yet.{" "}
+                <span className="text-sm text-muted-foreground flex items-center justify-center gap-1">
+                  Your funds must be refreshed periodically{" "}
                   <TooltipProvider>
                     <Tooltip>
                       <TooltipTrigger type="button">
                         <InfoIcon className="size-4 text-muted-foreground" />
                       </TooltipTrigger>
                       <TooltipContent className="max-w-xs">
-                        Bark supports unilateral exit, but you will need to take
-                        your wallet data and execute the exit yourself.
+                        Your virtual UTXOs (VTXOs) will be refreshed
+                        automatically to ensure you maintain ownership.
+                        Refreshes may incur a small fee. Keep your Alby Hub
+                        online so your funds do not expire.
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </span>
+              </div>
+              <div className="flex gap-3 items-center">
+                <ShieldAlertIcon className="size-6 shrink-0" />
+                <span className="text-sm text-muted-foreground flex items-center justify-center gap-1">
+                  Unilateral exit is not implemented in Alby Hub yet{" "}
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger type="button">
+                        <InfoIcon className="size-4 text-muted-foreground" />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-xs">
+                        You will need to take your hub wallet data and execute
+                        the exit yourself.
                       </TooltipContent>
                     </Tooltip>
                   </TooltipProvider>

--- a/frontend/src/screens/setup/SetupSecurity.tsx
+++ b/frontend/src/screens/setup/SetupSecurity.tsx
@@ -1,6 +1,7 @@
 import {
   ClockIcon,
   HandCoinsIcon,
+  InfoIcon,
   LandmarkIcon,
   ShieldAlertIcon,
   UnlockIcon,
@@ -13,6 +14,12 @@ import TwoColumnLayoutHeader from "src/components/TwoColumnLayoutHeader";
 import { Button } from "src/components/ui/button";
 import { Checkbox } from "src/components/ui/checkbox";
 import { Label } from "src/components/ui/label";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "src/components/ui/tooltip";
 import { useInfo } from "src/hooks/useInfo";
 import useSetupStore from "src/state/SetupStore";
 
@@ -71,10 +78,40 @@ export function SetupSecurity() {
               <div className="flex gap-3 items-center">
                 <ClockIcon className="size-6 shrink-0" />
                 <span className="text-sm text-muted-foreground">
-                  Your funds will be refreshed periodically which will incur a
-                  small fee.
+                  Your funds will be refreshed automatically which will incur a
+                  small fee. Keep your Alby Hub online so your funds do not
+                  expire.
                 </span>
               </div>
+              <div className="flex gap-3 items-center">
+                <ShieldAlertIcon className="size-6 shrink-0" />
+                <span className="text-sm text-muted-foreground">
+                  Unilateral exit is not implemented in Alby Hub yet.{" "}
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger type="button">
+                        <InfoIcon className="size-4 text-muted-foreground" />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-xs">
+                        Bark supports unilateral exit, but you will need to take
+                        your wallet data and execute the exit yourself.
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </span>
+              </div>
+              <ExternalLink
+                className="text-muted-foreground flex items-center text-sm"
+                to="https://second.tech/terms"
+              >
+                <p>
+                  By using Bark you agree to{" "}
+                  <span className="font-semibold underline">
+                    Second&apos;s Terms of Service
+                  </span>
+                  .
+                </p>
+              </ExternalLink>
             </>
           )}
           <div className="flex gap-3 items-center">


### PR DESCRIPTION
## Summary

Updates the Bark section of the Security & Recovery setup screen:

- Extends the funds-refresh notice to mention that the hub must stay online so funds do not expire
- Adds a note that unilateral exit is not implemented in Alby Hub yet, with an info tooltip explaining that Bark supports it but the exit must be executed manually with the wallet data
- Links Second's [Terms of Service](https://second.tech/terms), since the default Bark configuration connects to Second's Ark server

The tooltip trigger uses `type="button"` so it does not submit the surrounding setup form.

## Test plan

- `yarn lint` passes (ESLint + TypeScript + Prettier)
- Go through setup with the Bark backend and check the Security & Recovery page shows the new notices, the tooltip opens on the info icon, and the terms link opens second.tech/terms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1011" height="1281" alt="image" src="https://github.com/user-attachments/assets/0dcdb128-8f54-473c-8c75-bac67be879d9" />
