### PR TITLE
chore: sync Wails CLI version in CI with go.mod (v2.14.0)

### DIFF
--- a/.github/workflows/wails.yml
+++ b/.github/workflows/wails.yml
@@ -76,7 +76,7 @@ jobs:
           node-version: "22.x"
 
       - name: Install Wails
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.14.0
         shell: bash
 
       - name: Install Linux Wails deps

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,8 @@ go run cmd/http/main.go
 wails dev -tags "wails"
 ```
 
+**Wails versions must stay in sync:** the `github.com/wailsapp/wails/v2` version in `go.mod` and the Wails CLI version installed in `.github/workflows/wails.yml` (`go install ...cmd/wails@vX.Y.Z`) must match. When bumping one, always update the other — this is a common source of drift (e.g. via Dependabot updates to `go.mod` only).
+
 ## Testing
 
 ### Go Backend


### PR DESCRIPTION
## Summary
- The recent dependency bump (#2541) updated `github.com/wailsapp/wails/v2` to **v2.14.0** in `go.mod`, but the Wails workflow still installed the CLI at **v2.12.0** — align the CI install to v2.14.0.
- Add a note to `AGENTS.md` that the `go.mod` version and the CLI version in `.github/workflows/wails.yml` must be updated together, since this is an easy mismatch to reintroduce (e.g. Dependabot only touches `go.mod`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to use Wails version 2.14.0.
  * Added development guidance to keep the Wails CLI and project dependency versions aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->