### PR TITLE
fix: move jit min/max info from /api/info into separate endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1590,24 +1590,12 @@ func (api *api) GetInfo(ctx context.Context) (*InfoResponse, error) {
 			type lsps2SourceProvider interface {
 				GetLiquiditySourceLsps2() string
 			}
-			type lsps2MinPaymentSizeProvider interface {
-				GetLiquiditySourceLsps2MinPaymentSizeMsat() *uint64
-			}
-			type lsps2MaxPaymentSizeProvider interface {
-				GetLiquiditySourceLsps2MaxPaymentSizeMsat() *uint64
-			}
 
-			if ldkService, ok := api.svc.GetLNClient().(chainSourceProvider); ok {
+			if ldkService, ok := lnClient.(chainSourceProvider); ok {
 				info.ChainDataSourceType, info.ChainDataSourceAddress = ldkService.GetChainDataSource()
 			}
-			if ldkService, ok := api.svc.GetLNClient().(lsps2SourceProvider); ok {
+			if ldkService, ok := lnClient.(lsps2SourceProvider); ok {
 				info.JitChannelsLiquiditySource = ldkService.GetLiquiditySourceLsps2()
-			}
-			if ldkService, ok := api.svc.GetLNClient().(lsps2MinPaymentSizeProvider); ok {
-				info.JitChannelsMinPaymentSizeMsat = ldkService.GetLiquiditySourceLsps2MinPaymentSizeMsat()
-			}
-			if ldkService, ok := api.svc.GetLNClient().(lsps2MaxPaymentSizeProvider); ok {
-				info.JitChannelsMaxPaymentSizeMsat = ldkService.GetLiquiditySourceLsps2MaxPaymentSizeMsat()
 			}
 		}
 	}
@@ -1617,6 +1605,32 @@ func (api *api) GetInfo(ctx context.Context) (*InfoResponse, error) {
 	info.NodeAlias, _ = api.cfg.Get("NodeAlias", "")
 
 	return &info, nil
+}
+
+func (api *api) GetJitChannelsInfo(_ context.Context) (*JitChannelsInfoResponse, error) {
+	info := &JitChannelsInfoResponse{}
+
+	backendType, _ := api.cfg.Get("LNBackendType", "")
+	jitChannelsEnabled, _ := api.cfg.Get("JitChannelsEnabled", "")
+	if backendType != config.LDKBackendType || jitChannelsEnabled == "false" {
+		return info, nil
+	}
+
+	lnClient := api.svc.GetLNClient()
+	if lnClient == nil {
+		return info, nil
+	}
+
+	type lsps2PaymentSizeRangeProvider interface {
+		GetLiquiditySourceLsps2PaymentSizeRangeMsat() (*uint64, *uint64)
+	}
+	ldkService, ok := lnClient.(lsps2PaymentSizeRangeProvider)
+	if !ok {
+		return info, nil
+	}
+
+	info.MinPaymentSizeMsat, info.MaxPaymentSizeMsat = ldkService.GetLiquiditySourceLsps2PaymentSizeRangeMsat()
+	return info, nil
 }
 
 func (api *api) setCurrency(currency string) error {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -13,6 +13,55 @@ import (
 	"github.com/getAlby/hub/tests/mocks"
 )
 
+type jitChannelsInfoLNClient struct {
+	*mocks.MockLNClient
+	minPaymentSizeMsat uint64
+	maxPaymentSizeMsat uint64
+	calls              int
+}
+
+func (client *jitChannelsInfoLNClient) GetLiquiditySourceLsps2PaymentSizeRangeMsat() (*uint64, *uint64) {
+	client.calls++
+	return &client.minPaymentSizeMsat, &client.maxPaymentSizeMsat
+}
+
+func TestGetJitChannelsInfo(t *testing.T) {
+	t.Run("does not query LSPS2 when JIT channels are disabled", func(t *testing.T) {
+		cfg := mocks.NewMockConfig(t)
+		svc := mocks.NewMockService(t)
+		cfg.On("Get", "LNBackendType", "").Return("LDK", nil)
+		cfg.On("Get", "JitChannelsEnabled", "").Return("false", nil)
+
+		theAPI := &api{cfg: cfg, svc: svc}
+		info, err := theAPI.GetJitChannelsInfo(context.Background())
+
+		require.NoError(t, err)
+		require.Nil(t, info.MinPaymentSizeMsat)
+		require.Nil(t, info.MaxPaymentSizeMsat)
+	})
+
+	t.Run("returns the LSPS2 payment size range when enabled", func(t *testing.T) {
+		cfg := mocks.NewMockConfig(t)
+		svc := mocks.NewMockService(t)
+		lnClient := &jitChannelsInfoLNClient{
+			MockLNClient:       mocks.NewMockLNClient(t),
+			minPaymentSizeMsat: 1_000_000,
+			maxPaymentSizeMsat: 100_000_000,
+		}
+		cfg.On("Get", "LNBackendType", "").Return("LDK", nil)
+		cfg.On("Get", "JitChannelsEnabled", "").Return("true", nil)
+		svc.On("GetLNClient").Return(lnClient)
+
+		theAPI := &api{cfg: cfg, svc: svc}
+		info, err := theAPI.GetJitChannelsInfo(context.Background())
+
+		require.NoError(t, err)
+		require.Equal(t, 1, lnClient.calls)
+		require.Equal(t, uint64(1_000_000), *info.MinPaymentSizeMsat)
+		require.Equal(t, uint64(100_000_000), *info.MaxPaymentSizeMsat)
+	})
+}
+
 func TestGetCustomNodeCommandDefinitions(t *testing.T) {
 	lnClient := mocks.NewMockLNClient(t)
 	svc := mocks.NewMockService(t)

--- a/api/models.go
+++ b/api/models.go
@@ -51,6 +51,7 @@ type API interface {
 	SetTransactionUserLabels(ctx context.Context, id uint, labels map[string]string) error
 	RequestMempoolApi(ctx context.Context, endpoint string) (interface{}, error)
 	GetInfo(ctx context.Context) (*InfoResponse, error)
+	GetJitChannelsInfo(ctx context.Context) (*JitChannelsInfoResponse, error)
 	GetMnemonic(unlockPassword string) (*MnemonicResponse, error)
 	SetNextBackupReminder(backupReminderRequest *BackupReminderRequest) error
 	Start(startRequest *StartRequest)
@@ -304,41 +305,44 @@ type InfoResponseRelay struct {
 }
 
 type InfoResponse struct {
-	BackendType                   string              `json:"backendType"`
-	SetupCompleted                bool                `json:"setupCompleted"`
-	OAuthRedirect                 bool                `json:"oauthRedirect"`
-	Running                       bool                `json:"running"`
-	Unlocked                      bool                `json:"unlocked"`
-	AlbyAuthUrl                   string              `json:"albyAuthUrl"`
-	NextBackupReminder            string              `json:"nextBackupReminder"`
-	AlbyUserIdentifier            string              `json:"albyUserIdentifier"`
-	AlbyAccountConnected          bool                `json:"albyAccountConnected"`
-	Version                       string              `json:"version"`
-	Network                       string              `json:"network"`
-	EnableAdvancedSetup           bool                `json:"enableAdvancedSetup"`
-	LdkVssEnabled                 bool                `json:"ldkVssEnabled"`
-	LdkVssUrl                     string              `json:"ldkVssUrl"`
-	VssSupported                  bool                `json:"vssSupported"`
-	DatabaseType                  string              `json:"databaseType"`
-	StartupState                  string              `json:"startupState"`
-	StartupError                  string              `json:"startupError"`
-	StartupErrorTime              time.Time           `json:"startupErrorTime"`
-	AutoUnlockPasswordSupported   bool                `json:"autoUnlockPasswordSupported"`
-	AutoUnlockPasswordEnabled     bool                `json:"autoUnlockPasswordEnabled"`
-	Currency                      string              `json:"currency"`
-	BitcoinDisplayFormat          string              `json:"bitcoinDisplayFormat"`
-	Relays                        []InfoResponseRelay `json:"relays"`
-	NodeAlias                     string              `json:"nodeAlias"`
-	MempoolUrl                    string              `json:"mempoolUrl"`
-	ChainDataSourceType           string              `json:"chainDataSourceType,omitempty"`
-	ChainDataSourceAddress        string              `json:"chainDataSourceAddress,omitempty"`
-	JitChannelsLiquiditySource    string              `json:"jitChannelsLiquiditySource,omitempty"`
-	JitChannelsMinPaymentSizeMsat *uint64             `json:"jitChannelsMinPaymentSizeMsat,omitempty"`
-	JitChannelsMaxPaymentSizeMsat *uint64             `json:"jitChannelsMaxPaymentSizeMsat,omitempty"`
-	JitChannelsEnabled            bool                `json:"jitChannelsEnabled"`
-	HideUpdateBanner              bool                `json:"hideUpdateBanner"`
-	SupportsBolt12                bool                `json:"supportsBolt12"`
-	NodeMigrationFileCreated      bool                `json:"nodeMigrationFileCreated"`
+	BackendType                 string              `json:"backendType"`
+	SetupCompleted              bool                `json:"setupCompleted"`
+	OAuthRedirect               bool                `json:"oauthRedirect"`
+	Running                     bool                `json:"running"`
+	Unlocked                    bool                `json:"unlocked"`
+	AlbyAuthUrl                 string              `json:"albyAuthUrl"`
+	NextBackupReminder          string              `json:"nextBackupReminder"`
+	AlbyUserIdentifier          string              `json:"albyUserIdentifier"`
+	AlbyAccountConnected        bool                `json:"albyAccountConnected"`
+	Version                     string              `json:"version"`
+	Network                     string              `json:"network"`
+	EnableAdvancedSetup         bool                `json:"enableAdvancedSetup"`
+	LdkVssEnabled               bool                `json:"ldkVssEnabled"`
+	LdkVssUrl                   string              `json:"ldkVssUrl"`
+	VssSupported                bool                `json:"vssSupported"`
+	DatabaseType                string              `json:"databaseType"`
+	StartupState                string              `json:"startupState"`
+	StartupError                string              `json:"startupError"`
+	StartupErrorTime            time.Time           `json:"startupErrorTime"`
+	AutoUnlockPasswordSupported bool                `json:"autoUnlockPasswordSupported"`
+	AutoUnlockPasswordEnabled   bool                `json:"autoUnlockPasswordEnabled"`
+	Currency                    string              `json:"currency"`
+	BitcoinDisplayFormat        string              `json:"bitcoinDisplayFormat"`
+	Relays                      []InfoResponseRelay `json:"relays"`
+	NodeAlias                   string              `json:"nodeAlias"`
+	MempoolUrl                  string              `json:"mempoolUrl"`
+	ChainDataSourceType         string              `json:"chainDataSourceType,omitempty"`
+	ChainDataSourceAddress      string              `json:"chainDataSourceAddress,omitempty"`
+	JitChannelsLiquiditySource  string              `json:"jitChannelsLiquiditySource,omitempty"`
+	JitChannelsEnabled          bool                `json:"jitChannelsEnabled"`
+	HideUpdateBanner            bool                `json:"hideUpdateBanner"`
+	SupportsBolt12              bool                `json:"supportsBolt12"`
+	NodeMigrationFileCreated    bool                `json:"nodeMigrationFileCreated"`
+}
+
+type JitChannelsInfoResponse struct {
+	MinPaymentSizeMsat *uint64 `json:"minPaymentSizeMsat,omitempty"`
+	MaxPaymentSizeMsat *uint64 `json:"maxPaymentSizeMsat,omitempty"`
 }
 
 type UpdateSettingsRequest struct {

--- a/frontend/src/components/FirstChannelJitAlert.tsx
+++ b/frontend/src/components/FirstChannelJitAlert.tsx
@@ -7,6 +7,7 @@ import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
 import { useBalances } from "src/hooks/useBalances";
 import { useChannels } from "src/hooks/useChannels";
 import { useInfo } from "src/hooks/useInfo";
+import { useJitChannelsInfo } from "src/hooks/useJitChannelsInfo";
 import { CreateInvoiceRequest, Transaction } from "src/types";
 import { request } from "src/utils/request";
 
@@ -24,7 +25,8 @@ export default function FirstChannelJitAlert() {
     ? info.jitChannelsLiquiditySource
     : undefined;
 
-  const minPaymentSizeMsat = info?.jitChannelsMinPaymentSizeMsat;
+  const { data: jitChannelsInfo } = useJitChannelsInfo(!!lsps2Source);
+  const minPaymentSizeMsat = jitChannelsInfo?.minPaymentSizeMsat;
 
   const isJitEnabled = !!lsps2Source && !!channels;
   // the user's first received payment opens the channel when they have none yet.

--- a/frontend/src/hooks/useJitChannelsInfo.ts
+++ b/frontend/src/hooks/useJitChannelsInfo.ts
@@ -1,0 +1,11 @@
+import useSWR from "swr";
+
+import { JitChannelsInfoResponse } from "src/types";
+import { swrFetcher } from "src/utils/swr";
+
+export function useJitChannelsInfo(enabled: boolean) {
+  return useSWR<JitChannelsInfoResponse>(
+    enabled ? "/api/jit-channels/info" : null,
+    swrFetcher
+  );
+}

--- a/frontend/src/screens/settings/About.tsx
+++ b/frontend/src/screens/settings/About.tsx
@@ -4,15 +4,18 @@ import Loading from "src/components/Loading";
 import SettingsHeader from "src/components/SettingsHeader";
 import { Badge } from "src/components/ui/badge";
 import { useAlbyMe } from "src/hooks/useAlbyMe";
+import { useInfo } from "src/hooks/useInfo";
+import { useJitChannelsInfo } from "src/hooks/useJitChannelsInfo";
 import { useNodeDetails } from "src/hooks/useNodeDetails";
 import { backendTypeConfigs } from "src/lib/backendType";
-
-import { useInfo } from "src/hooks/useInfo";
 
 export function About() {
   const { data: info } = useInfo();
   const { data: albyMe, error: albyMeError } = useAlbyMe();
   const lsps2Source = info?.jitChannelsLiquiditySource;
+  const { data: jitChannelsInfo } = useJitChannelsInfo(
+    !!info?.jitChannelsEnabled && !!lsps2Source
+  );
   const lsps2Pubkey = lsps2Source?.includes("@")
     ? lsps2Source.split("@")[0]
     : undefined;
@@ -20,11 +23,11 @@ export function About() {
   const lsps2Label =
     lsps2NodeDetails?.alias ||
     (lsps2Pubkey ? lsps2Pubkey.slice(0, 8) + "..." : lsps2Source);
-  const lsps2MinPaymentSizeSat = info?.jitChannelsMinPaymentSizeMsat
-    ? Math.ceil(info.jitChannelsMinPaymentSizeMsat / 1000)
+  const lsps2MinPaymentSizeSat = jitChannelsInfo?.minPaymentSizeMsat
+    ? Math.ceil(jitChannelsInfo.minPaymentSizeMsat / 1000)
     : undefined;
-  const lsps2MaxPaymentSizeSat = info?.jitChannelsMaxPaymentSizeMsat
-    ? Math.floor(info.jitChannelsMaxPaymentSizeMsat / 1000)
+  const lsps2MaxPaymentSizeSat = jitChannelsInfo?.maxPaymentSizeMsat
+    ? Math.floor(jitChannelsInfo.maxPaymentSizeMsat / 1000)
     : undefined;
 
   if (!info || (info.albyAccountConnected && !albyMe && !albyMeError)) {

--- a/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
+++ b/frontend/src/screens/wallet/receive/ReceiveInvoice.tsx
@@ -43,6 +43,7 @@ import { useBalances } from "src/hooks/useBalances";
 import { useChannels } from "src/hooks/useChannels";
 
 import { useInfo } from "src/hooks/useInfo";
+import { useJitChannelsInfo } from "src/hooks/useJitChannelsInfo";
 import { useTransaction } from "src/hooks/useTransaction";
 import { copyToClipboard } from "src/lib/clipboard";
 import { cn } from "src/lib/utils";
@@ -73,23 +74,24 @@ export default function ReceiveInvoice() {
   const jitChannelsEnabled = !!info?.jitChannelsEnabled;
   const configuredLsps2Source = info?.jitChannelsLiquiditySource;
   const lsps2Source = jitChannelsEnabled ? configuredLsps2Source : undefined;
+  const { data: jitChannelsInfo } = useJitChannelsInfo(!!lsps2Source);
   const lsps2MinimumPaymentSizeSat = React.useMemo(() => {
-    if (jitChannelsEnabled && info?.jitChannelsMinPaymentSizeMsat) {
-      return Math.ceil(info.jitChannelsMinPaymentSizeMsat / 1000);
+    if (jitChannelsInfo?.minPaymentSizeMsat) {
+      return Math.ceil(jitChannelsInfo.minPaymentSizeMsat / 1000);
     }
     return undefined;
-  }, [info?.jitChannelsMinPaymentSizeMsat, jitChannelsEnabled]);
+  }, [jitChannelsInfo?.minPaymentSizeMsat]);
   // only enforce the minimum on the input when the user has no channels yet -
   // their first channel must meet the minimum size.
   const jitMinimumReceiveSat = channels?.length
     ? undefined
     : lsps2MinimumPaymentSizeSat;
   const lsps2MaximumPaymentSizeSat = React.useMemo(() => {
-    if (jitChannelsEnabled && info?.jitChannelsMaxPaymentSizeMsat) {
-      return Math.floor(info.jitChannelsMaxPaymentSizeMsat / 1000);
+    if (jitChannelsInfo?.maxPaymentSizeMsat) {
+      return Math.floor(jitChannelsInfo.maxPaymentSizeMsat / 1000);
     }
     return undefined;
-  }, [info?.jitChannelsMaxPaymentSizeMsat, jitChannelsEnabled]);
+  }, [jitChannelsInfo?.maxPaymentSizeMsat]);
   const jitMaximumReceiveSat =
     hasChannelManagement && lsps2Source
       ? lsps2MaximumPaymentSizeSat

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -182,12 +182,15 @@ export interface InfoResponse {
   chainDataSourceType?: string;
   chainDataSourceAddress?: string;
   jitChannelsLiquiditySource?: string;
-  jitChannelsMinPaymentSizeMsat?: number;
-  jitChannelsMaxPaymentSizeMsat?: number;
   jitChannelsEnabled: boolean;
   hideUpdateBanner: boolean;
   supportsBolt12: boolean;
   nodeMigrationFileCreated: boolean;
+}
+
+export interface JitChannelsInfoResponse {
+  minPaymentSizeMsat?: number;
+  maxPaymentSizeMsat?: number;
 }
 
 export type BitcoinDisplayFormat = "sats" | "bip177";

--- a/http/http_service.go
+++ b/http/http_service.go
@@ -64,8 +64,8 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	e.HideBanner = true
 
 	e.Use(middleware.SecureWithConfig(middleware.SecureConfig{
-		ContentTypeNosniff:    "nosniff",
-		XFrameOptions:         "DENY",
+		ContentTypeNosniff: "nosniff",
+		XFrameOptions:      "DENY",
 		// when making changes here, also update the CSP in frontend/vite.config.ts
 		ContentSecurityPolicy: "default-src 'self'; img-src 'self' https://uploads.getalby-assets.com https://cdn.getalby-assets.com https://getalby.com; connect-src 'self' https://api.getalby.com https://getalby.com https://zapplanner.albylabs.com wss://relay.getalby.com wss://relay2.getalby.com; frame-src https://www.youtube-nocookie.com",
 		ReferrerPolicy:        "no-referrer",
@@ -151,6 +151,7 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	readOnlyApiGroup.GET("/transactions", httpSvc.listTransactionsHandler)
 	readOnlyApiGroup.GET("/transactions/:paymentHash", httpSvc.lookupTransactionHandler)
 	readOnlyApiGroup.GET("/balances", httpSvc.balancesHandler)
+	readOnlyApiGroup.GET("/jit-channels/info", httpSvc.jitChannelsInfoHandler)
 	readOnlyApiGroup.GET("/mempool", httpSvc.mempoolApiHandler)
 	readOnlyApiGroup.GET("/health", httpSvc.healthHandler)
 	readOnlyApiGroup.GET("/commands", httpSvc.getCustomNodeCommandsHandler)
@@ -235,6 +236,17 @@ func (httpSvc *HttpService) infoHandler(c echo.Context) error {
 			}
 			responseBody.Unlocked = err == nil && token != nil && token.Valid
 		}
+	}
+
+	return c.JSON(http.StatusOK, responseBody)
+}
+
+func (httpSvc *HttpService) jitChannelsInfoHandler(c echo.Context) error {
+	responseBody, err := httpSvc.api.GetJitChannelsInfo(c.Request().Context())
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Message: err.Error(),
+		})
 	}
 
 	return c.JSON(http.StatusOK, responseBody)

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -59,6 +59,8 @@ type LDKService struct {
 	lsps2Address                       string
 	lsps2InfoMu                        sync.Mutex
 	lsps2InfoFetchedAt                 time.Time
+	lsps2InfoLastAttemptedAt           time.Time
+	lsps2InfoFetchInProgress           bool
 	lsps2MinPaymentSizeMsat            *uint64
 	lsps2MaxPaymentSizeMsat            *uint64
 	lsps2OpeningFeeParamsMenu          []ldk_node.Lsps2OpeningFeeParams
@@ -69,6 +71,7 @@ type LDKService struct {
 const resetRouterKey = "ResetRouter"
 const maxInvoiceExpiry = 24 * time.Hour
 const lsps2InfoCacheTTL = 60 * time.Minute
+const lsps2InfoRetryBackoff = 1 * time.Minute
 
 // cached opening fee params must be at most this old when used to derive the
 // maximum LSP fee for a new JIT channel invoice
@@ -2675,22 +2678,13 @@ func (ls *LDKService) GetLiquiditySourceLsps2() string {
 	return fmt.Sprintf("%s@%s", ls.lsps2Pubkey, ls.lsps2Address)
 }
 
-func (ls *LDKService) GetLiquiditySourceLsps2MinPaymentSizeMsat() *uint64 {
+func (ls *LDKService) GetLiquiditySourceLsps2PaymentSizeRangeMsat() (*uint64, *uint64) {
 	ls.fetchLsps2OpeningFeeParams(lsps2InfoCacheTTL)
 
 	ls.lsps2InfoMu.Lock()
 	defer ls.lsps2InfoMu.Unlock()
 
-	return ls.lsps2MinPaymentSizeMsat
-}
-
-func (ls *LDKService) GetLiquiditySourceLsps2MaxPaymentSizeMsat() *uint64 {
-	ls.fetchLsps2OpeningFeeParams(lsps2InfoCacheTTL)
-
-	ls.lsps2InfoMu.Lock()
-	defer ls.lsps2InfoMu.Unlock()
-
-	return ls.lsps2MaxPaymentSizeMsat
+	return ls.lsps2MinPaymentSizeMsat, ls.lsps2MaxPaymentSizeMsat
 }
 
 // getLsps2MaxTotalOpeningFeeMsat returns the maximum opening fee to accept
@@ -2706,26 +2700,45 @@ func (ls *LDKService) getLsps2MaxTotalOpeningFeeMsat(paymentSizeMsat uint64) uin
 }
 
 func (ls *LDKService) fetchLsps2OpeningFeeParams(maxCacheAge time.Duration) {
+	ls.fetchLsps2OpeningFeeParamsWith(maxCacheAge, func() ([]ldk_node.Lsps2OpeningFeeParams, error) {
+		response, err := ls.node.Lsps2Liquidity().RequestOpeningFeeParams()
+		if err != nil {
+			return nil, err
+		}
+		return response.OpeningFeeParamsMenu, nil
+	})
+}
+
+func (ls *LDKService) fetchLsps2OpeningFeeParamsWith(maxCacheAge time.Duration, request func() ([]ldk_node.Lsps2OpeningFeeParams, error)) {
 	if ls.lsps2Pubkey == "" || ls.lsps2Address == "" {
 		return
 	}
 
 	ls.lsps2InfoMu.Lock()
-	defer ls.lsps2InfoMu.Unlock()
-
-	if !ls.lsps2InfoFetchedAt.IsZero() && time.Since(ls.lsps2InfoFetchedAt) < maxCacheAge {
+	now := time.Now()
+	if (!ls.lsps2InfoFetchedAt.IsZero() && now.Sub(ls.lsps2InfoFetchedAt) < maxCacheAge) ||
+		ls.lsps2InfoFetchInProgress ||
+		(!ls.lsps2InfoLastAttemptedAt.IsZero() && now.Sub(ls.lsps2InfoLastAttemptedAt) < lsps2InfoRetryBackoff) {
+		ls.lsps2InfoMu.Unlock()
 		return
 	}
+	ls.lsps2InfoFetchInProgress = true
+	ls.lsps2InfoLastAttemptedAt = now
+	ls.lsps2InfoMu.Unlock()
 
-	response, err := ls.node.Lsps2Liquidity().RequestOpeningFeeParams()
+	menu, err := request()
 	if err != nil {
 		logger.Logger.WithError(err).Warn("Failed to fetch LSPS2 opening fee params")
+		ls.lsps2InfoMu.Lock()
+		ls.lsps2InfoLastAttemptedAt = time.Now()
+		ls.lsps2InfoFetchInProgress = false
+		ls.lsps2InfoMu.Unlock()
 		return
 	}
 
 	var minPaymentSizeMsat *uint64
 	var maxPaymentSizeMsat *uint64
-	for _, params := range response.OpeningFeeParamsMenu {
+	for _, params := range menu {
 		effectiveMinPaymentSizeMsat, ok := computeLsps2MinPaymentSizeMsat(params)
 		if !ok {
 			continue
@@ -2740,10 +2753,13 @@ func (ls *LDKService) fetchLsps2OpeningFeeParams(maxCacheAge time.Duration) {
 		}
 	}
 
+	ls.lsps2InfoMu.Lock()
 	ls.lsps2MinPaymentSizeMsat = minPaymentSizeMsat
 	ls.lsps2MaxPaymentSizeMsat = maxPaymentSizeMsat
-	ls.lsps2OpeningFeeParamsMenu = response.OpeningFeeParamsMenu
+	ls.lsps2OpeningFeeParamsMenu = menu
 	ls.lsps2InfoFetchedAt = time.Now()
+	ls.lsps2InfoFetchInProgress = false
+	ls.lsps2InfoMu.Unlock()
 }
 
 // computeLsps2MaxTotalOpeningFeeMsat returns the maximum LSPS2 opening fee to

--- a/lnclient/ldk/ldk_test.go
+++ b/lnclient/ldk/ldk_test.go
@@ -1,7 +1,9 @@
 package ldk
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/getAlby/ldk-node-go/ldk_node"
 	"github.com/stretchr/testify/assert"
@@ -130,6 +132,106 @@ func TestComputeLsps2MinPaymentSizeMsat(t *testing.T) {
 		_, ok := computeLsps2MinPaymentSizeMsat(params)
 		assert.False(t, ok)
 	})
+}
+
+func TestFetchLsps2OpeningFeeParamsCachesSuccessfulResponse(t *testing.T) {
+	ls := &LDKService{
+		lsps2Pubkey:  "pubkey",
+		lsps2Address: "127.0.0.1:9735",
+	}
+	menu := []ldk_node.Lsps2OpeningFeeParams{
+		makeLsps2OpeningFeeParams(10_000, 5_000, 1_000_000, 100_000_000),
+	}
+	calls := 0
+	request := func() ([]ldk_node.Lsps2OpeningFeeParams, error) {
+		calls++
+		return menu, nil
+	}
+
+	ls.fetchLsps2OpeningFeeParamsWith(time.Hour, request)
+	ls.fetchLsps2OpeningFeeParamsWith(time.Hour, request)
+
+	assert.Equal(t, 1, calls)
+	require.NotNil(t, ls.lsps2MinPaymentSizeMsat)
+	require.NotNil(t, ls.lsps2MaxPaymentSizeMsat)
+	assert.Equal(t, uint64(1_000_000), *ls.lsps2MinPaymentSizeMsat)
+	assert.Equal(t, uint64(100_000_000), *ls.lsps2MaxPaymentSizeMsat)
+	assert.Equal(t, menu, ls.lsps2OpeningFeeParamsMenu)
+}
+
+func TestFetchLsps2OpeningFeeParamsBacksOffAfterFailure(t *testing.T) {
+	oldMin := uint64(2_000_000)
+	oldMax := uint64(50_000_000)
+	oldMenu := []ldk_node.Lsps2OpeningFeeParams{
+		makeLsps2OpeningFeeParams(20_000, 5_000, oldMin, oldMax),
+	}
+	ls := &LDKService{
+		lsps2Pubkey:               "pubkey",
+		lsps2Address:              "127.0.0.1:9735",
+		lsps2InfoFetchedAt:        time.Now().Add(-2 * time.Hour),
+		lsps2MinPaymentSizeMsat:   &oldMin,
+		lsps2MaxPaymentSizeMsat:   &oldMax,
+		lsps2OpeningFeeParamsMenu: oldMenu,
+	}
+	calls := 0
+	request := func() ([]ldk_node.Lsps2OpeningFeeParams, error) {
+		calls++
+		return nil, errors.New("LSP unavailable")
+	}
+
+	ls.fetchLsps2OpeningFeeParamsWith(time.Hour, request)
+	ls.fetchLsps2OpeningFeeParamsWith(time.Hour, request)
+
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, oldMin, *ls.lsps2MinPaymentSizeMsat)
+	assert.Equal(t, oldMax, *ls.lsps2MaxPaymentSizeMsat)
+	assert.Equal(t, oldMenu, ls.lsps2OpeningFeeParamsMenu)
+
+	ls.lsps2InfoMu.Lock()
+	ls.lsps2InfoLastAttemptedAt = time.Now().Add(-lsps2InfoRetryBackoff - time.Second)
+	ls.lsps2InfoMu.Unlock()
+	ls.fetchLsps2OpeningFeeParamsWith(time.Hour, request)
+
+	assert.Equal(t, 2, calls)
+}
+
+func TestFetchLsps2OpeningFeeParamsDoesNotBlockConcurrentCallers(t *testing.T) {
+	ls := &LDKService{
+		lsps2Pubkey:  "pubkey",
+		lsps2Address: "127.0.0.1:9735",
+	}
+	fetchStarted := make(chan struct{})
+	releaseFetch := make(chan struct{})
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		ls.fetchLsps2OpeningFeeParamsWith(time.Hour, func() ([]ldk_node.Lsps2OpeningFeeParams, error) {
+			close(fetchStarted)
+			<-releaseFetch
+			return nil, errors.New("LSP unavailable")
+		})
+	}()
+	<-fetchStarted
+
+	secondDone := make(chan struct{})
+	secondFetchCalled := false
+	go func() {
+		defer close(secondDone)
+		ls.fetchLsps2OpeningFeeParamsWith(time.Hour, func() ([]ldk_node.Lsps2OpeningFeeParams, error) {
+			secondFetchCalled = true
+			return nil, nil
+		})
+	}()
+
+	select {
+	case <-secondDone:
+	case <-time.After(time.Second):
+		t.Fatal("concurrent LSPS2 caller blocked behind the network request")
+	}
+	assert.False(t, secondFetchCalled)
+
+	close(releaseFetch)
+	<-firstDone
 }
 
 func TestSanitizeChainEndpointForBitcoind(t *testing.T) {


### PR DESCRIPTION
fixes #2545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated endpoint for JIT channel payment limits.
  * JIT channel minimum and maximum payment amounts are now retrieved when available.
  * Updated receive invoices, setup alerts, and About settings to use the latest payment limits.

* **Bug Fixes**
  * Improved payment-limit retrieval reliability with caching, retry backoff, and concurrent-request handling.
  * Preserved previously available limits when a refresh fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->