### PR TITLE
fix: retry auto-unlock StartApp on failure instead of silently staying locked

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -837,9 +837,6 @@ func (api *api) SetAutoUnlockPassword(unlockPassword string) error {
 
 func (api *api) Stop() error {
 	logger.Logger.Info("Running Stop command")
-	if api.svc.GetLNClient() == nil {
-		return ErrLNClientNotStarted
-	}
 
 	// stop the lnclient, nostr relay etc.
 	// The user will be forced to re-enter their unlock password to restart the node

--- a/api/api.go
+++ b/api/api.go
@@ -18,7 +18,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -837,12 +836,6 @@ func (api *api) SetAutoUnlockPassword(unlockPassword string) error {
 }
 
 func (api *api) Stop() error {
-	if !startMutex.TryLock() {
-		// do not allow to stop twice in case this is somehow called twice
-		return errors.New("app is busy")
-	}
-	defer startMutex.Unlock()
-
 	logger.Logger.Info("Running Stop command")
 	if api.svc.GetLNClient() == nil {
 		return ErrLNClientNotStarted
@@ -850,9 +843,7 @@ func (api *api) Stop() error {
 
 	// stop the lnclient, nostr relay etc.
 	// The user will be forced to re-enter their unlock password to restart the node
-	api.svc.StopApp()
-
-	return nil
+	return api.svc.StopApp()
 }
 
 func (api *api) GetNodeConnectionInfo(ctx context.Context) (*NodeConnectionInfo, error) {
@@ -1722,11 +1713,9 @@ func (api *api) SetNextBackupReminder(backupReminderRequest *BackupReminderReque
 	return nil
 }
 
-var startMutex sync.Mutex
-
 func (api *api) Start(startRequest *StartRequest) {
 	api.startupError = nil
-	err := api.startInternal(startRequest)
+	err := api.svc.StartApp(startRequest.UnlockPassword)
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to start node")
 		api.startupError = err
@@ -1734,21 +1723,14 @@ func (api *api) Start(startRequest *StartRequest) {
 	}
 }
 
-func (api *api) startInternal(startRequest *StartRequest) (err error) {
-	if !startMutex.TryLock() {
-		// do not allow to start twice in case this is somehow called twice
-		return errors.New("app is busy")
-	}
-	defer startMutex.Unlock()
-	return api.svc.StartApp(startRequest.UnlockPassword)
+func (api *api) Setup(ctx context.Context, setupRequest *SetupRequest) error {
+	// hold the start/stop lock so setup cannot run concurrently with a start
+	return api.svc.WithStartLock(func() error {
+		return api.setupInternal(ctx, setupRequest)
+	})
 }
 
-func (api *api) Setup(ctx context.Context, setupRequest *SetupRequest) error {
-	if !startMutex.TryLock() {
-		// do not allow to start twice in case this is somehow called twice
-		return errors.New("app is busy")
-	}
-	defer startMutex.Unlock()
+func (api *api) setupInternal(ctx context.Context, setupRequest *SetupRequest) error {
 	info, err := api.GetInfo(ctx)
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to get info")

--- a/api/backup.go
+++ b/api/backup.go
@@ -105,7 +105,10 @@ func (api *api) CreateBackup(unlockPassword string, w io.Writer) error {
 		return fmt.Errorf("failed to reset router: %w", err)
 	}
 	// Stop the app to ensure no new requests are processed.
-	api.svc.StopApp()
+	err = api.svc.StopApp()
+	if err != nil {
+		return fmt.Errorf("failed to stop app: %w", err)
+	}
 
 	// Remove the OAuth access token from the DB to ensure the user
 	// has to re-auth with the correct OAuth client when they restore the backup

--- a/api/backup_test.go
+++ b/api/backup_test.go
@@ -61,7 +61,7 @@ func TestCreateBackup(t *testing.T) {
 
 	svc := mocks.NewMockService(t)
 	svc.On("GetLNClient").Return(lnClient)
-	svc.On("StopApp").Return()
+	svc.On("StopApp").Return(nil)
 
 	albyOAuthSvc := mocks.NewMockAlbyOAuthService(t)
 	albyOAuthSvc.On("RemoveOAuthAccessToken").Return(nil)

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -64,7 +64,7 @@ func NewLNDService(ctx context.Context, eventPublisher events.EventPublisher, ln
 	nodeInfo, err := fetchNodeInfo(ctx, lndClient)
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to connect to LND")
-		return nil, err
+		return nil, fmt.Errorf("connect to LND: %w", err)
 	}
 
 	lndCtx, cancel := context.WithCancel(ctx)

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -60,27 +60,10 @@ func NewLNDService(ctx context.Context, eventPublisher events.EventPublisher, ln
 		return nil, err
 	}
 
-	var nodeInfo *lnclient.NodeInfo
-	maxRetries := 60
-	for i := range maxRetries {
-		nodeInfo, err = fetchNodeInfo(ctx, lndClient)
-		if err == nil {
-			break
-		}
-		logger.Logger.WithFields(logrus.Fields{
-			"iteration": i,
-		}).WithError(err).Error("Failed to connect to LND, retrying in 10s")
-
-		select {
-		case <-time.After(10 * time.Second):
-		case <-ctx.Done():
-			logger.Logger.WithError(ctx.Err()).Error("Context cancelled during LND connection retries")
-			return nil, ctx.Err()
-		}
-	}
-
+	// confirm LND is running by fetching the node info
+	nodeInfo, err := fetchNodeInfo(ctx, lndClient)
 	if err != nil {
-		logger.Logger.WithError(err).Error("Failed to connect to LND on final attempt, not attempting further retries")
+		logger.Logger.WithError(err).Error("Failed to connect to LND")
 		return nil, err
 	}
 

--- a/service/models.go
+++ b/service/models.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"errors"
+
 	"gorm.io/gorm"
 
 	"github.com/getAlby/hub/alby"
@@ -12,6 +14,17 @@ import (
 	"github.com/getAlby/hub/transactions"
 )
 
+var (
+	// ErrAppBusy is returned when another start or stop operation is already in progress.
+	ErrAppBusy = errors.New("app is busy")
+	// ErrAlreadyStarted is returned when the app is already unlocked and running.
+	ErrAlreadyStarted = errors.New("app already started")
+	// ErrInvalidPassword is returned when the provided unlock password is incorrect.
+	ErrInvalidPassword = errors.New("invalid password")
+	// ErrIncompleteWalletData is returned when the unlock password check is missing from the database.
+	ErrIncompleteWalletData = errors.New("your wallet data is incomplete and cannot be unlocked. Please restore from a backup")
+)
+
 type RelayStatus struct {
 	Url    string
 	Online bool
@@ -19,7 +32,10 @@ type RelayStatus struct {
 
 type Service interface {
 	StartApp(encryptionKey string) error
-	StopApp()
+	StopApp() error
+	// WithStartLock runs fn while holding the start/stop lock,
+	// returning ErrAppBusy if a start or stop is already in progress.
+	WithStartLock(fn func() error) error
 	Shutdown()
 
 	// TODO: remove getters (currently used by http / wails services)

--- a/service/models.go
+++ b/service/models.go
@@ -19,6 +19,8 @@ var (
 	ErrAppBusy = errors.New("app is busy")
 	// ErrAlreadyStarted is returned when the app is already unlocked and running.
 	ErrAlreadyStarted = errors.New("app already started")
+	// ErrAppNotStarted is returned when trying to stop an app that is not running.
+	ErrAppNotStarted = errors.New("app not started")
 	// ErrInvalidPassword is returned when the provided unlock password is incorrect.
 	ErrInvalidPassword = errors.New("invalid password")
 	// ErrIncompleteWalletData is returned when the unlock password check is missing from the database.

--- a/service/service.go
+++ b/service/service.go
@@ -45,6 +45,7 @@ type service struct {
 	wg                   *sync.WaitGroup
 	nip47Service         nip47.Nip47Service
 	appCancelFn          context.CancelFunc
+	startMutex           sync.Mutex
 	keys                 keys.Keys
 	relayStatuses        []RelayStatus
 	startupState         string
@@ -157,7 +158,10 @@ func NewService(ctx context.Context) (*service, error) {
 	if autoUnlockPassword != "" {
 		nodeLastStartTime, _ := cfg.Get("NodeLastStartTime", "")
 		if nodeLastStartTime != "" {
-			svc.StartApp(autoUnlockPassword)
+			// do not block startup of the web UI: if the start attempt fails
+			// (e.g. the hub boots before the internet connection is restored),
+			// keep retrying in the background instead of staying locked
+			go svc.startAppWithRetries(autoUnlockPassword)
 		}
 	}
 
@@ -226,7 +230,10 @@ func finishRestoreNode(workDir string) error {
 }
 
 func (svc *service) Shutdown() {
-	svc.StopApp()
+	err := svc.StopApp()
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to stop app during shutdown")
+	}
 	svc.eventPublisher.PublishSync(&events.Event{
 		Event: "nwc_stopped",
 	})

--- a/service/service.go
+++ b/service/service.go
@@ -230,10 +230,13 @@ func finishRestoreNode(workDir string) error {
 }
 
 func (svc *service) Shutdown() {
-	err := svc.StopApp()
-	if err != nil {
-		logger.Logger.WithError(err).Error("Failed to stop app during shutdown")
-	}
+	// unlike StopApp, shutdown must never bail out: block until any
+	// in-progress start or stop has finished (the service context is
+	// already cancelled at this point, so an in-progress start aborts),
+	// then stop the app before tearing down the event publisher and DB
+	svc.startMutex.Lock()
+	defer svc.startMutex.Unlock()
+	svc.stopAppInternal()
 	svc.eventPublisher.PublishSync(&events.Event{
 		Event: "nwc_stopped",
 	})

--- a/service/start.go
+++ b/service/start.go
@@ -256,7 +256,56 @@ func (svc *service) watchSubscription(ctx context.Context, pool *nostr.SimplePoo
 	}
 }
 
+// startAppWithRetries runs StartApp with capped exponential backoff until it
+// succeeds or fails permanently. It is used for auto-unlock on startup: a hub
+// that boots before its internet connection is restored (e.g. after a power
+// cut) must not silently stay locked because the first start attempt failed.
+func (svc *service) startAppWithRetries(encryptionKey string) {
+	backoff := 10 * time.Second
+	const maxBackoff = 5 * time.Minute
+
+	for {
+		err := svc.StartApp(encryptionKey)
+		if err == nil {
+			return
+		}
+		if errors.Is(err, ErrAlreadyStarted) {
+			logger.Logger.Info("App was started manually, stopping auto-unlock retries")
+			return
+		}
+		if errors.Is(err, ErrInvalidPassword) || errors.Is(err, ErrIncompleteWalletData) {
+			logger.Logger.WithError(err).Error("Auto-unlock failed permanently, not retrying")
+			return
+		}
+
+		logger.Logger.WithError(err).WithField("retry_in", backoff.String()).Error("Auto-unlock failed, retrying")
+		select {
+		case <-svc.ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		backoff = min(backoff*2, maxBackoff)
+	}
+}
+
+// WithStartLock runs fn while holding the start/stop lock, returning
+// ErrAppBusy if a start, stop or setup operation is already in progress.
+func (svc *service) WithStartLock(fn func() error) error {
+	if !svc.startMutex.TryLock() {
+		return ErrAppBusy
+	}
+	defer svc.startMutex.Unlock()
+	return fn()
+}
+
 func (svc *service) StartApp(encryptionKey string) error {
+	// do not allow to start twice in case this is somehow called twice
+	return svc.WithStartLock(func() error {
+		return svc.startAppInternal(encryptionKey)
+	})
+}
+
+func (svc *service) startAppInternal(encryptionKey string) error {
 	defer func() {
 		svc.startupState = ""
 	}()
@@ -271,7 +320,7 @@ func (svc *service) StartApp(encryptionKey string) error {
 	}
 
 	if svc.lnClient != nil {
-		return errors.New("app already started")
+		return ErrAlreadyStarted
 	}
 	unlockPasswordCheckSet, err := svc.cfg.IsUnlockPasswordCheckSet()
 	if err != nil {
@@ -280,11 +329,11 @@ func (svc *service) StartApp(encryptionKey string) error {
 	}
 	if !unlockPasswordCheckSet {
 		logger.Logger.Error("Unlock password check is missing from the database")
-		return errors.New("your wallet data is incomplete and cannot be unlocked. Please restore from a backup")
+		return ErrIncompleteWalletData
 	}
 	if !svc.cfg.CheckUnlockPassword(encryptionKey) {
 		logger.Logger.Errorf("Invalid password")
-		return errors.New("invalid password")
+		return ErrInvalidPassword
 	}
 
 	err = svc.cfg.LoadJWTSecret(encryptionKey)

--- a/service/stop.go
+++ b/service/stop.go
@@ -10,14 +10,24 @@ import (
 func (svc *service) StopApp() error {
 	// do not allow stopping while a start or stop is already in progress
 	return svc.WithStartLock(func() error {
-		if svc.appCancelFn != nil {
-			logger.Logger.Info("Stopping app...")
-			svc.appCancelFn()
-			svc.wg.Wait()
-			logger.Logger.Info("app stopped")
+		// check under the lock so an in-progress start reports busy
+		// rather than not started
+		if svc.lnClient == nil {
+			return ErrAppNotStarted
 		}
+		svc.stopAppInternal()
 		return nil
 	})
+}
+
+// stopAppInternal must be called while holding the start lock
+func (svc *service) stopAppInternal() {
+	if svc.appCancelFn != nil {
+		logger.Logger.Info("Stopping app...")
+		svc.appCancelFn()
+		svc.wg.Wait()
+		logger.Logger.Info("app stopped")
+	}
 }
 
 func (svc *service) stopLNClient() {

--- a/service/stop.go
+++ b/service/stop.go
@@ -7,13 +7,17 @@ import (
 	"github.com/getAlby/hub/logger"
 )
 
-func (svc *service) StopApp() {
-	if svc.appCancelFn != nil {
-		logger.Logger.Info("Stopping app...")
-		svc.appCancelFn()
-		svc.wg.Wait()
-		logger.Logger.Info("app stopped")
-	}
+func (svc *service) StopApp() error {
+	// do not allow stopping while a start or stop is already in progress
+	return svc.WithStartLock(func() error {
+		if svc.appCancelFn != nil {
+			logger.Logger.Info("Stopping app...")
+			svc.appCancelFn()
+			svc.wg.Wait()
+			logger.Logger.Info("app stopped")
+		}
+		return nil
+	})
 }
 
 func (svc *service) stopLNClient() {

--- a/tests/mocks/Service.go
+++ b/tests/mocks/Service.go
@@ -605,7 +605,7 @@ type MockService_StartApp_Call struct {
 
 // StartApp is a helper method to define mock.On call
 //   - encryptionKey string
-func (_e *MockService_Expecter) StartApp(encryptionKey interface{}) *MockService_StartApp_Call {
+func (_e *MockService_Expecter) StartApp(encryptionKey any) *MockService_StartApp_Call {
 	return &MockService_StartApp_Call{Call: _e.mock.On("StartApp", encryptionKey)}
 }
 
@@ -633,9 +633,20 @@ func (_c *MockService_StartApp_Call) RunAndReturn(run func(encryptionKey string)
 }
 
 // StopApp provides a mock function for the type MockService
-func (_mock *MockService) StopApp() {
-	_mock.Called()
-	return
+func (_mock *MockService) StopApp() error {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for StopApp")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func() error); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
 }
 
 // MockService_StopApp_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'StopApp'
@@ -655,12 +666,63 @@ func (_c *MockService_StopApp_Call) Run(run func()) *MockService_StopApp_Call {
 	return _c
 }
 
-func (_c *MockService_StopApp_Call) Return() *MockService_StopApp_Call {
-	_c.Call.Return()
+func (_c *MockService_StopApp_Call) Return(err error) *MockService_StopApp_Call {
+	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *MockService_StopApp_Call) RunAndReturn(run func()) *MockService_StopApp_Call {
-	_c.Run(run)
+func (_c *MockService_StopApp_Call) RunAndReturn(run func() error) *MockService_StopApp_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// WithStartLock provides a mock function for the type MockService
+func (_mock *MockService) WithStartLock(fn func() error) error {
+	ret := _mock.Called(fn)
+
+	if len(ret) == 0 {
+		panic("no return value specified for WithStartLock")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(func() error) error); ok {
+		r0 = returnFunc(fn)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockService_WithStartLock_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WithStartLock'
+type MockService_WithStartLock_Call struct {
+	*mock.Call
+}
+
+// WithStartLock is a helper method to define mock.On call
+//   - fn func() error
+func (_e *MockService_Expecter) WithStartLock(fn any) *MockService_WithStartLock_Call {
+	return &MockService_WithStartLock_Call{Call: _e.mock.On("WithStartLock", fn)}
+}
+
+func (_c *MockService_WithStartLock_Call) Run(run func(fn func() error)) *MockService_WithStartLock_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 func() error
+		if args[0] != nil {
+			arg0 = args[0].(func() error)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockService_WithStartLock_Call) Return(err error) *MockService_WithStartLock_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockService_WithStartLock_Call) RunAndReturn(run func(fn func() error) error) *MockService_WithStartLock_Call {
+	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Closes #2556

## Problem

When `AutoUnlockPassword` is set, `NewService` called `svc.StartApp(autoUnlockPassword)` once, synchronously, and discarded the error. If that first attempt failed — e.g. after a power cut when the hub boots before the internet connection is restored — the process stayed alive but locked. A supervisor like systemd sees a healthy service and never restarts it, so the hub sits offline until someone unlocks manually.

LND had its own workaround in the wrong layer: `NewLNDService` retried the connection 60×10s, which blocked web UI startup for up to 10 minutes on auto-unlock and hung the `/start` request on manual unlock. The other backends had no retry at all.

## Changes

1. **Auto-unlock now runs as an async retry loop** (`startAppWithRetries`): a goroutine with capped exponential backoff (10s → 5min) that exits on success, context cancellation, `ErrAlreadyStarted` (user unlocked manually mid-loop), or permanent errors (`ErrInvalidPassword`, `ErrIncompleteWalletData`). Transient failures — including the offline Alby-auth error from token refresh — keep retrying. The web UI is no longer blocked while auto-unlock is in progress.
2. **Removed LND's internal retry loop** — `NewLNDService` now makes a single connection attempt. Auto-unlock retries are covered by the service-level loop; a manual unlock fails fast with a visible error. All backends behave uniformly.
3. **Moved the start/stop mutex from the `api` package into the `service` struct** — the auto-unlock path bypasses the api package, so the old package-level mutex didn't cover it and the `svc.lnClient != nil` check wasn't atomic. `WithStartLock(fn)` is the single guard (returning a sentinel `ErrAppBusy`), used by `StartApp`, `StopApp` and the api's `Setup`; the api-level global mutex is deleted. `StopApp` now returns an error so busy/stop conflicts are visible to callers.

Error messages returned to the frontend are unchanged (`app is busy`, `invalid password`, `app already started`).

## Testing

- `go test ./...` passes.
- Mocks regenerated with mockery for the `Service` interface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application startup now retries temporary automatic unlock failures with increasing delays and stops when canceled.
  * Added clearer lifecycle errors for busy, already-started, not-started, invalid-password, and incomplete-wallet conditions.

* **Bug Fixes**
  * Prevented conflicting start, stop, and setup operations from running simultaneously.
  * Backup creation now reports failures when stopping the application.
  * Shutdown handles stop errors more reliably.

* **Performance**
  * LND connection failures are reported immediately instead of waiting through repeated checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->