### PR TITLE
feat: max fee new param to pay_invoice

### DIFF
--- a/api/models.go
+++ b/api/models.go
@@ -45,7 +45,7 @@ type API interface {
 	GetBalances(ctx context.Context) (*BalancesResponse, error)
 	ListTransactions(ctx context.Context, appId *uint, limit uint64, offset uint64, filters ListTransactionsFilters) (*ListTransactionsResponse, error)
 	ListOnchainTransactions(ctx context.Context) ([]OnchainTransaction, error)
-	SendPayment(ctx context.Context, invoice string, amountMsat *uint64, metadata map[string]interface{}, fromAppId *uint) (*SendPaymentResponse, error)
+	SendPayment(ctx context.Context, invoice string, amountMsat *uint64, maxFeeMsat *uint64, metadata map[string]interface{}, fromAppId *uint) (*SendPaymentResponse, error)
 	CreateInvoice(ctx context.Context, amountMsat uint64, description string, toAppId *uint) (*MakeInvoiceResponse, error)
 	LookupInvoice(ctx context.Context, paymentHash string) (*LookupInvoiceResponse, error)
 	SetTransactionUserLabels(ctx context.Context, id uint, labels map[string]string) error
@@ -583,6 +583,7 @@ type PayInvoiceRequest struct {
 	Amount     *uint64  `json:"amount"` // deprecated
 	AmountSat  *uint64  `json:"amountSat"`
 	AmountMsat *uint64  `json:"amountMsat"`
+	MaxFeeMsat *uint64  `json:"maxFeeMsat"`
 	Metadata   Metadata `json:"metadata"`
 	FromAppID  *uint    `json:"fromAppId"`
 }

--- a/api/rebalance.go
+++ b/api/rebalance.go
@@ -132,7 +132,7 @@ func (api *api) RebalanceChannel(ctx context.Context, rebalanceChannelRequest *R
 		"order_id":        rebalanceCreateOrderResponse.OrderId,
 	}
 
-	payRebalanceInvoiceResponse, err := api.svc.GetTransactionsService().SendPaymentSync(rebalanceCreateOrderResponse.PayRequest, nil, payMetadata, lnClient, nil, nil)
+	payRebalanceInvoiceResponse, err := api.svc.GetTransactionsService().SendPaymentSync(rebalanceCreateOrderResponse.PayRequest, nil, nil, payMetadata, lnClient, nil, nil)
 
 	if err != nil {
 		logger.Logger.WithError(err).Error("failed to pay rebalance invoice")

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -121,13 +121,13 @@ func (api *api) ListTransactions(ctx context.Context, appId *uint, limit uint64,
 	}, nil
 }
 
-func (api *api) SendPayment(ctx context.Context, invoice string, amountMsat *uint64, metadata map[string]interface{}, appId *uint) (*SendPaymentResponse, error) {
+func (api *api) SendPayment(ctx context.Context, invoice string, amountMsat *uint64, maxFeeMsat *uint64, metadata map[string]interface{}, appId *uint) (*SendPaymentResponse, error) {
 	lnClient := api.svc.GetLNClient()
 	if lnClient == nil {
 		return nil, ErrLNClientNotStarted
 	}
 
-	transaction, err := api.svc.GetTransactionsService().SendPaymentSync(invoice, amountMsat, metadata, lnClient, appId, nil)
+	transaction, err := api.svc.GetTransactionsService().SendPaymentSync(invoice, amountMsat, maxFeeMsat, metadata, lnClient, appId, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +224,7 @@ func (api *api) Transfer(ctx context.Context, fromAppId *uint, toAppId *uint, am
 		return err
 	}
 
-	_, err = api.svc.GetTransactionsService().SendPaymentSync(transaction.PaymentRequest, nil, nil, lnClient, fromAppId, nil)
+	_, err = api.svc.GetTransactionsService().SendPaymentSync(transaction.PaymentRequest, nil, nil, nil, lnClient, fromAppId, nil)
 	return err
 }
 

--- a/http/http_service.go
+++ b/http/http_service.go
@@ -64,8 +64,8 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	e.HideBanner = true
 
 	e.Use(middleware.SecureWithConfig(middleware.SecureConfig{
-		ContentTypeNosniff:    "nosniff",
-		XFrameOptions:         "DENY",
+		ContentTypeNosniff: "nosniff",
+		XFrameOptions:      "DENY",
 		// when making changes here, also update the CSP in frontend/vite.config.ts
 		ContentSecurityPolicy: "default-src 'self'; img-src 'self' https://uploads.getalby-assets.com https://cdn.getalby-assets.com https://getalby.com; connect-src 'self' https://api.getalby.com https://getalby.com https://zapplanner.albylabs.com wss://relay.getalby.com wss://relay2.getalby.com; frame-src https://www.youtube-nocookie.com",
 		ReferrerPolicy:        "no-referrer",
@@ -652,7 +652,7 @@ func (httpSvc *HttpService) sendPaymentHandler(c echo.Context) error {
 	}
 	amountMsat := api.ResolveToMsat(payInvoiceRequest.AmountSat, payInvoiceRequest.AmountMsat, nil, payInvoiceRequest.Amount)
 
-	paymentResponse, err := httpSvc.api.SendPayment(ctx, c.Param("invoice"), amountMsat, payInvoiceRequest.Metadata, payInvoiceRequest.FromAppID)
+	paymentResponse, err := httpSvc.api.SendPayment(ctx, c.Param("invoice"), amountMsat, payInvoiceRequest.MaxFeeMsat, payInvoiceRequest.Metadata, payInvoiceRequest.FromAppID)
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{

--- a/lnclient/bark/bark.go
+++ b/lnclient/bark/bark.go
@@ -484,10 +484,13 @@ func (bs *BarkService) MakeInvoice(ctx context.Context, amountMsat int64, descri
 	}, nil
 }
 
-func (bs *BarkService) SendPaymentSync(invoice string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
+func (bs *BarkService) SendPaymentSync(invoice string, amountMsat *uint64, maxFeeMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
 	// 0-amount invoices not supported initially — keeps the surface minimal.
 	if amountMsat != nil {
 		return nil, errors.New("0-amount invoices not supported")
+	}
+	if maxFeeMsat != nil {
+		return nil, errors.New("max fee is not supported by the bark backend")
 	}
 
 	paymentRequest, decodeErr := decodepay.Decodepay(invoice)

--- a/lnclient/cashu/cashu.go
+++ b/lnclient/cashu/cashu.go
@@ -3,6 +3,7 @@ package cashu
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strconv"
 	"time"
@@ -71,7 +72,7 @@ func (cs *CashuService) Shutdown() error {
 	return cs.wallet.Shutdown()
 }
 
-func (cs *CashuService) SendPaymentSync(invoice string, amountMsat *uint64) (response *lnclient.PayInvoiceResponse, err error) {
+func (cs *CashuService) SendPaymentSync(invoice string, amountMsat *uint64, maxFeeMsat *uint64) (response *lnclient.PayInvoiceResponse, err error) {
 	// TODO: support 0-amount invoices
 	if amountMsat != nil {
 		return nil, errors.New("0-amount invoices not supported")
@@ -81,6 +82,10 @@ func (cs *CashuService) SendPaymentSync(invoice string, amountMsat *uint64) (res
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to request melt quote")
 		return nil, err
+	}
+
+	if maxFeeMsat != nil && meltQuoteResponse.FeeReserve*1000 > *maxFeeMsat {
+		return nil, fmt.Errorf("melt quote fee reserve of %d msat exceeds max fee of %d msat", meltQuoteResponse.FeeReserve*1000, *maxFeeMsat)
 	}
 
 	meltResponse, err := cs.wallet.Melt(meltQuoteResponse.Quote)

--- a/lnclient/cln/cln.go
+++ b/lnclient/cln/cln.go
@@ -2312,10 +2312,11 @@ func (c *CLNService) SendPaymentProbes(ctx context.Context, invoice string) erro
 	return nil
 }
 
-func (c *CLNService) SendPaymentSync(payReq string, amount *uint64) (*lnclient.PayInvoiceResponse, error) {
+func (c *CLNService) SendPaymentSync(payReq string, amount *uint64, maxFeeMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
 	logger.Logger.WithFields(logrus.Fields{
-		"payReq": payReq,
-		"amount": amount,
+		"payReq":       payReq,
+		"amount":       amount,
+		"max_fee_msat": maxFeeMsat,
 	}).Debug("Send Payment Sync")
 
 	dec_req := &clngrpc.DecodeRequest{
@@ -2341,9 +2342,17 @@ func (c *CLNService) SendPaymentSync(payReq string, amount *uint64) (*lnclient.P
 		}
 	}
 
+	var maxFee *clngrpc.Amount
+	if maxFeeMsat != nil {
+		maxFee = &clngrpc.Amount{
+			Msat: *maxFeeMsat,
+		}
+	}
+
 	req := &clngrpc.XpayRequest{
 		Invstring:  payReq,
 		AmountMsat: amountMsat,
+		Maxfee:     maxFee,
 	}
 
 	resp, err := c.client.Xpay(c.ctx, req)

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -580,7 +580,7 @@ func (ls *LDKService) MakeOffer(ctx context.Context, description string) (string
 	return offer.String(), nil
 }
 
-func (ls *LDKService) SendPaymentSync(invoice string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
+func (ls *LDKService) SendPaymentSync(invoice string, amountMsat *uint64, maxFeeMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
 	paymentRequest, err := decodepay.Decodepay(invoice)
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
@@ -615,6 +615,9 @@ func (ls *LDKService) SendPaymentSync(invoice string, amountMsat *uint64) (*lncl
 	saturationPower := ls.cfg.GetEnv().LDKMaxChannelSaturationPowerOfHalf
 	maxPathCount := ls.cfg.GetEnv().LDKMaxPathCount
 	maxTotalRoutingFeeMsat := getMaxTotalRoutingFeeLimit(paymentAmountMsat)
+	if maxFeeMsat != nil {
+		maxTotalRoutingFeeMsat = *maxFeeMsat
+	}
 
 	routeParameters := &ldk_node.RouteParametersConfig{
 		MaxTotalRoutingFeeMsat:          &maxTotalRoutingFeeMsat,

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -432,7 +432,7 @@ func (svc *LNDService) Shutdown() error {
 	return nil
 }
 
-func (svc *LNDService) SendPaymentSync(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
+func (svc *LNDService) SendPaymentSync(payReq string, amountMsat *uint64, maxFeeMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
 	const MAX_PARTIAL_PAYMENTS = 16
 
 	paymentRequest, err := decodepay.Decodepay(payReq)
@@ -447,10 +447,14 @@ func (svc *LNDService) SendPaymentSync(payReq string, amountMsat *uint64) (*lncl
 	if amountMsat != nil {
 		paymentAmountMsat = *amountMsat
 	}
+	feeLimitMsat := transactions.CalculateFeeReserveMsat(paymentAmountMsat)
+	if maxFeeMsat != nil {
+		feeLimitMsat = *maxFeeMsat
+	}
 	sendRequest := &routerrpc.SendPaymentRequest{
 		PaymentRequest: payReq,
 		MaxParts:       MAX_PARTIAL_PAYMENTS,
-		FeeLimitMsat:   int64(transactions.CalculateFeeReserveMsat(paymentAmountMsat)),
+		FeeLimitMsat:   int64(feeLimitMsat),
 		TimeoutSeconds: SEND_PAYMENT_TIMEOUT,
 	}
 

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -58,7 +58,7 @@ type NodeConnectionInfo struct {
 }
 
 type LNClient interface {
-	SendPaymentSync(payReq string, amountMsat *uint64) (*PayInvoiceResponse, error)
+	SendPaymentSync(payReq string, amountMsat *uint64, maxFeeMsat *uint64) (*PayInvoiceResponse, error)
 	SendKeysend(amountMsat uint64, destination string, customRecords []TLVRecord, preimage string) (*PayKeysendResponse, error)
 	GetPubkey() string
 	GetInfo(ctx context.Context) (info *NodeInfo, err error)

--- a/lnclient/phoenixd/phoenixd.go
+++ b/lnclient/phoenixd/phoenixd.go
@@ -343,10 +343,13 @@ func (svc *PhoenixService) lookupOutgoingPayment(ctx context.Context, paymentHas
 	return outgoingPaymentToTransaction(&paymentRes)
 }
 
-func (svc *PhoenixService) SendPaymentSync(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
+func (svc *PhoenixService) SendPaymentSync(payReq string, amountMsat *uint64, maxFeeMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
 	// TODO: support 0-amount invoices
 	if amountMsat != nil {
 		return nil, errors.New("0-amount invoices not supported")
+	}
+	if maxFeeMsat != nil {
+		return nil, errors.New("max fee is not supported by the phoenixd backend")
 	}
 	form := url.Values{}
 	form.Add("invoice", payReq)

--- a/nip47/controllers/multi_pay_invoice_controller.go
+++ b/nip47/controllers/multi_pay_invoice_controller.go
@@ -69,7 +69,7 @@ func (controller *nip47Controller) HandleMultiPayInvoiceEvent(ctx context.Contex
 			dTag := []string{"d", invoiceDTagValue}
 
 			controller.
-				pay(bolt11, invoiceInfo.Amount, metadata, &paymentRequest, nip47Request, requestEventId, app, publishResponse, nostr.Tags{dTag})
+				pay(bolt11, invoiceInfo.Amount, invoiceInfo.MaxFee, metadata, &paymentRequest, nip47Request, requestEventId, app, publishResponse, nostr.Tags{dTag})
 		}(invoiceInfo)
 	}
 

--- a/nip47/controllers/pay_invoice_controller.go
+++ b/nip47/controllers/pay_invoice_controller.go
@@ -17,6 +17,7 @@ import (
 type payInvoiceParams struct {
 	Invoice  string                 `json:"invoice"`
 	Amount   *uint64                `json:"amount"`
+	MaxFee   *uint64                `json:"max_fee"`
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
@@ -49,17 +50,18 @@ func (controller *nip47Controller) HandlePayInvoiceEvent(ctx context.Context, ni
 		return
 	}
 
-	controller.pay(bolt11, payParams.Amount, payParams.Metadata, &paymentRequest, nip47Request, requestEventId, app, publishResponse, tags)
+	controller.pay(bolt11, payParams.Amount, payParams.MaxFee, payParams.Metadata, &paymentRequest, nip47Request, requestEventId, app, publishResponse, tags)
 }
 
-func (controller *nip47Controller) pay(bolt11 string, amount *uint64, metadata map[string]interface{}, paymentRequest *decodepay.Bolt11, nip47Request *models.Request, requestEventId uint, app *db.App, publishResponse publishFunc, tags nostr.Tags) {
+func (controller *nip47Controller) pay(bolt11 string, amount *uint64, maxFee *uint64, metadata map[string]interface{}, paymentRequest *decodepay.Bolt11, nip47Request *models.Request, requestEventId uint, app *db.App, publishResponse publishFunc, tags nostr.Tags) {
 	logger.Logger.WithFields(logrus.Fields{
 		"request_event_id": requestEventId,
 		"app_id":           app.ID,
 		"bolt11":           bolt11,
+		"max_fee":          maxFee,
 	}).Info("Sending payment")
 
-	transaction, err := controller.transactionsService.SendPaymentSync(bolt11, amount, metadata, controller.lnClient, &app.ID, &requestEventId)
+	transaction, err := controller.transactionsService.SendPaymentSync(bolt11, amount, maxFee, metadata, controller.lnClient, &app.ID, &requestEventId)
 	if err != nil {
 		logger.Logger.WithFields(logrus.Fields{
 			"request_event_id": requestEventId,

--- a/nip47/controllers/pay_invoice_controller_test.go
+++ b/nip47/controllers/pay_invoice_controller_test.go
@@ -25,6 +25,15 @@ const nip47PayInvoiceJson = `
 	}
 }
 `
+const nip47PayInvoiceMaxFeeJson = `
+{
+	"method": "pay_invoice",
+	"params": {
+		"invoice": "lntbs1230n1pnkqautdqyw3jsnp4q09a0z84kg4a2m38zjllw43h953fx5zvqe8qxfgw694ymkq26u8zcpp5yvnh6hsnlnj4xnuh2trzlnunx732dv8ta2wjr75pdfxf6p2vlyassp5hyeg97a3ft5u769kjwsn7p0e85h79pzz8kladmnqhpcypz2uawjs9qyysgqcqpcxq8zals8sq9yeg2pa9eywkgj50cyzxd5elatujuc0c0wh6j9nat5mn34pgk8u9ufpgs99tw9ldlfk42cqlkr48au3lmuh09269prg4qkggh4a8cyqpfl0y6j",
+		"max_fee": 555000
+	}
+}
+`
 const nip47PayInvoiceZeroAmountJson = `
 {
 	"method": "pay_invoice",
@@ -101,6 +110,48 @@ func TestHandlePayInvoiceEvent(t *testing.T) {
 	err = json.Unmarshal(transaction.Metadata, &decodedMetadata)
 	assert.NoError(t, err)
 	assert.Equal(t, 123, decodedMetadata.A)
+}
+
+func TestHandlePayInvoiceEvent_MaxFee(t *testing.T) {
+	ctx := context.TODO()
+	svc, err := tests.CreateTestService(t)
+	require.NoError(t, err)
+	defer svc.Remove()
+
+	app, _, err := tests.CreateApp(svc)
+	assert.NoError(t, err)
+
+	appPermission := &db.AppPermission{
+		AppId: app.ID,
+		App:   *app,
+		Scope: constants.PAY_INVOICE_SCOPE,
+	}
+	err = svc.DB.Create(appPermission).Error
+	assert.NoError(t, err)
+
+	nip47Request := &models.Request{}
+	err = json.Unmarshal([]byte(nip47PayInvoiceMaxFeeJson), nip47Request)
+	assert.NoError(t, err)
+
+	dbRequestEvent := &db.RequestEvent{}
+	err = svc.DB.Create(&dbRequestEvent).Error
+	assert.NoError(t, err)
+
+	var publishedResponse *models.Response
+
+	publishResponse := func(response *models.Response, tags nostr.Tags) {
+		publishedResponse = response
+	}
+
+	NewTestNip47Controller(svc).
+		HandlePayInvoiceEvent(ctx, nip47Request, dbRequestEvent.ID, app, publishResponse, nostr.Tags{})
+
+	require.NotNil(t, publishedResponse)
+	require.Nil(t, publishedResponse.Error)
+	mockLn, ok := svc.LNClient.(*tests.MockLn)
+	require.True(t, ok)
+	require.NotNil(t, mockLn.LastSendPaymentMaxFeeMsat)
+	assert.Equal(t, uint64(555000), *mockLn.LastSendPaymentMaxFeeMsat)
 }
 
 func TestHandlePayInvoiceEvent_ZeroAmount(t *testing.T) {

--- a/swaps/swaps_service.go
+++ b/swaps/swaps_service.go
@@ -1216,7 +1216,7 @@ func (svc *swapsService) startSwapOutListener(swap *db.Swap) {
 						"swap_id": swap.SwapId,
 					}
 					logger.Logger.WithField("swapId", swap.SwapId).Info("Initiating swap invoice payment")
-					_, err = svc.transactionsService.SendPaymentSync(swap.Invoice, nil, metadata, svc.lnClient, nil, nil)
+					_, err = svc.transactionsService.SendPaymentSync(swap.Invoice, nil, nil, metadata, svc.lnClient, nil, nil)
 					if err != nil {
 						logger.Logger.WithError(err).WithFields(logrus.Fields{
 							"swapId": swap.SwapId,

--- a/tests/mock_ln_client.go
+++ b/tests/mock_ln_client.go
@@ -87,6 +87,8 @@ type MockLn struct {
 	Pubkey                     string
 	MockTransaction            *lnclient.Transaction
 	LastMinCltvExpiryDelta     *uint64
+	LastSendPaymentAmountMsat  *uint64
+	LastSendPaymentMaxFeeMsat  *uint64
 	SupportedNotificationTypes *[]string
 }
 
@@ -94,7 +96,9 @@ func NewMockLn() (*MockLn, error) {
 	return &MockLn{}, nil
 }
 
-func (mln *MockLn) SendPaymentSync(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
+func (mln *MockLn) SendPaymentSync(payReq string, amountMsat *uint64, maxFeeMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
+	mln.LastSendPaymentAmountMsat = amountMsat
+	mln.LastSendPaymentMaxFeeMsat = maxFeeMsat
 	if len(mln.PayInvoiceResponses) > 0 {
 		response := mln.PayInvoiceResponses[0]
 		err := mln.PayInvoiceErrors[0]

--- a/tests/mocks/LNClient.go
+++ b/tests/mocks/LNClient.go
@@ -1875,8 +1875,8 @@ func (_c *MockLNClient_SendKeysend_Call) RunAndReturn(run func(amountMsat uint64
 }
 
 // SendPaymentSync provides a mock function for the type MockLNClient
-func (_mock *MockLNClient) SendPaymentSync(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
-	ret := _mock.Called(payReq, amountMsat)
+func (_mock *MockLNClient) SendPaymentSync(payReq string, amountMsat *uint64, maxFeeMsat *uint64) (*lnclient.PayInvoiceResponse, error) {
+	ret := _mock.Called(payReq, amountMsat, maxFeeMsat)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendPaymentSync")
@@ -1884,18 +1884,18 @@ func (_mock *MockLNClient) SendPaymentSync(payReq string, amountMsat *uint64) (*
 
 	var r0 *lnclient.PayInvoiceResponse
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, *uint64) (*lnclient.PayInvoiceResponse, error)); ok {
-		return returnFunc(payReq, amountMsat)
+	if returnFunc, ok := ret.Get(0).(func(string, *uint64, *uint64) (*lnclient.PayInvoiceResponse, error)); ok {
+		return returnFunc(payReq, amountMsat, maxFeeMsat)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, *uint64) *lnclient.PayInvoiceResponse); ok {
-		r0 = returnFunc(payReq, amountMsat)
+	if returnFunc, ok := ret.Get(0).(func(string, *uint64, *uint64) *lnclient.PayInvoiceResponse); ok {
+		r0 = returnFunc(payReq, amountMsat, maxFeeMsat)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*lnclient.PayInvoiceResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, *uint64) error); ok {
-		r1 = returnFunc(payReq, amountMsat)
+	if returnFunc, ok := ret.Get(1).(func(string, *uint64, *uint64) error); ok {
+		r1 = returnFunc(payReq, amountMsat, maxFeeMsat)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1910,11 +1910,12 @@ type MockLNClient_SendPaymentSync_Call struct {
 // SendPaymentSync is a helper method to define mock.On call
 //   - payReq string
 //   - amountMsat *uint64
-func (_e *MockLNClient_Expecter) SendPaymentSync(payReq interface{}, amountMsat interface{}) *MockLNClient_SendPaymentSync_Call {
-	return &MockLNClient_SendPaymentSync_Call{Call: _e.mock.On("SendPaymentSync", payReq, amountMsat)}
+//   - maxFeeMsat *uint64
+func (_e *MockLNClient_Expecter) SendPaymentSync(payReq interface{}, amountMsat interface{}, maxFeeMsat interface{}) *MockLNClient_SendPaymentSync_Call {
+	return &MockLNClient_SendPaymentSync_Call{Call: _e.mock.On("SendPaymentSync", payReq, amountMsat, maxFeeMsat)}
 }
 
-func (_c *MockLNClient_SendPaymentSync_Call) Run(run func(payReq string, amountMsat *uint64)) *MockLNClient_SendPaymentSync_Call {
+func (_c *MockLNClient_SendPaymentSync_Call) Run(run func(payReq string, amountMsat *uint64, maxFeeMsat *uint64)) *MockLNClient_SendPaymentSync_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -1924,9 +1925,14 @@ func (_c *MockLNClient_SendPaymentSync_Call) Run(run func(payReq string, amountM
 		if args[1] != nil {
 			arg1 = args[1].(*uint64)
 		}
+		var arg2 *uint64
+		if args[2] != nil {
+			arg2 = args[2].(*uint64)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -1937,7 +1943,7 @@ func (_c *MockLNClient_SendPaymentSync_Call) Return(payInvoiceResponse *lnclient
 	return _c
 }
 
-func (_c *MockLNClient_SendPaymentSync_Call) RunAndReturn(run func(payReq string, amountMsat *uint64) (*lnclient.PayInvoiceResponse, error)) *MockLNClient_SendPaymentSync_Call {
+func (_c *MockLNClient_SendPaymentSync_Call) RunAndReturn(run func(payReq string, amountMsat *uint64, maxFeeMsat *uint64) (*lnclient.PayInvoiceResponse, error)) *MockLNClient_SendPaymentSync_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/transactions/app_payments_test.go
+++ b/transactions/app_payments_test.go
@@ -25,7 +25,7 @@ func TestSendPaymentSync_App_NoPermission(t *testing.T) {
 	assert.NoError(t, err)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.Equal(t, "app does not have pay_invoice scope", err.Error())
@@ -52,7 +52,7 @@ func TestSendPaymentSync_App_WithPermission(t *testing.T) {
 	assert.NoError(t, err)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -130,7 +130,7 @@ func TestSendPaymentSync_App_BudgetExceeded(t *testing.T) {
 	svc.EventPublisher.RegisterSubscriber(mockEventConsumer)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, NewQuotaExceededError())
@@ -176,7 +176,7 @@ func TestSendPaymentSync_App_BudgetExceeded_SettledPayment(t *testing.T) {
 	assert.NoError(t, err)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, NewQuotaExceededError())
@@ -213,7 +213,7 @@ func TestSendPaymentSync_App_BudgetExceeded_UnsettledPayment(t *testing.T) {
 	assert.NoError(t, err)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, NewQuotaExceededError())
@@ -251,7 +251,7 @@ func TestSendPaymentSync_App_BudgetNotExceeded_FailedPayment(t *testing.T) {
 	assert.NoError(t, err)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)

--- a/transactions/isolated_app_payments_test.go
+++ b/transactions/isolated_app_payments_test.go
@@ -34,7 +34,7 @@ func TestSendPaymentSync_IsolatedApp_NoBalance(t *testing.T) {
 	assert.NoError(t, err)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, NewInsufficientBalanceError())
@@ -74,7 +74,7 @@ func TestSendPaymentSync_IsolatedApp_BalanceInsufficient(t *testing.T) {
 	svc.EventPublisher.RegisterSubscriber(mockEventConsumer)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, NewInsufficientBalanceError())
@@ -119,7 +119,7 @@ func TestSendPaymentSync_IsolatedApp_BalanceSufficient(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -166,7 +166,7 @@ func TestSendPaymentSync_IsolatedApp_BalanceInsufficient_OutstandingPayment(t *t
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, NewInsufficientBalanceError())
@@ -210,7 +210,7 @@ func TestSendPaymentSync_IsolatedApp_BalanceInsufficient_SettledPayment(t *testi
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, NewInsufficientBalanceError())
@@ -253,7 +253,7 @@ func TestSendPaymentSync_IsolatedApp_BalanceSufficient_UnrelatedPayment(t *testi
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -299,7 +299,7 @@ func TestSendPaymentSync_IsolatedApp_BalanceSufficient_FailedPayment(t *testing.
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -339,7 +339,7 @@ func TestSendPaymentSync_IsolatedApp_BalanceInsufficientThenSufficient(t *testin
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, NewInsufficientBalanceError())
@@ -352,7 +352,7 @@ func TestSendPaymentSync_IsolatedApp_BalanceInsufficientThenSufficient(t *testin
 		AmountMsat: 10000, // add extra to cover fee reserves max of(10 sats or 1%)
 	})
 
-	transaction, err = transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err = transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)

--- a/transactions/payments_test.go
+++ b/transactions/payments_test.go
@@ -30,7 +30,7 @@ func TestSendPaymentSync_NoApp(t *testing.T) {
 	}
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, metadata, svc.LNClient, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, metadata, svc.LNClient, nil, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -47,6 +47,24 @@ func TestSendPaymentSync_NoApp(t *testing.T) {
 	assert.Equal(t, 123, decodedMetadata.A)
 }
 
+func TestSendPaymentSync_WithMaxFee(t *testing.T) {
+	svc, err := tests.CreateTestService(t)
+	require.NoError(t, err)
+	defer svc.Remove()
+
+	maxFeeMsat := uint64(555000)
+
+	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, &maxFeeMsat, nil, svc.LNClient, nil, nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, constants.TRANSACTION_STATE_SETTLED, transaction.State)
+	mockLn, ok := svc.LNClient.(*tests.MockLn)
+	require.True(t, ok)
+	require.NotNil(t, mockLn.LastSendPaymentMaxFeeMsat)
+	assert.Equal(t, maxFeeMsat, *mockLn.LastSendPaymentMaxFeeMsat)
+}
+
 func TestSendPaymentSync_ZeroAmount(t *testing.T) {
 	svc, err := tests.CreateTestService(t)
 	require.NoError(t, err)
@@ -58,7 +76,7 @@ func TestSendPaymentSync_ZeroAmount(t *testing.T) {
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
 	amount := uint64(1234)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockZeroAmountInvoice, &amount, metadata, svc.LNClient, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockZeroAmountInvoice, &amount, nil, metadata, svc.LNClient, nil, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, amount, transaction.AmountMsat)
@@ -78,7 +96,7 @@ func TestSendPaymentSync_AmountOnNonZeroAmountInvoice(t *testing.T) {
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
 	amount := uint64(1234)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, &amount, metadata, svc.LNClient, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, &amount, nil, metadata, svc.LNClient, nil, nil)
 
 	assert.NoError(t, err)
 	// amount is from the invoice, not what was specified
@@ -97,7 +115,7 @@ func TestSendPaymentSync_MetadataTooLarge(t *testing.T) {
 	metadata["randomkey"] = strings.Repeat("a", constants.INVOICE_METADATA_MAX_LENGTH-15) // json encoding adds 16 characters
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, metadata, svc.LNClient, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, metadata, svc.LNClient, nil, nil)
 
 	assert.Error(t, err)
 	assert.Equal(t, fmt.Sprintf("encoded payment metadata provided is too large. Limit: %d Received: %d", constants.INVOICE_METADATA_MAX_LENGTH, constants.INVOICE_METADATA_MAX_LENGTH+1), err.Error())
@@ -118,7 +136,7 @@ func TestSendPaymentSync_Duplicate_AlreadyPaid(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, nil, nil)
 
 	assert.Error(t, err)
 	assert.Equal(t, "this invoice has already been paid", err.Error())
@@ -139,7 +157,7 @@ func TestSendPaymentSync_Duplicate_Pending(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, nil, nil)
 
 	assert.Error(t, err)
 	assert.Equal(t, "there is already a payment pending for this invoice", err.Error())
@@ -159,7 +177,7 @@ func TestSendPaymentSync_Duplicate_Failed(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	_, err = transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, nil, nil)
+	_, err = transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, nil, nil)
 
 	assert.NoError(t, err)
 }
@@ -389,7 +407,7 @@ func TestSendPaymentSync_FailedRemovesFeeReserve(t *testing.T) {
 	svc.EventPublisher.RegisterSubscriber(mockEventConsumer)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, nil, nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, transaction)
@@ -419,7 +437,7 @@ func TestSendPaymentSync_PendingHasFeeReserve(t *testing.T) {
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
 	go func() {
-		transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, nil, nil)
+		transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, nil, nil)
 	}()
 	// ensure the goroutine above runs first
 	time.Sleep(10 * time.Millisecond)
@@ -444,7 +462,7 @@ func TestConsumeEvent_FailedMarkedAsSuccessful(t *testing.T) {
 	svc.LNClient.(*tests.MockLn).PayInvoiceErrors = append(svc.LNClient.(*tests.MockLn).PayInvoiceErrors, errors.New("some error"))
 	svc.LNClient.(*tests.MockLn).PayInvoiceResponses = append(svc.LNClient.(*tests.MockLn).PayInvoiceResponses, nil)
 
-	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, svc.LNClient, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockLNClientTransaction.Invoice, nil, nil, nil, svc.LNClient, nil, nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, transaction)

--- a/transactions/self_hold_payments_test.go
+++ b/transactions/self_hold_payments_test.go
@@ -37,7 +37,7 @@ func TestSelfHoldPaymentSettled(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		result, err := transactionsService.SendPaymentSync(transaction.PaymentRequest, nil, nil, svc.LNClient, nil, nil)
+		result, err := transactionsService.SendPaymentSync(transaction.PaymentRequest, nil, nil, nil, svc.LNClient, nil, nil)
 		assert.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Equal(t, constants.TRANSACTION_STATE_SETTLED, result.State)
@@ -75,7 +75,7 @@ func TestSelfHoldPaymentCanceled(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		result, err := transactionsService.SendPaymentSync(transaction.PaymentRequest, nil, nil, svc.LNClient, nil, nil)
+		result, err := transactionsService.SendPaymentSync(transaction.PaymentRequest, nil, nil, nil, svc.LNClient, nil, nil)
 		assert.ErrorIs(t, err, lnclient.NewHoldInvoiceCanceledError())
 		assert.Nil(t, result)
 
@@ -245,7 +245,7 @@ func TestWrappedInvoice(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		result, err := transactionsService.SendPaymentSync(bobWrappedInvoice.PaymentRequest, nil, nil, svc.LNClient, &aliceApp.ID, nil)
+		result, err := transactionsService.SendPaymentSync(bobWrappedInvoice.PaymentRequest, nil, nil, nil, svc.LNClient, &aliceApp.ID, nil)
 		assert.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Equal(t, constants.TRANSACTION_STATE_SETTLED, result.State)
@@ -256,7 +256,7 @@ func TestWrappedInvoice(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Bob pays Charlie's invoice to get the preimage
-	result, err := transactionsService.SendPaymentSync(charlieInvoice.PaymentRequest, nil, nil, svc.LNClient, &bobApp.ID, nil)
+	result, err := transactionsService.SendPaymentSync(charlieInvoice.PaymentRequest, nil, nil, nil, svc.LNClient, &bobApp.ID, nil)
 	assert.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, constants.TRANSACTION_STATE_SETTLED, result.State)

--- a/transactions/self_payment_detection_test.go
+++ b/transactions/self_payment_detection_test.go
@@ -29,7 +29,7 @@ func TestSendPaymentSync_SelfPaymentDetection_WithIncomingTransaction(t *testing
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, svc.LNClient, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, nil, svc.LNClient, nil, nil)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, transaction)
@@ -58,7 +58,7 @@ func TestSendPaymentSync_SelfPaymentDetection_WithoutIncomingTransaction(t *test
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, svc.LNClient, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, nil, svc.LNClient, nil, nil)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, transaction)
@@ -90,7 +90,7 @@ func TestSendPaymentSync_SelfPaymentDetection_DifferentPubkey(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, svc.LNClient, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, nil, svc.LNClient, nil, nil)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, transaction)

--- a/transactions/self_payments_test.go
+++ b/transactions/self_payments_test.go
@@ -34,7 +34,7 @@ func TestSendPaymentSync_SelfPayment_NoAppToNoApp(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, svc.LNClient, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, nil, svc.LNClient, nil, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -86,7 +86,7 @@ func TestSendPaymentSync_SelfPayment_NoAppToIsolatedApp(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, svc.LNClient, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, nil, svc.LNClient, nil, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -141,7 +141,7 @@ func TestSendPaymentSync_SelfPayment_NoAppToApp(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, svc.LNClient, nil, nil)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, nil, svc.LNClient, nil, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -210,7 +210,7 @@ func TestSendPaymentSync_SelfPayment_IsolatedAppToNoApp(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -287,7 +287,7 @@ func TestSendPaymentSync_SelfPayment_IsolatedAppToApp(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -371,7 +371,7 @@ func TestSendPaymentSync_SelfPayment_IsolatedAppToIsolatedApp(t *testing.T) {
 	svc.EventPublisher.RegisterSubscriber(mockEventConsumer)
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -465,7 +465,7 @@ func TestSendPaymentSync_SelfPayment_IsolatedAppToSelf(t *testing.T) {
 	})
 
 	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, nil, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)
@@ -547,7 +547,7 @@ func TestSendPaymentSync_SelfPayment_IsolatedAppToApp_AmountProvidedIgnoredOnNon
 
 	// this amount is wrong, it will just be ignored
 	amountMsat := uint64(1000)
-	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, &amountMsat, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
+	transaction, err := transactionsService.SendPaymentSync(tests.MockInvoice, &amountMsat, nil, nil, svc.LNClient, &app.ID, &dbRequestEvent.ID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(123000), transaction.AmountMsat)

--- a/transactions/transactions_service.go
+++ b/transactions/transactions_service.go
@@ -40,7 +40,7 @@ type TransactionsService interface {
 	MakeInvoice(ctx context.Context, amountMsat uint64, description string, descriptionHash string, expiry uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint, throughNodePubkey *string) (*Transaction, error)
 	LookupTransaction(ctx context.Context, paymentHash string, transactionType *string, lnClient lnclient.LNClient, appId *uint) (*Transaction, error)
 	ListTransactions(ctx context.Context, from, until, limit, offset uint64, unpaidOutgoing bool, unpaidIncoming bool, lnClient lnclient.LNClient, appId *uint, forceFilterByAppId bool, filters *ListTransactionsFilters) (transactions []Transaction, totalCount uint64, err error)
-	SendPaymentSync(payReq string, amountMsat *uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error)
+	SendPaymentSync(payReq string, amountMsat *uint64, maxFeeMsat *uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error)
 	SendKeysend(amountMsat uint64, destination string, customRecords []lnclient.TLVRecord, preimage string, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error)
 	MakeHoldInvoice(ctx context.Context, amountMsat uint64, description string, descriptionHash string, expiry uint64, paymentHash string, minCltvExpiryDelta *uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error)
 	SettleHoldInvoice(ctx context.Context, preimage string, lnClient lnclient.LNClient) (*Transaction, error)
@@ -298,7 +298,7 @@ func (svc *transactionsService) MakeHoldInvoice(ctx context.Context, amountMsat 
 	return &dbTransaction, nil
 }
 
-func (svc *transactionsService) SendPaymentSync(payReq string, amountMsat *uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error) {
+func (svc *transactionsService) SendPaymentSync(payReq string, amountMsat *uint64, maxFeeMsat *uint64, metadata map[string]interface{}, lnClient lnclient.LNClient, appId *uint, requestEventId *uint) (*Transaction, error) {
 	var metadataBytes []byte
 	if metadata != nil {
 		var err error
@@ -436,7 +436,7 @@ func (svc *transactionsService) SendPaymentSync(payReq string, amountMsat *uint6
 	if selfPayment {
 		response, err = svc.interceptSelfPayment(payReq, paymentRequest.PaymentHash, lnClient)
 	} else {
-		response, err = lnClient.SendPaymentSync(payReq, amountMsat)
+		response, err = lnClient.SendPaymentSync(payReq, amountMsat, maxFeeMsat)
 	}
 
 	if err != nil {

--- a/wails/wails_handlers.go
+++ b/wails/wails_handlers.go
@@ -380,7 +380,7 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			}
 		}
 		amountMsat := api.ResolveToMsat(payRequest.AmountSat, payRequest.AmountMsat, nil, payRequest.Amount)
-		paymentResponse, err := app.api.SendPayment(ctx, invoice, amountMsat, payRequest.Metadata, payRequest.FromAppID)
+		paymentResponse, err := app.api.SendPayment(ctx, invoice, amountMsat, payRequest.MaxFeeMsat, payRequest.Metadata, payRequest.FromAppID)
 		if err != nil {
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}


### PR DESCRIPTION
relates #2557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional maximum-fee setting for invoice payments.
  - Payment requests can now specify a fee limit through supported payment interfaces.
  - Supported Lightning backends enforce the requested fee cap where available.

- **Compatibility**
  - Backends without maximum-fee support clearly reject requests that use this option.

- **Tests**
  - Added coverage verifying maximum-fee values are forwarded and enforced correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->