### PR TITLE
feat: add extensions field to the NWC event info

### DIFF
--- a/nip47/controllers/get_info_controller.go
+++ b/nip47/controllers/get_info_controller.go
@@ -21,6 +21,7 @@ type getInfoResponse struct {
 	BlockHash        *string     `json:"block_hash"`
 	Methods          []string    `json:"methods"`
 	Notifications    []string    `json:"notifications"`
+	Extensions       []string    `json:"extensions,omitempty"`
 	Metadata         interface{} `json:"metadata,omitempty"`
 	LightningAddress *string     `json:"lud16"`
 }
@@ -31,9 +32,11 @@ func (controller *nip47Controller) HandleGetInfoEvent(ctx context.Context, nip47
 		supportedNotifications = controller.lnClient.GetSupportedNIP47NotificationTypes()
 	}
 
+	methods := controller.permissionsService.GetPermittedMethods(app, controller.lnClient)
 	responsePayload := &getInfoResponse{
-		Methods:       controller.permissionsService.GetPermittedMethods(app, controller.lnClient),
+		Methods:       methods,
 		Notifications: supportedNotifications,
+		Extensions:    models.GetSupportedExtensions(methods, supportedNotifications),
 	}
 
 	if app != nil {

--- a/nip47/controllers/get_info_controller_test.go
+++ b/nip47/controllers/get_info_controller_test.go
@@ -79,6 +79,7 @@ func TestHandleGetInfoEvent_NoPermission(t *testing.T) {
 	// get_info method is always granted, but does not return pubkey
 	assert.Contains(t, infoResponse.Methods, models.GET_INFO_METHOD)
 	assert.Equal(t, []string{}, infoResponse.Notifications)
+	assert.Equal(t, []string{models.METADATA_EXTENSION}, infoResponse.Extensions)
 	require.NotNil(t, infoResponse.Metadata)
 	assert.Equal(t, float64(123), infoResponse.Metadata.(map[string]interface{})["a"])
 	assert.Equal(t, app.ID, infoResponse.Metadata.(map[string]interface{})["id"])
@@ -360,4 +361,5 @@ func TestHandleGetInfoEvent_WithNotifications(t *testing.T) {
 	assert.Equal(t, tests.MockNodeInfo.BlockHash, *infoResponse.BlockHash)
 	assert.Contains(t, infoResponse.Methods, "get_info")
 	assert.Equal(t, []string{"payment_received", "payment_sent"}, infoResponse.Notifications)
+	assert.Equal(t, []string{models.NOTIFICATIONS_EXTENSION, models.METADATA_EXTENSION}, infoResponse.Extensions)
 }

--- a/nip47/models/models.go
+++ b/nip47/models/models.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"slices"
 )
 
 const (
@@ -28,6 +29,40 @@ const (
 	CANCEL_HOLD_INVOICE_METHOD = "cancel_hold_invoice"
 	SETTLE_HOLD_INVOICE_METHOD = "settle_hold_invoice"
 )
+
+// NWC extension identifiers, see https://github.com/nostr-wallet-connect/nwc
+const (
+	NOTIFICATIONS_EXTENSION       = "02"
+	HOLD_INVOICES_EXTENSION       = "03"
+	KEYSEND_EXTENSION             = "04"
+	TRANSACTION_HISTORY_EXTENSION = "05"
+	METADATA_EXTENSION            = "06"
+)
+
+// GetSupportedExtensions returns the optional NWC extension specs supported for a
+// connection with the given permitted methods and notification types.
+func GetSupportedExtensions(methods []string, notificationTypes []string) []string {
+	extensions := []string{}
+	if len(notificationTypes) > 0 {
+		extensions = append(extensions, NOTIFICATIONS_EXTENSION)
+	}
+	if slices.Contains(methods, MAKE_HOLD_INVOICE_METHOD) &&
+		slices.Contains(methods, CANCEL_HOLD_INVOICE_METHOD) &&
+		slices.Contains(methods, SETTLE_HOLD_INVOICE_METHOD) {
+		extensions = append(extensions, HOLD_INVOICES_EXTENSION)
+	}
+	if slices.Contains(methods, PAY_KEYSEND_METHOD) || slices.Contains(methods, MULTI_PAY_KEYSEND_METHOD) {
+		extensions = append(extensions, KEYSEND_EXTENSION)
+	}
+	if slices.Contains(methods, LIST_TRANSACTIONS_METHOD) {
+		extensions = append(extensions, TRANSACTION_HISTORY_EXTENSION)
+	}
+	// NWC-06 metadata conventions are always supported: metadata is accepted by
+	// pay_invoice / make_invoice / make_hold_invoice and returned by
+	// lookup_invoice / list_transactions.
+	extensions = append(extensions, METADATA_EXTENSION)
+	return extensions
+}
 
 type Transaction struct {
 	Type            string      `json:"type"`

--- a/nip47/models/models_test.go
+++ b/nip47/models/models_test.go
@@ -1,0 +1,77 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSupportedExtensions(t *testing.T) {
+	tests := []struct {
+		name              string
+		methods           []string
+		notificationTypes []string
+		expected          []string
+	}{
+		{
+			name:     "core methods only always support metadata conventions",
+			methods:  []string{GET_INFO_METHOD, GET_BALANCE_METHOD},
+			expected: []string{METADATA_EXTENSION},
+		},
+		{
+			name:              "notifications permission advertises notifications extension",
+			methods:           []string{GET_INFO_METHOD},
+			notificationTypes: []string{"payment_received", "payment_sent"},
+			expected:          []string{NOTIFICATIONS_EXTENSION, METADATA_EXTENSION},
+		},
+		{
+			name: "hold invoice methods advertise hold invoice extension",
+			methods: []string{
+				MAKE_HOLD_INVOICE_METHOD, CANCEL_HOLD_INVOICE_METHOD, SETTLE_HOLD_INVOICE_METHOD,
+			},
+			expected: []string{HOLD_INVOICES_EXTENSION, METADATA_EXTENSION},
+		},
+		{
+			name:     "partial hold invoice methods do not advertise hold invoice extension",
+			methods:  []string{MAKE_HOLD_INVOICE_METHOD, CANCEL_HOLD_INVOICE_METHOD},
+			expected: []string{METADATA_EXTENSION},
+		},
+		{
+			name:     "pay_keysend advertises keysend extension",
+			methods:  []string{PAY_KEYSEND_METHOD},
+			expected: []string{KEYSEND_EXTENSION, METADATA_EXTENSION},
+		},
+		{
+			name:     "multi_pay_keysend advertises keysend extension",
+			methods:  []string{MULTI_PAY_KEYSEND_METHOD},
+			expected: []string{KEYSEND_EXTENSION, METADATA_EXTENSION},
+		},
+		{
+			name:     "list_transactions advertises transaction history extension",
+			methods:  []string{LIST_TRANSACTIONS_METHOD},
+			expected: []string{TRANSACTION_HISTORY_EXTENSION, METADATA_EXTENSION},
+		},
+		{
+			name: "all capabilities advertise all extensions in numerical order",
+			methods: []string{
+				MAKE_HOLD_INVOICE_METHOD, CANCEL_HOLD_INVOICE_METHOD, SETTLE_HOLD_INVOICE_METHOD,
+				PAY_KEYSEND_METHOD,
+				LIST_TRANSACTIONS_METHOD,
+			},
+			notificationTypes: []string{"payment_received"},
+			expected: []string{
+				NOTIFICATIONS_EXTENSION,
+				HOLD_INVOICES_EXTENSION,
+				KEYSEND_EXTENSION,
+				TRANSACTION_HISTORY_EXTENSION,
+				METADATA_EXTENSION,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GetSupportedExtensions(tt.methods, tt.notificationTypes))
+		})
+	}
+}

--- a/nip47/publish_nip47_info.go
+++ b/nip47/publish_nip47_info.go
@@ -84,9 +84,16 @@ func (svc *nip47Service) PublishNip47Info(ctx context.Context, pool nostrmodels.
 		// NWA: associate the info event with the app so that the app can receive the wallet pubkey
 		tags = append(tags, []string{"p", app.AppPubkey})
 	}
-	if permitsNotifications && len(lnClient.GetSupportedNIP47NotificationTypes()) > 0 {
+	var notificationTypes []string
+	if permitsNotifications {
+		notificationTypes = lnClient.GetSupportedNIP47NotificationTypes()
+	}
+	if len(notificationTypes) > 0 {
 		capabilities = append(capabilities, "notifications")
-		tags = append(tags, []string{"notifications", strings.Join(lnClient.GetSupportedNIP47NotificationTypes(), " ")})
+		tags = append(tags, []string{"notifications", strings.Join(notificationTypes, " ")})
+	}
+	if extensions := models.GetSupportedExtensions(capabilities, notificationTypes); len(extensions) > 0 {
+		tags = append(tags, []string{"extensions", strings.Join(extensions, " ")})
 	}
 
 	ev := &nostr.Event{}


### PR DESCRIPTION
fixes #2555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NWC connection information now reports supported protocol extensions.
  * Advertised capabilities include notifications, hold invoices, keysend, transaction history, and metadata when applicable.
  * Published connection information now includes supported notification types and extension details.

* **Bug Fixes**
  * Improved capability reporting so extensions are advertised only when the required permissions are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->