### PR TITLE
fix: include static channel backups in node migration file

### DIFF
--- a/api/backup.go
+++ b/api/backup.go
@@ -21,7 +21,6 @@ import (
 	"github.com/getAlby/hub/config"
 	"github.com/getAlby/hub/db"
 	"github.com/getAlby/hub/logger"
-	"github.com/getAlby/hub/utils"
 	"golang.org/x/crypto/pbkdf2"
 )
 
@@ -174,18 +173,38 @@ func (api *api) CreateBackup(unlockPassword string, w io.Writer) error {
 	var filesToArchive []string
 
 	if lnStorageDir != "" {
-		lnFiles, err := filepath.Glob(filepath.Join(workDir, lnStorageDir, "*"))
+		// Files are stored in the archive relative to the workdir, so the
+		// storage directory must be located inside it.
+		lnStorageDir, err = filepath.Abs(lnStorageDir)
+		if err != nil {
+			return fmt.Errorf("failed to get absolute LNClient storage directory: %w", err)
+		}
+		if relStorageDir, err := filepath.Rel(workDir, lnStorageDir); err != nil || !filepath.IsLocal(relStorageDir) {
+			return fmt.Errorf("LNClient storage directory %q is not inside the workdir %q", lnStorageDir, workDir)
+		}
+
+		// Archive the whole storage tree: backends may keep state in
+		// subdirectories (e.g. LDK's static channel backups next to its node
+		// storage).
+		err = filepath.WalkDir(lnStorageDir, func(path string, d os.DirEntry, err error) error {
+			if errors.Is(err, os.ErrNotExist) {
+				// nothing to archive if the storage directory does not exist
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			// Avoid backing up log files.
+			if d.IsDir() || filepath.Ext(path) == ".log" {
+				return nil
+			}
+			filesToArchive = append(filesToArchive, path)
+			return nil
+		})
 		if err != nil {
 			return fmt.Errorf("failed to list files in the LNClient storage directory: %w", err)
 		}
-		logger.Logger.WithField("lnFiles", lnFiles).Info("Listed node storage dir")
-
-		// Avoid backing up log files.
-		lnFiles = utils.Filter(lnFiles, func(s string) bool {
-			return filepath.Ext(s) != ".log"
-		})
-
-		filesToArchive = append(filesToArchive, lnFiles...)
+		logger.Logger.WithField("lnFiles", filesToArchive).Info("Listed node storage dir")
 	}
 
 	cw, err := encryptingWriter(w, unlockPassword)

--- a/api/backup.go
+++ b/api/backup.go
@@ -194,8 +194,16 @@ func (api *api) CreateBackup(unlockPassword string, w io.Writer) error {
 			if err != nil {
 				return err
 			}
+			if d.IsDir() {
+				return nil
+			}
+			// Only regular files are expected: symlinks could point outside the
+			// storage directory and special files cannot be copied.
+			if !d.Type().IsRegular() {
+				return fmt.Errorf("unexpected non-regular file %q", path)
+			}
 			// Avoid backing up log files.
-			if d.IsDir() || filepath.Ext(path) == ".log" {
+			if filepath.Ext(path) == ".log" {
 				return nil
 			}
 			filesToArchive = append(filesToArchive, path)

--- a/api/backup_test.go
+++ b/api/backup_test.go
@@ -91,6 +91,10 @@ func TestCreateBackup(t *testing.T) {
 	zr, err := zip.NewReader(bytes.NewReader(decrypted), int64(len(decrypted)))
 	require.NoError(t, err)
 
+	// A backend without a storage directory contributes nothing but the
+	// database to the archive.
+	require.Len(t, zr.File, 1)
+
 	dbFile, err := zr.Open("nwc.db")
 	require.NoError(t, err)
 	dbContents, err := io.ReadAll(dbFile)
@@ -110,6 +114,81 @@ func TestCreateBackup(t *testing.T) {
 	require.NoError(t, restoredDB.First(&restoredApp).Error)
 	require.Equal(t, app.Name, restoredApp.Name)
 	require.Equal(t, app.AppPubkey, restoredApp.AppPubkey)
+}
+
+// TestCreateBackupArchivesStorageDirRecursively verifies that the whole
+// LNClient storage directory tree is archived (e.g. LDK node storage and the
+// static channel backups next to it), excluding log files at any depth.
+func TestCreateBackupArchivesStorageDirRecursively(t *testing.T) {
+	logger.Init(strconv.Itoa(int(logrus.DebugLevel)))
+
+	workDir := t.TempDir()
+
+	gormDB, err := test_db.NewDB(t)
+	require.NoError(t, err)
+	defer test_db.CloseDB(gormDB)
+
+	appConfig := &config.AppConfig{
+		Workdir:     workDir,
+		DatabaseUri: test_db.GetTestDatabaseURI(),
+	}
+	cfg, err := config.NewConfig(appConfig, gormDB)
+	require.NoError(t, err)
+
+	unlockPassword := ""
+	require.NoError(t, cfg.SaveUnlockPasswordCheck(unlockPassword))
+
+	storageDir := filepath.Join(workDir, "ldk", "storage")
+	require.NoError(t, os.MkdirAll(storageDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(storageDir, "node.db"), []byte("node data"), 0600))
+
+	scbDir := filepath.Join(workDir, "ldk", "static_channel_backups")
+	require.NoError(t, os.MkdirAll(scbDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(scbDir, "2024-01-02T03-04-05.json"), []byte("{}"), 0600))
+
+	logsDir := filepath.Join(workDir, "ldk", "logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "ldk_node_2024_01_02.log"), []byte("log"), 0600))
+
+	lnClient := mocks.NewMockLNClient(t)
+	lnClient.On("GetStorageDir").Return(filepath.Join(workDir, "ldk"), nil)
+	lnClient.On("ResetRouter", "ALL").Return(nil)
+
+	svc := mocks.NewMockService(t)
+	svc.On("GetLNClient").Return(lnClient)
+	svc.On("StopApp").Return(nil)
+
+	albyOAuthSvc := mocks.NewMockAlbyOAuthService(t)
+	albyOAuthSvc.On("RemoveOAuthAccessToken").Return(nil)
+
+	theAPI := &api{
+		db:           gormDB,
+		cfg:          cfg,
+		svc:          svc,
+		albyOAuthSvc: albyOAuthSvc,
+	}
+
+	var buf bytes.Buffer
+	err = theAPI.CreateBackup(unlockPassword, &buf)
+	require.NoError(t, err)
+
+	cr, err := decryptingReader(&buf, unlockPassword)
+	require.NoError(t, err)
+	decrypted, err := io.ReadAll(cr)
+	require.NoError(t, err)
+
+	zr, err := zip.NewReader(bytes.NewReader(decrypted), int64(len(decrypted)))
+	require.NoError(t, err)
+
+	entryNames := make([]string, 0, len(zr.File))
+	for _, f := range zr.File {
+		entryNames = append(entryNames, f.Name)
+	}
+	require.ElementsMatch(t, []string{
+		"nwc.db",
+		"ldk/storage/node.db",
+		"ldk/static_channel_backups/2024-01-02T03-04-05.json",
+	}, entryNames)
 }
 
 // TestRestoreBackupRejectsPathTraversal verifies that a backup archive

--- a/api/backup_test.go
+++ b/api/backup_test.go
@@ -23,17 +23,19 @@ import (
 	"github.com/getAlby/hub/tests/mocks"
 )
 
-// TestCreateBackup creates a backup from the test database (sqlite by
-// default, postgres when TEST_DATABASE_URI is set) and verifies that the
-// archive contains a valid sqlite database with the expected data.
-func TestCreateBackup(t *testing.T) {
-	logger.Init(strconv.Itoa(int(logrus.DebugLevel)))
+// backupTestUnlockPassword is the unlock password of the hubs set up by
+// newBackupTestAPI.
+const backupTestUnlockPassword = ""
 
-	workDir := t.TempDir()
+// newBackupTestAPI sets up a fully set-up hub on the test database (sqlite
+// by default, postgres when TEST_DATABASE_URI is set) whose LNClient reports
+// the given storage directory.
+func newBackupTestAPI(t *testing.T, workDir string, storageDir string) *api {
+	logger.Init(strconv.Itoa(int(logrus.DebugLevel)))
 
 	gormDB, err := test_db.NewDB(t)
 	require.NoError(t, err)
-	defer test_db.CloseDB(gormDB)
+	t.Cleanup(func() { test_db.CloseDB(gormDB) })
 
 	appConfig := &config.AppConfig{
 		Workdir:     workDir,
@@ -42,21 +44,12 @@ func TestCreateBackup(t *testing.T) {
 	cfg, err := config.NewConfig(appConfig, gormDB)
 	require.NoError(t, err)
 
-	unlockPassword := ""
-
 	// Represent a fully set-up hub: the unlock-password canary is written during
 	// setup and is required for the password check to pass.
-	require.NoError(t, cfg.SaveUnlockPasswordCheck(unlockPassword))
-
-	app := &db.App{
-		Name:      "test",
-		AppPubkey: "2b7dea2866958f17c568cf024e113db7a3baa9c253a9016889196b8d0b11c7ae",
-		Metadata:  datatypes.JSON("{}"),
-	}
-	require.NoError(t, gormDB.Create(app).Error)
+	require.NoError(t, cfg.SaveUnlockPasswordCheck(backupTestUnlockPassword))
 
 	lnClient := mocks.NewMockLNClient(t)
-	lnClient.On("GetStorageDir").Return("", nil)
+	lnClient.On("GetStorageDir").Return(storageDir, nil)
 	lnClient.On("ResetRouter", "ALL").Return(nil)
 
 	svc := mocks.NewMockService(t)
@@ -66,15 +59,48 @@ func TestCreateBackup(t *testing.T) {
 	albyOAuthSvc := mocks.NewMockAlbyOAuthService(t)
 	albyOAuthSvc.On("RemoveOAuthAccessToken").Return(nil)
 
-	theAPI := &api{
+	return &api{
 		db:           gormDB,
 		cfg:          cfg,
 		svc:          svc,
 		albyOAuthSvc: albyOAuthSvc,
 	}
+}
+
+// zipEntryNames decrypts a backup created by CreateBackup and returns the
+// names of the archive entries.
+func zipEntryNames(t *testing.T, backup *bytes.Buffer) []string {
+	cr, err := decryptingReader(backup, backupTestUnlockPassword)
+	require.NoError(t, err)
+	decrypted, err := io.ReadAll(cr)
+	require.NoError(t, err)
+
+	zr, err := zip.NewReader(bytes.NewReader(decrypted), int64(len(decrypted)))
+	require.NoError(t, err)
+
+	entryNames := make([]string, 0, len(zr.File))
+	for _, f := range zr.File {
+		entryNames = append(entryNames, f.Name)
+	}
+	return entryNames
+}
+
+// TestCreateBackup creates a backup from the test database and verifies that
+// the archive contains a valid sqlite database with the expected data.
+func TestCreateBackup(t *testing.T) {
+	workDir := t.TempDir()
+	theAPI := newBackupTestAPI(t, workDir, "")
+	unlockPassword := backupTestUnlockPassword
+
+	app := &db.App{
+		Name:      "test",
+		AppPubkey: "2b7dea2866958f17c568cf024e113db7a3baa9c253a9016889196b8d0b11c7ae",
+		Metadata:  datatypes.JSON("{}"),
+	}
+	require.NoError(t, theAPI.db.Create(app).Error)
 
 	var buf bytes.Buffer
-	err = theAPI.CreateBackup(unlockPassword, &buf)
+	err := theAPI.CreateBackup(unlockPassword, &buf)
 	require.NoError(t, err)
 
 	// The temporary database created when converting from postgres must
@@ -120,23 +146,8 @@ func TestCreateBackup(t *testing.T) {
 // LNClient storage directory tree is archived (e.g. LDK node storage and the
 // static channel backups next to it), excluding log files at any depth.
 func TestCreateBackupArchivesStorageDirRecursively(t *testing.T) {
-	logger.Init(strconv.Itoa(int(logrus.DebugLevel)))
-
 	workDir := t.TempDir()
-
-	gormDB, err := test_db.NewDB(t)
-	require.NoError(t, err)
-	defer test_db.CloseDB(gormDB)
-
-	appConfig := &config.AppConfig{
-		Workdir:     workDir,
-		DatabaseUri: test_db.GetTestDatabaseURI(),
-	}
-	cfg, err := config.NewConfig(appConfig, gormDB)
-	require.NoError(t, err)
-
-	unlockPassword := ""
-	require.NoError(t, cfg.SaveUnlockPasswordCheck(unlockPassword))
+	theAPI := newBackupTestAPI(t, workDir, filepath.Join(workDir, "ldk"))
 
 	storageDir := filepath.Join(workDir, "ldk", "storage")
 	require.NoError(t, os.MkdirAll(storageDir, 0700))
@@ -150,45 +161,34 @@ func TestCreateBackupArchivesStorageDirRecursively(t *testing.T) {
 	require.NoError(t, os.MkdirAll(logsDir, 0700))
 	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "ldk_node_2024_01_02.log"), []byte("log"), 0600))
 
-	lnClient := mocks.NewMockLNClient(t)
-	lnClient.On("GetStorageDir").Return(filepath.Join(workDir, "ldk"), nil)
-	lnClient.On("ResetRouter", "ALL").Return(nil)
-
-	svc := mocks.NewMockService(t)
-	svc.On("GetLNClient").Return(lnClient)
-	svc.On("StopApp").Return(nil)
-
-	albyOAuthSvc := mocks.NewMockAlbyOAuthService(t)
-	albyOAuthSvc.On("RemoveOAuthAccessToken").Return(nil)
-
-	theAPI := &api{
-		db:           gormDB,
-		cfg:          cfg,
-		svc:          svc,
-		albyOAuthSvc: albyOAuthSvc,
-	}
-
 	var buf bytes.Buffer
-	err = theAPI.CreateBackup(unlockPassword, &buf)
+	err := theAPI.CreateBackup(backupTestUnlockPassword, &buf)
 	require.NoError(t, err)
 
-	cr, err := decryptingReader(&buf, unlockPassword)
-	require.NoError(t, err)
-	decrypted, err := io.ReadAll(cr)
-	require.NoError(t, err)
-
-	zr, err := zip.NewReader(bytes.NewReader(decrypted), int64(len(decrypted)))
-	require.NoError(t, err)
-
-	entryNames := make([]string, 0, len(zr.File))
-	for _, f := range zr.File {
-		entryNames = append(entryNames, f.Name)
-	}
 	require.ElementsMatch(t, []string{
 		"nwc.db",
 		"ldk/storage/node.db",
 		"ldk/static_channel_backups/2024-01-02T03-04-05.json",
-	}, entryNames)
+	}, zipEntryNames(t, &buf))
+}
+
+// TestCreateBackupRejectsNonRegularFiles verifies that a symlink inside the
+// storage directory tree fails the backup instead of being followed (it could
+// point outside the workdir) or silently omitted.
+func TestCreateBackupRejectsNonRegularFiles(t *testing.T) {
+	workDir := t.TempDir()
+	theAPI := newBackupTestAPI(t, workDir, filepath.Join(workDir, "ldk"))
+
+	scbDir := filepath.Join(workDir, "ldk", "static_channel_backups")
+	require.NoError(t, os.MkdirAll(scbDir, 0700))
+
+	outsideFile := filepath.Join(t.TempDir(), "secret")
+	require.NoError(t, os.WriteFile(outsideFile, []byte("secret"), 0600))
+	require.NoError(t, os.Symlink(outsideFile, filepath.Join(scbDir, "link.json")))
+
+	var buf bytes.Buffer
+	err := theAPI.CreateBackup(backupTestUnlockPassword, &buf)
+	require.ErrorContains(t, err, "unexpected non-regular file")
 }
 
 // TestRestoreBackupRejectsPathTraversal verifies that a backup archive

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -2049,11 +2049,8 @@ func (ls *LDKService) GetBalances(ctx context.Context, includeInactiveChannels b
 }
 
 func (ls *LDKService) GetStorageDir() (string, error) {
-	// Note: the below will return the path including the WORK_DIR which is harder to use,
-	// so for now we just return a hardcoded value.
-	// cfg := ls.node.Config()
-	// return cfg.StorageDirPath, nil
-	return "ldk/storage", nil
+	// holds the node storage as well as the static channel backups
+	return ls.workdir, nil
 }
 
 func (ls *LDKService) deleteOldLDKPayments() {


### PR DESCRIPTION
Fixes #2573

## Problem

The migration file created by "Migrate Alby Hub to another device" only archived the top-level files of `ldk/storage` (via a one-level glob on `GetStorageDir()`, which was hardcoded to `"ldk/storage"`). The static channel backup snapshots written by `saveStaticChannelBackupToDisk` to the sibling directory `ldk/static_channel_backups` were never included, so they were lost after restoring on a new device.

## Fix

- `LNClient.GetStorageDir` now returns the backend's real working directory, holding all local state to migrate (documented on the interface). LDK returns `ls.workdir` (`<WORK_DIR>/ldk`), matching what Bark already did with `bs.workDir`. Backends without local state keep returning `""`.
- `CreateBackup` resolves that path with `filepath.Abs` (instead of joining it onto the workdir) and archives the whole tree with `filepath.WalkDir`, still excluding `.log` files at any depth. The directory is verified to be inside the hub workdir, since archive entries are stored workdir-relative. A missing directory is treated as nothing to archive.
- No restore-side changes: entries keep the same `ldk/...` shape and `finishRestoreNode` already moves the top-level `ldk` directory wholesale, so old and new migration files restore identically.

Side effect worth noting: Bark's `GetStorageDir` already returned an absolute path, which the old `filepath.Join(workDir, ...)` turned into a non-existent doubled path — so Bark migration files previously contained only `nwc.db`. With this change they include the Bark working directory.

## Tests

- New `TestCreateBackupArchivesStorageDirRecursively`: lays out `ldk/storage/node.db`, `ldk/static_channel_backups/<ts>.json` and `ldk/logs/*.log`, and asserts the archive contains exactly `nwc.db`, the storage file and the snapshot.
- `TestCreateBackup` (backend returning `""`) now asserts the archive contains only `nwc.db`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backups now include nested Lightning node data and static channel backups.
  * Log files are excluded from backups at any directory depth.
  * Backups no longer fail when the storage directory is missing.
  * Backup paths are validated to remain within the working directory.
  * Backups now reject symbolic links and other non-regular files.
* **Tests**
  * Added coverage for recursive storage archiving, missing-storage scenarios, and unsupported file types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->