### PR TITLE
fix(lnd): reconcile missed payment notifications on startup

### DIFF
--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -82,6 +82,14 @@ func NewLNDService(ctx context.Context, eventPublisher events.EventPublisher, ln
 	go lndService.subscribeChannelEvents(lndCtx)
 	go lndService.subscribeOpenHoldInvoices(lndCtx)
 	go lndService.trackForwardedPayments(lndCtx)
+	// The streams above only deliver events while the hub is attached.
+	// Replay terminal payments and invoices that settled while we were away,
+	// otherwise they stay stuck as pending in the hub database.
+	go func() {
+		if err := lndService.reconcileMissedPayments(lndCtx); err != nil {
+			logger.Logger.WithError(err).Error("Failed to reconcile missed LND payments")
+		}
+	}()
 
 	logger.Logger.WithField("alias", nodeInfo.Alias).Info("Connected to LND")
 

--- a/lnclient/lnd/reconcile.go
+++ b/lnclient/lnd/reconcile.go
@@ -1,0 +1,138 @@
+package lnd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+
+	"github.com/getAlby/hub/events"
+	"github.com/getAlby/hub/lnclient"
+	"github.com/getAlby/hub/logger"
+)
+
+// reconcileLookback bounds the startup reconciliation window. It mirrors the
+// 24h cap used by the transactions service when polling unsettled payments,
+// so a restart only replays recent terminal activity instead of full history.
+const reconcileLookback = 24 * time.Hour
+
+const reconcilePageSize = 100
+
+type paymentsLister interface {
+	ListPayments(ctx context.Context, req *lnrpc.ListPaymentsRequest, options ...grpc.CallOption) (*lnrpc.ListPaymentsResponse, error)
+}
+
+type invoicesLister interface {
+	ListInvoices(ctx context.Context, req *lnrpc.ListInvoiceRequest, options ...grpc.CallOption) (*lnrpc.ListInvoiceResponse, error)
+}
+
+type eventPublisher interface {
+	Publish(event *events.Event)
+}
+
+// reconcileMissedPayments replays terminal LND payments and invoices that
+// settled while the hub was offline and the notification streams were down.
+// It publishes the same events the subscriptions publish, so the transactions
+// service deduplicates them through its existing pending-first lookups.
+func (svc *LNDService) reconcileMissedPayments(ctx context.Context) error {
+	return reconcileMissedEvents(ctx, svc.client, svc.client, svc.eventPublisher, time.Now().Add(-reconcileLookback))
+}
+
+func reconcileMissedEvents(ctx context.Context, payments paymentsLister, invoices invoicesLister, publisher eventPublisher, since time.Time) error {
+	return errors.Join(
+		publishTerminalPayments(ctx, payments, publisher, since),
+		publishSettledInvoices(ctx, invoices, publisher, since),
+	)
+}
+
+func publishTerminalPayments(ctx context.Context, payments paymentsLister, publisher eventPublisher, since time.Time) error {
+	var indexOffset uint64
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		resp, err := payments.ListPayments(ctx, &lnrpc.ListPaymentsRequest{
+			IncludeIncomplete: false,
+			IndexOffset:       indexOffset,
+			MaxPayments:       reconcilePageSize,
+			Reversed:          false,
+			CreationDateStart: uint64(since.Unix()),
+			OmitHops:          true,
+		})
+		if err != nil {
+			return fmt.Errorf("list payments for reconciliation: %w", err)
+		}
+		for _, payment := range resp.Payments {
+			switch payment.Status {
+			case lnrpc.Payment_SUCCEEDED:
+				transaction, err := lndPaymentToTransaction(payment)
+				if err != nil {
+					continue
+				}
+				logger.Logger.WithField("payment_hash", transaction.PaymentHash).Info("Reconciling missed settled payment")
+				publisher.Publish(&events.Event{
+					Event:      "nwc_lnclient_payment_sent",
+					Properties: transaction,
+				})
+			case lnrpc.Payment_FAILED:
+				transaction, err := lndPaymentToTransaction(payment)
+				if err != nil {
+					continue
+				}
+				logger.Logger.WithField("payment_hash", transaction.PaymentHash).Info("Reconciling missed failed payment")
+				publisher.Publish(&events.Event{
+					Event: "nwc_lnclient_payment_failed",
+					Properties: &lnclient.PaymentFailedEventProperties{
+						Transaction: transaction,
+						Reason:      payment.FailureReason.String(),
+					},
+				})
+			default:
+				continue
+			}
+		}
+		if len(resp.Payments) < reconcilePageSize || resp.LastIndexOffset == indexOffset {
+			return nil
+		}
+		indexOffset = resp.LastIndexOffset
+	}
+}
+
+func publishSettledInvoices(ctx context.Context, invoices invoicesLister, publisher eventPublisher, since time.Time) error {
+	var indexOffset uint64
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		resp, err := invoices.ListInvoices(ctx, &lnrpc.ListInvoiceRequest{
+			IndexOffset:       indexOffset,
+			NumMaxInvoices:    reconcilePageSize,
+			Reversed:          false,
+			CreationDateStart: uint64(since.Unix()),
+		})
+		if err != nil {
+			return fmt.Errorf("list invoices for reconciliation: %w", err)
+		}
+		for _, invoice := range resp.Invoices {
+			if invoice.State != lnrpc.Invoice_SETTLED {
+				continue
+			}
+			transaction := lndInvoiceToTransaction(invoice)
+			logger.Logger.WithFields(logrus.Fields{
+				"payment_hash": transaction.PaymentHash,
+			}).Info("Reconciling missed settled invoice")
+			publisher.Publish(&events.Event{
+				Event:      "nwc_lnclient_payment_received",
+				Properties: transaction,
+			})
+		}
+		if len(resp.Invoices) < reconcilePageSize || resp.LastIndexOffset == indexOffset {
+			return nil
+		}
+		indexOffset = resp.LastIndexOffset
+	}
+}

--- a/lnclient/lnd/reconcile.go
+++ b/lnclient/lnd/reconcile.go
@@ -108,17 +108,19 @@ func publishSettledInvoices(ctx context.Context, invoices invoicesLister, publis
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		// lnd has no server-side settlement-time filter: CreationDateStart
+		// filters by creation date, so settled invoices are filtered by
+		// SettleDate here after scanning all invoices.
 		resp, err := invoices.ListInvoices(ctx, &lnrpc.ListInvoiceRequest{
-			IndexOffset:       indexOffset,
-			NumMaxInvoices:    reconcilePageSize,
-			Reversed:          false,
-			CreationDateStart: uint64(since.Unix()),
+			IndexOffset:    indexOffset,
+			NumMaxInvoices: reconcilePageSize,
+			Reversed:       false,
 		})
 		if err != nil {
 			return fmt.Errorf("list invoices for reconciliation: %w", err)
 		}
 		for _, invoice := range resp.Invoices {
-			if invoice.State != lnrpc.Invoice_SETTLED {
+			if invoice.State != lnrpc.Invoice_SETTLED || invoice.SettleDate < since.Unix() {
 				continue
 			}
 			transaction := lndInvoiceToTransaction(invoice)

--- a/lnclient/lnd/reconcile_test.go
+++ b/lnclient/lnd/reconcile_test.go
@@ -1,0 +1,231 @@
+package lnd
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"os"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/getAlby/hub/events"
+	"github.com/getAlby/hub/lnclient"
+	"github.com/getAlby/hub/logger"
+	"github.com/lightningnetwork/lnd/lnrpc"
+)
+
+type stubEventPublisher struct {
+	mu     sync.Mutex
+	events []*events.Event
+}
+
+func TestMain(m *testing.M) {
+	logger.Init("error")
+	os.Exit(m.Run())
+}
+
+func (s *stubEventPublisher) RegisterSubscriber(events.EventSubscriber) {}
+
+func (s *stubEventPublisher) Publish(event *events.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, event)
+}
+
+func (s *stubEventPublisher) published() []*events.Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]*events.Event{}, s.events...)
+}
+
+type stubPaymentsAPI struct {
+	pages []*lnrpc.ListPaymentsResponse
+	err   error
+	calls int
+}
+
+func (s *stubPaymentsAPI) ListPayments(ctx context.Context, req *lnrpc.ListPaymentsRequest, _ ...grpc.CallOption) (*lnrpc.ListPaymentsResponse, error) {
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	if len(s.pages) == 0 {
+		return &lnrpc.ListPaymentsResponse{}, nil
+	}
+	page := s.pages[0]
+	s.pages = s.pages[1:]
+	return page, nil
+}
+
+type stubInvoicesAPI struct {
+	pages []*lnrpc.ListInvoiceResponse
+	err   error
+	calls int
+}
+
+func (s *stubInvoicesAPI) ListInvoices(ctx context.Context, req *lnrpc.ListInvoiceRequest, _ ...grpc.CallOption) (*lnrpc.ListInvoiceResponse, error) {
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	if len(s.pages) == 0 {
+		return &lnrpc.ListInvoiceResponse{}, nil
+	}
+	page := s.pages[0]
+	s.pages = s.pages[1:]
+	return page, nil
+}
+
+func settledPaymentFixture(hash string) *lnrpc.Payment {
+	return &lnrpc.Payment{
+		PaymentHash:     hash,
+		Status:          lnrpc.Payment_SUCCEEDED,
+		PaymentPreimage: hash,
+		ValueMsat:       1000,
+		FeeMsat:         10,
+		CreationTimeNs:  time.Now().Add(-time.Hour).UnixNano(),
+	}
+}
+
+func TestReconcileMissedEvents_PublishesTerminalStates(t *testing.T) {
+	ctx := context.Background()
+	publisher := &stubEventPublisher{}
+	payments := &stubPaymentsAPI{
+		pages: []*lnrpc.ListPaymentsResponse{
+			{
+				Payments: []*lnrpc.Payment{
+					settledPaymentFixture("aa"),
+					{
+						PaymentHash:    "bb",
+						Status:         lnrpc.Payment_FAILED,
+						FailureReason:  lnrpc.PaymentFailureReason_FAILURE_REASON_NO_ROUTE,
+						ValueMsat:      2000,
+						CreationTimeNs: time.Now().Add(-time.Hour).UnixNano(),
+					},
+					{
+						PaymentHash:    "cc",
+						Status:         lnrpc.Payment_IN_FLIGHT,
+						ValueMsat:      3000,
+						CreationTimeNs: time.Now().Add(-time.Hour).UnixNano(),
+					},
+				},
+				LastIndexOffset: 3,
+			},
+			{
+				Payments:         []*lnrpc.Payment{},
+				FirstIndexOffset: 3,
+			},
+		},
+	}
+	rHash, _ := hex.DecodeString("dd")
+	invoices := &stubInvoicesAPI{
+		pages: []*lnrpc.ListInvoiceResponse{
+			{
+				Invoices: []*lnrpc.Invoice{
+					{
+						RHash:        rHash,
+						RPreimage:    rHash,
+						State:        lnrpc.Invoice_SETTLED,
+						ValueMsat:    4000,
+						CreationDate: time.Now().Add(-time.Hour).Unix(),
+						SettleDate:   time.Now().Add(-30 * time.Minute).Unix(),
+					},
+					{
+						State:        lnrpc.Invoice_OPEN,
+						ValueMsat:    5000,
+						CreationDate: time.Now().Add(-time.Hour).Unix(),
+					},
+				},
+				LastIndexOffset: 2,
+			},
+			{
+				Invoices:         []*lnrpc.Invoice{},
+				FirstIndexOffset: 2,
+			},
+		},
+	}
+
+	err := reconcileMissedEvents(ctx, payments, invoices, publisher, time.Now().Add(-24*time.Hour))
+	require.NoError(t, err)
+
+	published := publisher.published()
+	require.Len(t, published, 3)
+
+	byEvent := map[string]*events.Event{}
+	for _, event := range published {
+		byEvent[event.Event] = event
+	}
+
+	sent, ok := byEvent["nwc_lnclient_payment_sent"]
+	require.True(t, ok, "expected payment sent event for settled payment")
+	assert.Equal(t, "aa", sent.Properties.(*lnclient.Transaction).PaymentHash)
+
+	failed, ok := byEvent["nwc_lnclient_payment_failed"]
+	require.True(t, ok, "expected payment failed event for failed payment")
+	failedProps := failed.Properties.(*lnclient.PaymentFailedEventProperties)
+	assert.Equal(t, "bb", failedProps.Transaction.PaymentHash)
+	assert.NotEmpty(t, failedProps.Reason)
+
+	received, ok := byEvent["nwc_lnclient_payment_received"]
+	require.True(t, ok, "expected payment received event for settled invoice")
+	assert.Equal(t, "dd", received.Properties.(*lnclient.Transaction).PaymentHash)
+}
+
+func TestReconcileMissedEvents_EmptyListsPublishNothing(t *testing.T) {
+	publisher := &stubEventPublisher{}
+	err := reconcileMissedEvents(context.Background(), &stubPaymentsAPI{}, &stubInvoicesAPI{}, publisher, time.Now().Add(-24*time.Hour))
+	require.NoError(t, err)
+	assert.Empty(t, publisher.published())
+}
+
+func TestReconcileMissedEvents_PaymentsErrorStillReconcilesInvoices(t *testing.T) {
+	publisher := &stubEventPublisher{}
+	payments := &stubPaymentsAPI{err: errors.New("lnd unavailable")}
+	rHash, _ := hex.DecodeString("dd")
+	invoices := &stubInvoicesAPI{
+		pages: []*lnrpc.ListInvoiceResponse{
+			{
+				Invoices: []*lnrpc.Invoice{
+					{
+						RHash:        rHash,
+						RPreimage:    rHash,
+						State:        lnrpc.Invoice_SETTLED,
+						ValueMsat:    4000,
+						CreationDate: time.Now().Add(-time.Hour).Unix(),
+						SettleDate:   time.Now().Add(-30 * time.Minute).Unix(),
+					},
+				},
+				LastIndexOffset: 1,
+			},
+			{
+				Invoices:         []*lnrpc.Invoice{},
+				FirstIndexOffset: 1,
+			},
+		},
+	}
+
+	err := reconcileMissedEvents(context.Background(), payments, invoices, publisher, time.Now().Add(-24*time.Hour))
+	require.Error(t, err)
+	require.Len(t, publisher.published(), 1)
+	assert.Equal(t, "nwc_lnclient_payment_received", publisher.published()[0].Event)
+}
+
+func TestReconcileMissedEvents_RespectsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	publisher := &stubEventPublisher{}
+	payments := &stubPaymentsAPI{}
+	invoices := &stubInvoicesAPI{}
+
+	err := reconcileMissedEvents(ctx, payments, invoices, publisher, time.Now().Add(-24*time.Hour))
+	require.Error(t, err)
+	assert.Zero(t, payments.calls)
+	assert.Zero(t, invoices.calls)
+	assert.Empty(t, publisher.published())
+}

--- a/lnclient/lnd/reconcile_test.go
+++ b/lnclient/lnd/reconcile_test.go
@@ -229,3 +229,44 @@ func TestReconcileMissedEvents_RespectsCancellation(t *testing.T) {
 	assert.Zero(t, invoices.calls)
 	assert.Empty(t, publisher.published())
 }
+
+func TestPublishSettledInvoices_OldCreationDateRecentSettle(t *testing.T) {
+	publisher := &stubEventPublisher{}
+	rHash, _ := hex.DecodeString("ee")
+	invoices := &stubInvoicesAPI{
+		pages: []*lnrpc.ListInvoiceResponse{
+			{
+				Invoices: []*lnrpc.Invoice{
+					{
+						RHash:        rHash,
+						RPreimage:    rHash,
+						State:        lnrpc.Invoice_SETTLED,
+						ValueMsat:    6000,
+						CreationDate: time.Now().Add(-72 * time.Hour).Unix(),
+						SettleDate:   time.Now().Add(-30 * time.Minute).Unix(),
+					},
+					{
+						RHash:        rHash,
+						RPreimage:    rHash,
+						State:        lnrpc.Invoice_SETTLED,
+						ValueMsat:    7000,
+						CreationDate: time.Now().Add(-72 * time.Hour).Unix(),
+						SettleDate:   time.Now().Add(-48 * time.Hour).Unix(),
+					},
+				},
+				LastIndexOffset: 2,
+			},
+			{
+				Invoices:         []*lnrpc.Invoice{},
+				FirstIndexOffset: 2,
+			},
+		},
+	}
+
+	err := publishSettledInvoices(context.Background(), invoices, publisher, time.Now().Add(-24*time.Hour))
+	require.NoError(t, err)
+
+	published := publisher.published()
+	require.Len(t, published, 1)
+	assert.Equal(t, "nwc_lnclient_payment_received", published[0].Event)
+}

--- a/lnclient/lnd/wrapper/lnd.go
+++ b/lnclient/lnd/wrapper/lnd.go
@@ -149,6 +149,10 @@ func (wrapper *LNDWrapper) ListInvoices(ctx context.Context, req *lnrpc.ListInvo
 	return wrapper.client.ListInvoices(ctx, req, options...)
 }
 
+func (wrapper *LNDWrapper) ListPayments(ctx context.Context, req *lnrpc.ListPaymentsRequest, options ...grpc.CallOption) (*lnrpc.ListPaymentsResponse, error) {
+	return wrapper.client.ListPayments(ctx, req, options...)
+}
+
 func (wrapper *LNDWrapper) LookupInvoice(ctx context.Context, req *lnrpc.PaymentHash, options ...grpc.CallOption) (*lnrpc.Invoice, error) {
 	return wrapper.client.LookupInvoice(ctx, req, options...)
 }

--- a/transactions/reconcile_missed_events_test.go
+++ b/transactions/reconcile_missed_events_test.go
@@ -1,0 +1,160 @@
+package transactions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getAlby/hub/constants"
+	"github.com/getAlby/hub/db"
+	"github.com/getAlby/hub/events"
+	"github.com/getAlby/hub/lnclient"
+	"github.com/getAlby/hub/tests"
+)
+
+// TestReconcileMissedEvents_SettlesStuckPendingTransactions proves the
+// end-to-end recovery for https://github.com/getAlby/hub/issues/1188:
+// payments that settled on the LN node while the hub was offline stay pending
+// because the notification streams never redeliver them and the unsettled
+// polling fallback is disabled for backends with notification support.
+// Replaying the missed terminal states as the same events the streams publish
+// must converge every stuck row exactly once.
+func TestReconcileMissedEvents_SettlesStuckPendingTransactions(t *testing.T) {
+	ctx := context.TODO()
+
+	svc, err := tests.CreateTestService(t)
+	require.NoError(t, err)
+	defer svc.Remove()
+
+	sentHash := "reconcile-sent-hash"
+	receivedHash := "reconcile-received-hash"
+	failedHash := "reconcile-failed-hash"
+
+	svc.DB.Create(&db.Transaction{
+		State:       constants.TRANSACTION_STATE_PENDING,
+		Type:        constants.TRANSACTION_TYPE_OUTGOING,
+		PaymentHash: sentHash,
+		AmountMsat:  123000,
+	})
+	svc.DB.Create(&db.Transaction{
+		State:       constants.TRANSACTION_STATE_PENDING,
+		Type:        constants.TRANSACTION_TYPE_INCOMING,
+		PaymentHash: receivedHash,
+		AmountMsat:  456000,
+	})
+	svc.DB.Create(&db.Transaction{
+		State:       constants.TRANSACTION_STATE_PENDING,
+		Type:        constants.TRANSACTION_TYPE_OUTGOING,
+		PaymentHash: failedHash,
+		AmountMsat:  789000,
+	})
+
+	mockEventConsumer := tests.NewMockEventConsumer()
+	svc.EventPublisher.RegisterSubscriber(mockEventConsumer)
+	transactionsService := NewTransactionsService(svc.DB, svc.EventPublisher)
+
+	// precondition: with notification support enabled (e.g. LND backend),
+	// the unsettled polling fallback is skipped so the rows stay stuck.
+	transactionsService.checkUnsettledTransactions(ctx, svc.LNClient)
+	assertPendingWithHash(t, transactionsService, sentHash, constants.TRANSACTION_TYPE_OUTGOING)
+	assertPendingWithHash(t, transactionsService, receivedHash, constants.TRANSACTION_TYPE_INCOMING)
+	assertPendingWithHash(t, transactionsService, failedHash, constants.TRANSACTION_TYPE_OUTGOING)
+
+	settledAt := tests.MockTimeUnix
+	preimage := "reconcile-preimage"
+
+	// replay the missed terminal states exactly as the startup reconciliation does.
+	transactionsService.ConsumeEvent(ctx, &events.Event{
+		Event: "nwc_lnclient_payment_sent",
+		Properties: &lnclient.Transaction{
+			Type:        "outgoing",
+			PaymentHash: sentHash,
+			AmountMsat:  123000,
+			Preimage:    preimage,
+			SettledAt:   &settledAt,
+		},
+	}, map[string]interface{}{})
+	transactionsService.ConsumeEvent(ctx, &events.Event{
+		Event: "nwc_lnclient_payment_received",
+		Properties: &lnclient.Transaction{
+			Type:        "incoming",
+			PaymentHash: receivedHash,
+			AmountMsat:  456000,
+			Preimage:    preimage,
+			SettledAt:   &settledAt,
+		},
+	}, map[string]interface{}{})
+	transactionsService.ConsumeEvent(ctx, &events.Event{
+		Event: "nwc_lnclient_payment_failed",
+		Properties: &lnclient.PaymentFailedEventProperties{
+			Transaction: &lnclient.Transaction{
+				Type:        "outgoing",
+				PaymentHash: failedHash,
+				AmountMsat:  789000,
+			},
+			Reason: "FAILURE_REASON_NO_ROUTE",
+		},
+	}, map[string]interface{}{})
+
+	assertStateWithHash(t, transactionsService, sentHash, constants.TRANSACTION_TYPE_OUTGOING, constants.TRANSACTION_STATE_SETTLED)
+	assertStateWithHash(t, transactionsService, receivedHash, constants.TRANSACTION_TYPE_INCOMING, constants.TRANSACTION_STATE_SETTLED)
+	assertStateWithHash(t, transactionsService, failedHash, constants.TRANSACTION_TYPE_OUTGOING, constants.TRANSACTION_STATE_FAILED)
+
+	consumedEvents := mockEventConsumer.WaitForConsumedEvents(3)
+	require.Len(t, consumedEvents, 3)
+	consumedByEvent := map[string]int{}
+	for _, consumedEvent := range consumedEvents {
+		consumedByEvent[consumedEvent.Event]++
+	}
+	assert.Equal(t, map[string]int{
+		"nwc_payment_sent":     1,
+		"nwc_payment_received": 1,
+		"nwc_payment_failed":   1,
+	}, consumedByEvent)
+
+	// duplicate redelivery (stream finally catching up after the reconcile
+	// pass) must not transition or notify twice.
+	transactionsService.ConsumeEvent(ctx, &events.Event{
+		Event: "nwc_lnclient_payment_sent",
+		Properties: &lnclient.Transaction{
+			Type:        "outgoing",
+			PaymentHash: sentHash,
+			AmountMsat:  123000,
+			Preimage:    preimage,
+			SettledAt:   &settledAt,
+		},
+	}, map[string]interface{}{})
+	transactionsService.ConsumeEvent(ctx, &events.Event{
+		Event: "nwc_lnclient_payment_failed",
+		Properties: &lnclient.PaymentFailedEventProperties{
+			Transaction: &lnclient.Transaction{
+				Type:        "outgoing",
+				PaymentHash: failedHash,
+				AmountMsat:  789000,
+			},
+			Reason: "FAILURE_REASON_NO_ROUTE",
+		},
+	}, map[string]interface{}{})
+
+	assertStateWithHash(t, transactionsService, sentHash, constants.TRANSACTION_TYPE_OUTGOING, constants.TRANSACTION_STATE_SETTLED)
+	assertStateWithHash(t, transactionsService, failedHash, constants.TRANSACTION_TYPE_OUTGOING, constants.TRANSACTION_STATE_FAILED)
+	assert.Len(t, mockEventConsumer.GetConsumedEvents(), 3)
+}
+
+func assertPendingWithHash(t *testing.T, transactionsService *transactionsService, paymentHash string, transactionType string) {
+	t.Helper()
+	assertStateWithHash(t, transactionsService, paymentHash, transactionType, constants.TRANSACTION_STATE_PENDING)
+}
+
+func assertStateWithHash(t *testing.T, transactionsService *transactionsService, paymentHash string, transactionType string, state string) {
+	t.Helper()
+	var transaction db.Transaction
+	result := transactionsService.db.Limit(1).Find(&transaction, &db.Transaction{
+		Type:        transactionType,
+		PaymentHash: paymentHash,
+	})
+	require.Equal(t, int64(1), result.RowsAffected)
+	assert.Equal(t, state, transaction.State)
+}


### PR DESCRIPTION
Fixes #1188.

Payments that reach a terminal state on LND while the hub is offline stay stuck as pending: the notification streams only deliver while attached (SubscribeInvoices uses no add/settle index, TrackPayments replays in-flight payments only), and the unsettled polling fallback is skipped for backends with notification support (and is LookupInvoice-only, so it cannot see outgoing payments).

Add a startup reconciliation pass to NewLNDService that lists terminal payments (SUCCEEDED/FAILED) and settled invoices from the last 24h and publishes the same nwc_lnclient_payment_sent/failed/received events the subscriptions publish. Deduplication and exactly-once convergence come from the existing pending-first lookups, findSettledTransaction, and the settled/failed guards in the transactions service.

- Bounded 24h window (mirrors the existing unsettled-transaction cap), paginated with OmitHops; invoices still reconcile if the payments listing fails, and list errors never block startup.
- Aborts on shutdown via the service context; safe to rerun next start.
- No LNClient interface changes, no migrations.

Tests: lnclient/lnd unit tests over stubbed list APIs (terminal-state matrix, pagination, error-then-continue, cancellation), plus a transactions-level boundary test proving stuck pending rows converge to settled/settled/failed with exactly one notification each and that duplicate redelivery is a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transactions and invoices completed while the service was offline are now reconciled automatically after reconnection.
  * Previously stuck pending payments transition to their correct terminal states, including sent, received, and failed outcomes.
  * Settled invoices are reconciled based on settlement time, including invoices created earlier but settled recently.
  * Replayed events no longer cause duplicate state changes or notifications.

* **Reliability**
  * Missed payment and invoice events are recovered more consistently after service interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->