### PR TITLE
fix: preserve rotated oauth token across persistence failures

### DIFF
--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -321,6 +321,9 @@ func (svc *albyOAuthService) fetchUserToken(ctx context.Context) (*oauth2.Token,
 	if shouldUseLatestToken(svc.latestToken, svc.pendingRefreshFrom, currentToken) {
 		currentToken = svc.latestToken
 	}
+	if svc.pendingRefreshFrom != "" {
+		svc.saveToken(currentToken, svc.pendingRefreshFrom)
+	}
 
 	// only use the current token if it has at least 60 seconds before expiry
 	if currentToken.Expiry.After(time.Now().Add(time.Duration(60) * time.Second)) {
@@ -589,7 +592,6 @@ func (svc *albyOAuthService) GetAuthUrl() string {
 }
 
 func (svc *albyOAuthService) UnlinkAccount(ctx context.Context) error {
-	svc.lockAndClearTokenState()
 	ldkVssEnabled, err := svc.cfg.Get("LdkVssEnabled", "")
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to fetch LdkVssEnabled user config")
@@ -599,6 +601,7 @@ func (svc *albyOAuthService) UnlinkAccount(ctx context.Context) error {
 	if ldkVssEnabled == "true" {
 		return errors.New("alby account cannot be unlinked while VSS is activated")
 	}
+	svc.lockAndClearTokenState()
 
 	destroyAlbyAccountErr := svc.destroyAlbyAccountNWCNode(ctx)
 	if destroyAlbyAccountErr != nil {

--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -35,12 +35,13 @@ import (
 )
 
 type albyOAuthService struct {
-	cfg            config.Config
-	oauthConf      *oauth2.Config
-	db             *gorm.DB
-	keys           keys.Keys
-	eventPublisher events.EventPublisher
-	latestToken    *oauth2.Token
+	cfg                config.Config
+	oauthConf          *oauth2.Config
+	db                 *gorm.DB
+	keys               keys.Keys
+	eventPublisher     events.EventPublisher
+	latestToken        *oauth2.Token
+	pendingRefreshFrom string
 }
 
 const (
@@ -92,9 +93,7 @@ func NewAlbyOAuthService(db *gorm.DB, cfg config.Config, keys keys.Keys, eventPu
 }
 
 func (svc *albyOAuthService) RemoveOAuthAccessToken() error {
-	tokenMutex.Lock()
-	svc.clearLatestToken()
-	tokenMutex.Unlock()
+	svc.lockAndClearTokenState()
 	err := svc.cfg.SetUpdate(accessTokenKey, "", "")
 	if err != nil {
 		logger.Logger.WithError(err).Error("failed to remove access token")
@@ -109,13 +108,14 @@ func (svc *albyOAuthService) CallbackHandler(ctx context.Context, code string) e
 		return err
 	}
 	tokenMutex.Lock()
-	svc.saveToken(token)
+	svc.saveToken(token, "")
 	tokenMutex.Unlock()
 
 	me, err := svc.GetMe(ctx)
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to fetch user me")
 		// remove token so user can retry
+		svc.lockAndClearTokenState()
 		cfgErr := svc.cfg.SetUpdate(accessTokenKey, "", "")
 		if cfgErr != nil {
 			logger.Logger.WithError(cfgErr).Error("failed to remove existing access token")
@@ -143,6 +143,7 @@ func (svc *albyOAuthService) CallbackHandler(ctx context.Context, code string) e
 		})
 	} else if me.Identifier != existingUserIdentifier {
 		// remove token so user can retry with correct account
+		svc.lockAndClearTokenState()
 		err := svc.cfg.SetUpdate(accessTokenKey, "", "")
 		if err != nil {
 			logger.Logger.WithError(err).Error("Failed to set user access token")
@@ -179,13 +180,19 @@ func (svc *albyOAuthService) IsConnected(ctx context.Context) bool {
 	return token != nil
 }
 
-func (svc *albyOAuthService) saveToken(token *oauth2.Token) {
+func (svc *albyOAuthService) saveToken(token *oauth2.Token, rotatedFrom string) {
 	svc.setLatestToken(token)
+	if rotatedFrom != "" {
+		svc.pendingRefreshFrom = rotatedFrom
+	} else {
+		svc.pendingRefreshFrom = ""
+	}
 
 	var lastErr error
 	for attempt := 0; attempt < tokenSaveAttempts; attempt++ {
 		lastErr = svc.persistToken(token)
 		if lastErr == nil {
+			svc.pendingRefreshFrom = ""
 			return
 		}
 		if attempt < tokenSaveAttempts-1 {
@@ -226,19 +233,46 @@ func (svc *albyOAuthService) setLatestToken(token *oauth2.Token) {
 
 func (svc *albyOAuthService) clearLatestToken() {
 	svc.latestToken = nil
+	svc.pendingRefreshFrom = ""
 }
 
-func tokenAheadOfDB(memToken, dbToken *oauth2.Token) bool {
-	if memToken == nil {
+func (svc *albyOAuthService) lockAndClearTokenState() {
+	tokenMutex.Lock()
+	svc.clearLatestToken()
+	tokenMutex.Unlock()
+}
+
+func (svc *albyOAuthService) reconcileTokenState(dbToken *oauth2.Token) {
+	if svc.latestToken == nil {
+		return
+	}
+	if svc.pendingRefreshFrom == "" {
+		if svc.latestToken.RefreshToken != dbToken.RefreshToken {
+			svc.clearLatestToken()
+		}
+		return
+	}
+	if dbToken.RefreshToken == svc.pendingRefreshFrom {
+		return
+	}
+	if dbToken.RefreshToken == svc.latestToken.RefreshToken {
+		svc.pendingRefreshFrom = ""
+		return
+	}
+	svc.clearLatestToken()
+}
+
+func shouldUseLatestToken(latestToken *oauth2.Token, pendingRefreshFrom string, dbToken *oauth2.Token) bool {
+	if latestToken == nil {
 		return false
 	}
-	if dbToken == nil {
+	if pendingRefreshFrom != "" && dbToken.RefreshToken == pendingRefreshFrom {
 		return true
 	}
-	if memToken.RefreshToken != "" && memToken.RefreshToken != dbToken.RefreshToken {
+	if latestToken.RefreshToken == dbToken.RefreshToken && latestToken.Expiry.After(dbToken.Expiry) {
 		return true
 	}
-	return memToken.Expiry.After(dbToken.Expiry)
+	return false
 }
 
 var tokenMutex sync.Mutex
@@ -283,7 +317,8 @@ func (svc *albyOAuthService) fetchUserToken(ctx context.Context) (*oauth2.Token,
 		RefreshToken: refreshToken,
 	}
 
-	if tokenAheadOfDB(svc.latestToken, currentToken) {
+	svc.reconcileTokenState(currentToken)
+	if shouldUseLatestToken(svc.latestToken, svc.pendingRefreshFrom, currentToken) {
 		currentToken = svc.latestToken
 	}
 
@@ -293,13 +328,14 @@ func (svc *albyOAuthService) fetchUserToken(ctx context.Context) (*oauth2.Token,
 		return currentToken, nil
 	}
 
+	refreshUsed := currentToken.RefreshToken
 	newToken, err := svc.oauthConf.TokenSource(ctx, currentToken).Token()
 	if err != nil {
 		logger.Logger.WithError(err).Warn("Failed to refresh existing token")
 		return nil, err
 	}
 
-	svc.saveToken(newToken)
+	svc.saveToken(newToken, refreshUsed)
 	return newToken, nil
 }
 
@@ -553,9 +589,7 @@ func (svc *albyOAuthService) GetAuthUrl() string {
 }
 
 func (svc *albyOAuthService) UnlinkAccount(ctx context.Context) error {
-	tokenMutex.Lock()
-	svc.clearLatestToken()
-	tokenMutex.Unlock()
+	svc.lockAndClearTokenState()
 	ldkVssEnabled, err := svc.cfg.Get("LdkVssEnabled", "")
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to fetch LdkVssEnabled user config")

--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -40,6 +40,7 @@ type albyOAuthService struct {
 	db             *gorm.DB
 	keys           keys.Keys
 	eventPublisher events.EventPublisher
+	latestToken    *oauth2.Token
 }
 
 const (
@@ -53,6 +54,11 @@ const (
 const (
 	albyOAuthAPIURL  = "https://api.getalby.com"
 	albyOAuthAuthUrl = "https://getalby.com/oauth"
+)
+
+const (
+	tokenSaveAttempts   = 3
+	tokenSaveRetryDelay = 200 * time.Millisecond
 )
 
 const ALBY_ACCOUNT_APP_NAME = "getalby.com"
@@ -86,6 +92,9 @@ func NewAlbyOAuthService(db *gorm.DB, cfg config.Config, keys keys.Keys, eventPu
 }
 
 func (svc *albyOAuthService) RemoveOAuthAccessToken() error {
+	tokenMutex.Lock()
+	svc.clearLatestToken()
+	tokenMutex.Unlock()
 	err := svc.cfg.SetUpdate(accessTokenKey, "", "")
 	if err != nil {
 		logger.Logger.WithError(err).Error("failed to remove access token")
@@ -99,7 +108,9 @@ func (svc *albyOAuthService) CallbackHandler(ctx context.Context, code string) e
 		logger.Logger.WithError(err).Error("Failed to exchange token")
 		return err
 	}
+	tokenMutex.Lock()
 	svc.saveToken(token)
+	tokenMutex.Unlock()
 
 	me, err := svc.GetMe(ctx)
 	if err != nil {
@@ -169,18 +180,65 @@ func (svc *albyOAuthService) IsConnected(ctx context.Context) bool {
 }
 
 func (svc *albyOAuthService) saveToken(token *oauth2.Token) {
+	svc.setLatestToken(token)
+
+	var lastErr error
+	for attempt := 0; attempt < tokenSaveAttempts; attempt++ {
+		lastErr = svc.persistToken(token)
+		if lastErr == nil {
+			return
+		}
+		if attempt < tokenSaveAttempts-1 {
+			time.Sleep(tokenSaveRetryDelay)
+		}
+	}
+
+	logger.Logger.WithError(lastErr).Error("Failed to persist oauth token after retries")
+}
+
+func (svc *albyOAuthService) persistToken(token *oauth2.Token) error {
 	err := svc.cfg.SetUpdate(accessTokenExpiryKey, strconv.FormatInt(token.Expiry.Unix(), 10), "")
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to save access token expiry")
+		return err
 	}
 	err = svc.cfg.SetUpdate(accessTokenKey, token.AccessToken, "")
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to save access token")
+		return err
 	}
 	err = svc.cfg.SetUpdate(refreshTokenKey, token.RefreshToken, "")
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to save refresh token")
+		return err
 	}
+	return nil
+}
+
+func (svc *albyOAuthService) setLatestToken(token *oauth2.Token) {
+	if token == nil {
+		svc.latestToken = nil
+		return
+	}
+	clone := *token
+	svc.latestToken = &clone
+}
+
+func (svc *albyOAuthService) clearLatestToken() {
+	svc.latestToken = nil
+}
+
+func tokenAheadOfDB(memToken, dbToken *oauth2.Token) bool {
+	if memToken == nil {
+		return false
+	}
+	if dbToken == nil {
+		return true
+	}
+	if memToken.RefreshToken != "" && memToken.RefreshToken != dbToken.RefreshToken {
+		return true
+	}
+	return memToken.Expiry.After(dbToken.Expiry)
 }
 
 var tokenMutex sync.Mutex
@@ -223,6 +281,10 @@ func (svc *albyOAuthService) fetchUserToken(ctx context.Context) (*oauth2.Token,
 		AccessToken:  accessToken,
 		Expiry:       time.Unix(expiry64, 0),
 		RefreshToken: refreshToken,
+	}
+
+	if tokenAheadOfDB(svc.latestToken, currentToken) {
+		currentToken = svc.latestToken
 	}
 
 	// only use the current token if it has at least 60 seconds before expiry
@@ -491,6 +553,9 @@ func (svc *albyOAuthService) GetAuthUrl() string {
 }
 
 func (svc *albyOAuthService) UnlinkAccount(ctx context.Context) error {
+	tokenMutex.Lock()
+	svc.clearLatestToken()
+	tokenMutex.Unlock()
 	ldkVssEnabled, err := svc.cfg.Get("LdkVssEnabled", "")
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to fetch LdkVssEnabled user config")

--- a/alby/alby_oauth_token_test.go
+++ b/alby/alby_oauth_token_test.go
@@ -1,0 +1,227 @@
+package alby
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/getAlby/hub/config"
+	"github.com/getAlby/hub/events"
+	"github.com/getAlby/hub/logger"
+)
+
+type oauthTestConfig struct {
+	values            map[string]string
+	remainingFailures int
+}
+
+func newOAuthTestConfig() *oauthTestConfig {
+	return &oauthTestConfig{values: map[string]string{}}
+}
+
+func (c *oauthTestConfig) Get(key string, _ string) (string, error) {
+	return c.values[key], nil
+}
+
+func (c *oauthTestConfig) SetUpdate(key string, value string, _ string) error {
+	if key == refreshTokenKey && c.remainingFailures > 0 {
+		c.remainingFailures--
+		return errors.New("transient db error")
+	}
+	c.values[key] = value
+	return nil
+}
+
+func (c *oauthTestConfig) SetIgnore(string, string, string) error { return nil }
+func (c *oauthTestConfig) LoadJWTSecret(string) error             { return nil }
+func (c *oauthTestConfig) GetJWTSecret() (string, error)          { return "", nil }
+func (c *oauthTestConfig) GetRelayUrls() []string                 { return nil }
+func (c *oauthTestConfig) GetNetwork() string                     { return "" }
+func (c *oauthTestConfig) GetMempoolUrl() string                  { return "" }
+func (c *oauthTestConfig) GetEnv() *config.AppConfig {
+	return &config.AppConfig{AlbyClientId: "test-client-id", AlbyClientSecret: "test-client-secret"}
+}
+func (c *oauthTestConfig) CheckUnlockPassword(string) bool           { return false }
+func (c *oauthTestConfig) IsUnlockPasswordCheckSet() (bool, error)   { return false, nil }
+func (c *oauthTestConfig) ChangeUnlockPassword(string, string) error { return nil }
+func (c *oauthTestConfig) SetAutoUnlockPassword(string) error        { return nil }
+func (c *oauthTestConfig) SaveUnlockPasswordCheck(string) error      { return nil }
+func (c *oauthTestConfig) SetupCompleted() (bool, error)             { return true, nil }
+func (c *oauthTestConfig) GetCurrency() string                       { return "" }
+func (c *oauthTestConfig) SetCurrency(string) error                  { return nil }
+func (c *oauthTestConfig) GetBitcoinDisplayFormat() string           { return "" }
+func (c *oauthTestConfig) SetBitcoinDisplayFormat(string) error      { return nil }
+
+func newOAuthTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	r1Consumed := false
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("grant_type") != "refresh_token" {
+			http.Error(w, "unsupported grant", http.StatusBadRequest)
+			return
+		}
+
+		refreshToken := r.FormValue("refresh_token")
+		switch refreshToken {
+		case "refresh-token-r1":
+			if r1Consumed {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid_grant"})
+				return
+			}
+			r1Consumed = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token":  "access-token-a2",
+				"token_type":    "bearer",
+				"expires_in":    3600,
+				"refresh_token": "refresh-token-r2",
+			})
+		case "refresh-token-r2":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token":  "access-token-a3",
+				"token_type":    "bearer",
+				"expires_in":    3600,
+				"refresh_token": "refresh-token-r2",
+			})
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid_grant"})
+		}
+	}))
+}
+
+func seedExpiredOAuthTokens(t *testing.T, cfg config.Config) {
+	t.Helper()
+	expired := time.Now().Add(-2 * time.Hour).Unix()
+	require.NoError(t, cfg.SetUpdate(accessTokenKey, "access-token-a1", ""))
+	require.NoError(t, cfg.SetUpdate(accessTokenExpiryKey, strconv.FormatInt(expired, 10), ""))
+	require.NoError(t, cfg.SetUpdate(refreshTokenKey, "refresh-token-r1", ""))
+}
+
+func newOAuthTestService(t *testing.T, cfg config.Config, tokenURL string) *albyOAuthService {
+	t.Helper()
+	svc := NewAlbyOAuthService(nil, cfg, nil, events.NewEventPublisher())
+	svc.oauthConf = &oauth2.Config{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		Endpoint: oauth2.Endpoint{
+			TokenURL:  tokenURL,
+			AuthStyle: oauth2.AuthStyleInHeader,
+		},
+	}
+	return svc
+}
+
+func initOAuthTokenTest(t *testing.T) {
+	t.Helper()
+	logger.Init("4")
+}
+
+func TestFetchUserTokenSurvivesTransientRefreshTokenPersistenceFailure(t *testing.T) {
+	initOAuthTokenTest(t)
+
+	server := newOAuthTestServer(t)
+	defer server.Close()
+
+	cfg := newOAuthTestConfig()
+	seedExpiredOAuthTokens(t, cfg)
+	cfg.remainingFailures = 10
+
+	oauthSvc := newOAuthTestService(t, cfg, server.URL+"/oauth/token")
+	ctx := context.Background()
+
+	firstToken, err := oauthSvc.fetchUserToken(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "access-token-a2", firstToken.AccessToken)
+	require.Equal(t, "refresh-token-r2", firstToken.RefreshToken)
+
+	storedRefreshToken, err := cfg.Get(refreshTokenKey, "")
+	require.NoError(t, err)
+	assert.Equal(t, "refresh-token-r1", storedRefreshToken, "stale refresh token must remain in db after failed persistence")
+
+	expired := time.Now().Add(-2 * time.Hour).Unix()
+	require.NoError(t, cfg.SetUpdate(accessTokenExpiryKey, strconv.FormatInt(expired, 10), ""))
+
+	secondToken, err := oauthSvc.fetchUserToken(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "access-token-a2", secondToken.AccessToken)
+	require.Equal(t, "refresh-token-r2", secondToken.RefreshToken)
+}
+
+func TestFetchUserTokenRetriesRefreshTokenPersistence(t *testing.T) {
+	initOAuthTokenTest(t)
+
+	server := newOAuthTestServer(t)
+	defer server.Close()
+
+	cfg := newOAuthTestConfig()
+	seedExpiredOAuthTokens(t, cfg)
+	cfg.remainingFailures = 1
+
+	oauthSvc := newOAuthTestService(t, cfg, server.URL+"/oauth/token")
+	ctx := context.Background()
+
+	_, err := oauthSvc.fetchUserToken(ctx)
+	require.NoError(t, err)
+
+	storedRefreshToken, err := cfg.Get(refreshTokenKey, "")
+	require.NoError(t, err)
+	assert.Equal(t, "refresh-token-r2", storedRefreshToken)
+}
+
+func TestFetchUserTokenConcurrentRefreshUsesSingleRotatedToken(t *testing.T) {
+	initOAuthTokenTest(t)
+
+	server := newOAuthTestServer(t)
+	defer server.Close()
+
+	cfg := newOAuthTestConfig()
+	seedExpiredOAuthTokens(t, cfg)
+
+	oauthSvc := newOAuthTestService(t, cfg, server.URL+"/oauth/token")
+	ctx := context.Background()
+
+	const workers = 8
+	results := make(chan *oauth2.Token, workers)
+	errs := make(chan error, workers)
+
+	for i := 0; i < workers; i++ {
+		go func() {
+			token, err := oauthSvc.fetchUserToken(ctx)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- token
+		}()
+	}
+
+	for i := 0; i < workers; i++ {
+		select {
+		case err := <-errs:
+			require.NoError(t, err)
+		case token := <-results:
+			require.Equal(t, "access-token-a2", token.AccessToken)
+			require.Equal(t, "refresh-token-r2", token.RefreshToken)
+		}
+	}
+}

--- a/alby/alby_oauth_token_test.go
+++ b/alby/alby_oauth_token_test.go
@@ -165,13 +165,14 @@ func TestFetchUserTokenSurvivesTransientRefreshTokenPersistenceFailure(t *testin
 	require.NoError(t, err)
 	assert.Equal(t, "refresh-token-r1", storedRefreshToken, "stale refresh token must remain in db after failed persistence")
 
-	expired := time.Now().Add(-2 * time.Hour).Unix()
-	require.NoError(t, cfg.SetUpdate(accessTokenExpiryKey, strconv.FormatInt(expired, 10), ""))
-
+	cfg.failKeys = nil
 	secondToken, err := oauthSvc.fetchUserToken(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "access-token-a2", secondToken.AccessToken)
 	require.Equal(t, "refresh-token-r2", secondToken.RefreshToken)
+	storedRefreshToken, err = cfg.Get(refreshTokenKey, "")
+	require.NoError(t, err)
+	require.Equal(t, "refresh-token-r2", storedRefreshToken)
 }
 
 func TestFetchUserTokenRetriesRefreshTokenPersistence(t *testing.T) {

--- a/alby/alby_oauth_token_test.go
+++ b/alby/alby_oauth_token_test.go
@@ -22,6 +22,7 @@ import (
 type oauthTestConfig struct {
 	values            map[string]string
 	remainingFailures int
+	failKeys          map[string]int
 }
 
 func newOAuthTestConfig() *oauthTestConfig {
@@ -33,9 +34,15 @@ func (c *oauthTestConfig) Get(key string, _ string) (string, error) {
 }
 
 func (c *oauthTestConfig) SetUpdate(key string, value string, _ string) error {
-	if key == refreshTokenKey && c.remainingFailures > 0 {
+	if c.remainingFailures > 0 {
 		c.remainingFailures--
 		return errors.New("transient db error")
+	}
+	if c.failKeys != nil {
+		if remaining, ok := c.failKeys[key]; ok && remaining > 0 {
+			c.failKeys[key] = remaining - 1
+			return errors.New("transient db error")
+		}
 	}
 	c.values[key] = value
 	return nil
@@ -144,7 +151,7 @@ func TestFetchUserTokenSurvivesTransientRefreshTokenPersistenceFailure(t *testin
 
 	cfg := newOAuthTestConfig()
 	seedExpiredOAuthTokens(t, cfg)
-	cfg.remainingFailures = 10
+	cfg.failKeys = map[string]int{refreshTokenKey: 10}
 
 	oauthSvc := newOAuthTestService(t, cfg, server.URL+"/oauth/token")
 	ctx := context.Background()
@@ -175,7 +182,7 @@ func TestFetchUserTokenRetriesRefreshTokenPersistence(t *testing.T) {
 
 	cfg := newOAuthTestConfig()
 	seedExpiredOAuthTokens(t, cfg)
-	cfg.remainingFailures = 1
+	cfg.failKeys = map[string]int{refreshTokenKey: 1}
 
 	oauthSvc := newOAuthTestService(t, cfg, server.URL+"/oauth/token")
 	ctx := context.Background()
@@ -224,4 +231,181 @@ func TestFetchUserTokenConcurrentRefreshUsesSingleRotatedToken(t *testing.T) {
 			require.Equal(t, "refresh-token-r2", token.RefreshToken)
 		}
 	}
+}
+
+func newNonRotatingRefreshOAuthServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "access-token-a2",
+			"token_type":   "bearer",
+			"expires_in":   3600,
+		})
+	}))
+}
+
+func TestFetchUserTokenPrefersNewerDatabaseTokenOverStaleMemory(t *testing.T) {
+	initOAuthTokenTest(t)
+
+	server := newOAuthTestServer(t)
+	defer server.Close()
+
+	cfg := newOAuthTestConfig()
+	seedExpiredOAuthTokens(t, cfg)
+	cfg.failKeys = map[string]int{refreshTokenKey: 10}
+
+	oauthSvc := newOAuthTestService(t, cfg, server.URL+"/oauth/token")
+	ctx := context.Background()
+
+	_, err := oauthSvc.fetchUserToken(ctx)
+	require.NoError(t, err)
+
+	cfg.failKeys = nil
+	require.NoError(t, cfg.SetUpdate(refreshTokenKey, "refresh-token-r3", ""))
+	require.NoError(t, cfg.SetUpdate(accessTokenKey, "access-token-a3", ""))
+	require.NoError(t, cfg.SetUpdate(accessTokenExpiryKey, strconv.FormatInt(time.Now().Add(2*time.Hour).Unix(), 10), ""))
+
+	token, err := oauthSvc.fetchUserToken(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "refresh-token-r3", token.RefreshToken)
+	require.Equal(t, "access-token-a3", token.AccessToken)
+}
+
+func TestFetchUserTokenPrefersNewerDatabaseExpiryWithSameRefreshToken(t *testing.T) {
+	initOAuthTokenTest(t)
+
+	cfg := newOAuthTestConfig()
+	future := time.Now().Add(2 * time.Hour)
+	past := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, cfg.SetUpdate(accessTokenKey, "access-token-a-db", ""))
+	require.NoError(t, cfg.SetUpdate(accessTokenExpiryKey, strconv.FormatInt(future.Unix(), 10), ""))
+	require.NoError(t, cfg.SetUpdate(refreshTokenKey, "refresh-token-r2", ""))
+
+	oauthSvc := newOAuthTestService(t, cfg, "http://localhost/unused")
+	oauthSvc.setLatestToken(&oauth2.Token{
+		AccessToken:  "access-token-a-mem",
+		RefreshToken: "refresh-token-r2",
+		Expiry:       past,
+	})
+
+	token, err := oauthSvc.fetchUserToken(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "access-token-a-db", token.AccessToken)
+}
+
+func TestFetchUserTokenPrefersNewerMemoryExpiryWithSameRefreshToken(t *testing.T) {
+	initOAuthTokenTest(t)
+
+	cfg := newOAuthTestConfig()
+	past := time.Now().Add(-2 * time.Hour)
+	future := time.Now().Add(2 * time.Hour)
+	require.NoError(t, cfg.SetUpdate(accessTokenKey, "access-token-a-db", ""))
+	require.NoError(t, cfg.SetUpdate(accessTokenExpiryKey, strconv.FormatInt(past.Unix(), 10), ""))
+	require.NoError(t, cfg.SetUpdate(refreshTokenKey, "refresh-token-r2", ""))
+
+	oauthSvc := newOAuthTestService(t, cfg, "http://localhost/unused")
+	oauthSvc.setLatestToken(&oauth2.Token{
+		AccessToken:  "access-token-a-mem",
+		RefreshToken: "refresh-token-r2",
+		Expiry:       future,
+	})
+
+	token, err := oauthSvc.fetchUserToken(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "access-token-a-mem", token.AccessToken)
+}
+
+func TestFetchUserTokenNonRotatingRefreshPersistsSameRefreshToken(t *testing.T) {
+	initOAuthTokenTest(t)
+
+	server := newNonRotatingRefreshOAuthServer(t)
+	defer server.Close()
+
+	cfg := newOAuthTestConfig()
+	seedExpiredOAuthTokens(t, cfg)
+
+	oauthSvc := newOAuthTestService(t, cfg, server.URL)
+	ctx := context.Background()
+
+	token, err := oauthSvc.fetchUserToken(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "access-token-a2", token.AccessToken)
+	require.Equal(t, "refresh-token-r1", token.RefreshToken)
+
+	storedRefreshToken, err := cfg.Get(refreshTokenKey, "")
+	require.NoError(t, err)
+	require.Equal(t, "refresh-token-r1", storedRefreshToken)
+}
+
+func TestRemoveOAuthAccessTokenClearsLatestToken(t *testing.T) {
+	initOAuthTokenTest(t)
+
+	cfg := newOAuthTestConfig()
+	future := time.Now().Add(2 * time.Hour)
+	require.NoError(t, cfg.SetUpdate(accessTokenKey, "access-token-a1", ""))
+	require.NoError(t, cfg.SetUpdate(accessTokenExpiryKey, strconv.FormatInt(future.Unix(), 10), ""))
+	require.NoError(t, cfg.SetUpdate(refreshTokenKey, "refresh-token-r1", ""))
+
+	oauthSvc := newOAuthTestService(t, cfg, "http://localhost/unused")
+	oauthSvc.setLatestToken(&oauth2.Token{
+		AccessToken:  "access-token-a1",
+		RefreshToken: "refresh-token-r1",
+		Expiry:       future,
+	})
+
+	require.NoError(t, oauthSvc.RemoveOAuthAccessToken())
+	require.Nil(t, oauthSvc.latestToken)
+
+	token, err := oauthSvc.fetchUserToken(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, token)
+}
+
+func TestLockAndClearTokenStateClearsLatestToken(t *testing.T) {
+	initOAuthTokenTest(t)
+
+	cfg := newOAuthTestConfig()
+	oauthSvc := newOAuthTestService(t, cfg, "http://localhost/unused")
+	oauthSvc.setLatestToken(&oauth2.Token{
+		AccessToken:  "access-token-a1",
+		RefreshToken: "refresh-token-r1",
+		Expiry:       time.Now().Add(2 * time.Hour),
+	})
+	oauthSvc.pendingRefreshFrom = "refresh-token-r0"
+
+	oauthSvc.lockAndClearTokenState()
+	require.Nil(t, oauthSvc.latestToken)
+	require.Equal(t, "", oauthSvc.pendingRefreshFrom)
+}
+
+func TestFetchUserTokenPersistenceEventuallyConverges(t *testing.T) {
+	initOAuthTokenTest(t)
+
+	server := newOAuthTestServer(t)
+	defer server.Close()
+
+	cfg := newOAuthTestConfig()
+	seedExpiredOAuthTokens(t, cfg)
+	cfg.failKeys = map[string]int{refreshTokenKey: 1}
+
+	oauthSvc := newOAuthTestService(t, cfg, server.URL+"/oauth/token")
+	ctx := context.Background()
+
+	_, err := oauthSvc.fetchUserToken(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "", oauthSvc.pendingRefreshFrom)
+
+	token, err := oauthSvc.fetchUserToken(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "access-token-a2", token.AccessToken)
+	require.Equal(t, "refresh-token-r2", token.RefreshToken)
+	require.Equal(t, "", oauthSvc.pendingRefreshFrom)
+	storedRefreshToken, err := cfg.Get(refreshTokenKey, "")
+	require.NoError(t, err)
+	require.Equal(t, "refresh-token-r2", storedRefreshToken)
 }


### PR DESCRIPTION
## Summary

- Fixes Alby Account session loss when OAuth refresh succeeds but persisting the rotated refresh token fails transiently (fixes #2581).
- Retries durable token persistence (3 attempts) and bridges failed saves with in-memory state tied to `pendingRefreshFrom`, so a consumed refresh token is not reused from the database.
- Clears in-memory OAuth state on unlink, access-token removal, and failed/wrong-account callback flows.

## Test plan

- [x] `go test ./alby -run TestFetchUserToken|TestRemoveOAuth|TestLockAndClear -count=1`
- [x] `go test ./alby -race -run TestFetchUserToken|TestRemoveOAuth|TestLockAndClear -count=20`
- [ ] CI SQLite + Postgres matrix

## Notes

- Does not close the crash window where the process dies after provider rotation but before any successful DB write; atomic OAuth config persistence would be a separate follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OAuth token refresh reliability when token storage temporarily fails.
  - Prevented concurrent refreshes from invalidating rotated refresh tokens.
  - Ensured the most current valid token is used when credentials differ.
  - Cleared cached OAuth credentials when accounts are removed or unlinked.
  - Improved recovery from transient token persistence failures.

- **Tests**
  - Added coverage for token rotation, retry behavior, concurrent refreshes, token reconciliation, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->